### PR TITLE
[박혜성] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation 'ch.qos.logback:logback-classic:1.5.6'
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core:3.25.1'
 }
 
 test {

--- a/src/main/java/codesquad/ClientRequest.java
+++ b/src/main/java/codesquad/ClientRequest.java
@@ -10,6 +10,7 @@ import java.net.Socket;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.text.MessageFormat;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,12 +36,20 @@ public class ClientRequest implements Runnable {
             HttpRequestMessage requestMessage = HttpRequestMessage.parse(rawHttpRequestMessage);
             log.debug("Http request message={}", requestMessage);
 
+            // 정적 파일의 경로를 찾습니다.
+            String rawHttpResponseMessage = getStaticFile("static/" + requestMessage.requestUrl());
+
+            // 컨텐츠 타입을 매핑합니다.
+            int extensionStartIndex = requestMessage.requestUrl().indexOf(".");
+            String fileNameExtension = requestMessage.requestUrl().substring(extensionStartIndex + 1);
+            String contentType = ContentTypes.getMimeType(fileNameExtension);
+
             // HTTP 응답을 생성합니다.
             OutputStream clientOutput = clientSocket.getOutputStream();
             clientOutput.write("HTTP/1.1 200 OK\r\n".getBytes());
-            clientOutput.write("Content-Type: text/html\r\n".getBytes());
+            String contentTypeHeader = MessageFormat.format("Content-Type: {0}\r\n", contentType);
+            clientOutput.write(contentTypeHeader.getBytes());
             clientOutput.write("\r\n".getBytes());
-            String rawHttpResponseMessage = getStaticFile("static/index.html");
             clientOutput.write(rawHttpResponseMessage.getBytes()); // 응답 본문으로 "Hello"를 보냅니다.
             clientOutput.flush();
 

--- a/src/main/java/codesquad/ClientRequest.java
+++ b/src/main/java/codesquad/ClientRequest.java
@@ -1,17 +1,14 @@
 package codesquad;
 
 import java.io.BufferedReader;
-import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.text.MessageFormat;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,9 +33,6 @@ public class ClientRequest implements Runnable {
             HttpRequestMessage requestMessage = HttpRequestMessage.parse(rawHttpRequestMessage);
             log.debug("Http request message={}", requestMessage);
 
-            // 정적 파일의 경로를 찾습니다.
-            String rawHttpResponseMessage = getStaticFile("static/" + requestMessage.requestUrl());
-
             // 컨텐츠 타입을 매핑합니다.
             int extensionStartIndex = requestMessage.requestUrl().indexOf(".");
             String fileNameExtension = requestMessage.requestUrl().substring(extensionStartIndex + 1);
@@ -50,7 +44,7 @@ public class ClientRequest implements Runnable {
             String contentTypeHeader = MessageFormat.format("Content-Type: {0}\r\n", contentType);
             clientOutput.write(contentTypeHeader.getBytes());
             clientOutput.write("\r\n".getBytes());
-            clientOutput.write(rawHttpResponseMessage.getBytes()); // 응답 본문으로 "Hello"를 보냅니다.
+            clientOutput.write(getStaticFile("static" + requestMessage.requestUrl()));
             clientOutput.flush();
 
             clientSocket.close();
@@ -69,14 +63,12 @@ public class ClientRequest implements Runnable {
         return sb.toString();
     }
 
-    private String getStaticFile(String resourcePath) throws IOException {
+    private byte[] getStaticFile(String resourcePath) throws IOException {
         URL resource = getClass().getClassLoader().getResource(resourcePath);
-        Path path = new File(resource.getPath()).toPath();
-        List<String> contents = Files.readAllLines(path);
-        StringBuilder sb = new StringBuilder();
-        for (String content : contents) {
-            sb.append(content).append("\n");
+        try (FileInputStream fileInputStream = new FileInputStream(resource.getPath())) {
+            return fileInputStream.readAllBytes();
+        } catch (NullPointerException e) {
+            throw new IllegalArgumentException("유효하지 않은 경로입니다. path=" + resourcePath);
         }
-        return sb.toString();
     }
 }

--- a/src/main/java/codesquad/ContentTypes.java
+++ b/src/main/java/codesquad/ContentTypes.java
@@ -1,0 +1,28 @@
+package codesquad;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public final class ContentTypes {
+
+    private static final Map<String, String> MIME_TYPES = new HashMap<>();
+
+    static {
+        MIME_TYPES.put("html", "text/html");
+        MIME_TYPES.put("css", "text/css");
+        MIME_TYPES.put("js", "text/javascript");
+        MIME_TYPES.put("jpg", "image/jpeg");
+        MIME_TYPES.put("png", "image/png");
+        MIME_TYPES.put("ico", "image/vnd.microsoft.icon");
+        MIME_TYPES.put("svg", "image/svg+xml");
+    }
+
+    private ContentTypes() {
+    }
+
+    public static String getMimeType(String fileNameExtension) {
+        return Optional.ofNullable(MIME_TYPES.get(fileNameExtension))
+                .orElseThrow(() -> new IllegalArgumentException(fileNameExtension + "는 지원하지 않는 확장자입니다."));
+    }
+}

--- a/src/test/java/codesquad/ContentTypesTest.java
+++ b/src/test/java/codesquad/ContentTypesTest.java
@@ -1,0 +1,51 @@
+package codesquad;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class ContentTypesTest {
+
+    @Nested
+    @DisplayName("컨텍츠 타입 조회 시")
+    class GetContentTypes {
+
+        @ParameterizedTest
+        @CsvSource({
+                "html, text/html",
+                "css, text/css",
+                "js, text/javascript",
+                "jpg, image/jpeg",
+                "png, image/png",
+                "ico, image/vnd.microsoft.icon",
+                "svg, image/svg+xml"
+        })
+        @DisplayName("컨텐츠 타입을 반환한다.")
+        void getContentTypes(String fileNameExtension, String contentType) {
+            //given
+            //when
+            String result = ContentTypes.getMimeType(fileNameExtension);
+
+            //then
+            assertThat(result).isEqualTo(contentType);
+        }
+
+        @Test
+        @DisplayName("예외(illegalArguemnt): 지원하지 않는 컨텐츠 타입")
+        void exceptionWhenNoSupport() {
+            //given
+            String noSupport = "no/support";
+
+            //when
+            Exception exception = catchException(() -> ContentTypes.getMimeType(noSupport));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 다양한 컨텐츠 타입을 지원하도록 구현하였습니다.
  - 정적 파일의 확장자에 따라 컨텐츠 타입을 매핑합니다.
  - 컨텐츠 타입을 관리하는 유틸 클래스를 두고 HashMap을 이용하여 확장자-컨텐츠타입의 형태로 데이터를 관리합니다.
  - css, svg, ico 파일을 정상적으로 출력합니다.
- 정적 파일을 조회하면서 nio 패키지를 이용하고 있던 부분을 수정했습니다.
  - 요구사항에 따라 nio 패키지를 사용하던 것에서 FileInputStream을 이용하여 파일을 읽어오는 것으로 변경하였습니다. 

## 고민 사항

## 기타
- 익숙하고 읽기 쉬운 테스트를 작성하기 위해 assertj 의존성을 추가하였습니다.