### PR TITLE
[이경민] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,10 +10,10 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.slf4j:slf4j-simple:2.0.13'
+    implementation 'ch.qos.logback:logback-classic:1.5.6'
 
-    testImplementation platform('org.junit:junit-bom:5.10.0')
-    testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation platform('org.junit:junit-bom:5.10.3')
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.3'
     testImplementation 'org.assertj:assertj-core:3.26.0'
 }
 

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -12,12 +12,11 @@ public class Main {
 
     private static final Logger log = LoggerFactory.getLogger(Main.class);
     private static final int PORT = 8080;
-    private static final int N_THREADS = 10;
 
     public static void main(String[] args) throws IOException {
         ServerSocket serverSocket = new ServerSocket(PORT); // 8080 포트에서 서버를 엽니다.
         log.debug("Listening for connection on port 8080 ....");
-        var executor = Executors.newFixedThreadPool(N_THREADS);
+        var executor = Executors.newCachedThreadPool();
         while (true) {
             executor.execute(new ConnectionHandler(serverSocket.accept()));
         }

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -3,9 +3,7 @@ package codesquad;
 import codesquad.handler.ConnectionHandler;
 import java.io.IOException;
 import java.net.ServerSocket;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,15 +12,12 @@ public class Main {
 
     private static final Logger log = LoggerFactory.getLogger(Main.class);
     private static final int PORT = 8080;
-    private static final int CORE_POOL_SIZE = 10;
-    private static final int MAX_POOL_SIZE = 20;
-    private static final long KEEP_ALIVE_TIME = 0;
+    private static final int N_THREADS = 10;
 
     public static void main(String[] args) throws IOException {
         ServerSocket serverSocket = new ServerSocket(PORT); // 8080 포트에서 서버를 엽니다.
         log.debug("Listening for connection on port 8080 ....");
-        var executor = new ThreadPoolExecutor(CORE_POOL_SIZE, MAX_POOL_SIZE,
-            KEEP_ALIVE_TIME, TimeUnit.MICROSECONDS, new LinkedBlockingQueue<>());
+        var executor = Executors.newFixedThreadPool(N_THREADS);
         while (true) {
             executor.execute(new ConnectionHandler(serverSocket.accept()));
         }

--- a/src/main/java/codesquad/formatter/ContentTypeFormatter.java
+++ b/src/main/java/codesquad/formatter/ContentTypeFormatter.java
@@ -1,0 +1,29 @@
+package codesquad.formatter;
+
+public class ContentTypeFormatter {
+
+    private ContentTypeFormatter() {
+    }
+
+    public static String formatContentType(String fileExtension) {
+        return switch (fileExtension.toLowerCase()) {
+            case ".html" -> "text/html";
+            case ".css" -> "text/css";
+            case ".js" -> "text/javascript";
+            case ".ico" -> "image/x-icon";
+            case ".svg" -> "image/svg+xml";
+            case ".png" -> "image/png";
+            case ".jpg", ".jpeg" -> "image/jpeg";
+            case ".gif" -> "image/gif";
+            case ".pdf" -> "application/pdf";
+            case ".json" -> "application/json";
+            case ".xml" -> "application/xml";
+            case ".zip" -> "application/zip";
+            case ".mp3" -> "audio/mpeg";
+            case ".mp4" -> "video/mp4";
+            case ".webm" -> "video/webm";
+            case ".webp" -> "image/webp";
+            default -> "text/plain";
+        };
+    }
+}

--- a/src/main/java/codesquad/formatter/DateTimeResponseFormatter.java
+++ b/src/main/java/codesquad/formatter/DateTimeResponseFormatter.java
@@ -1,0 +1,18 @@
+package codesquad.formatter;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
+public class DateTimeResponseFormatter {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(
+        "EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ENGLISH);
+
+    private DateTimeResponseFormatter() {
+    }
+
+    public static String formatZonedDateTime(ZonedDateTime zonedDateTime) {
+        return zonedDateTime.format(FORMATTER);
+    }
+}

--- a/src/main/java/codesquad/handler/ConnectionHandler.java
+++ b/src/main/java/codesquad/handler/ConnectionHandler.java
@@ -2,9 +2,7 @@ package codesquad.handler;
 
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
-import codesquad.http.enums.StatusCode;
 import java.net.Socket;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,8 +21,7 @@ public class ConnectionHandler implements Runnable {
             var os = cilentSocket.getOutputStream()) {
             log.debug("Client connected");
             var request = HttpRequest.from(is);
-            var response = HttpResponse.of("HTTP/1.1", StatusCode.OK,
-                Map.of("Content-Type", "text/html"), request.getRequestUri());
+            var response = HttpResponse.from(request.getRequestUri());
             os.write(response.generateResponse());
             os.flush();
         } catch (Exception e) {

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -16,12 +16,14 @@ public class HttpRequest {
     private String requestUri;
     private String httpVersion;
     private Map<String, String> headers;
+    private String body;
 
     private HttpRequest(InputStream inputStream) {
         try {
             var br = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
             parseRequestLine(br.readLine());
             headers = parseHeaders(br);
+            body = parseBody(br);
         } catch (IOException e) {
             log.error(e.getMessage());
         }
@@ -45,6 +47,10 @@ public class HttpRequest {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public String getBody() {
+        return body;
     }
 
     private void parseRequestLine(String requestLine) {
@@ -79,6 +85,21 @@ public class HttpRequest {
             log.error(e.getMessage());
         }
         return headerMap;
+    }
+
+    private String parseBody(BufferedReader br) {
+        var size = Integer.parseInt(headers.getOrDefault("Content-Length", "0"));
+        char[] buffer = new char[size];
+        if (size != 0) {
+            try {
+                br.read(buffer);
+            } catch (IOException e) {
+                log.error(e.getMessage());
+            }
+        }
+        var result = new String(buffer);
+        log.debug(result);
+        return result;
     }
 
 }

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -31,6 +31,22 @@ public class HttpRequest {
         return new HttpRequest(inputStream);
     }
 
+    public String getHttpMethod() {
+        return httpMethod;
+    }
+
+    public String getRequestUri() {
+        return requestUri;
+    }
+
+    public String getHttpVersion() {
+        return httpVersion;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers;
+    }
+
     private void parseRequestLine(String requestLine) {
         if (requestLine == null || requestLine.isBlank()) {
             log.error("요청 라인이 없습니다.");
@@ -65,19 +81,4 @@ public class HttpRequest {
         return headerMap;
     }
 
-    public String getHttpMethod() {
-        return httpMethod;
-    }
-
-    public String getRequestUri() {
-        return requestUri;
-    }
-
-    public String getHttpVersion() {
-        return httpVersion;
-    }
-
-    public Map<String, String> getHeaders() {
-        return headers;
-    }
 }

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -1,7 +1,11 @@
 package codesquad.http;
 
+import codesquad.formatter.ContentTypeFormatter;
+import codesquad.formatter.DateTimeResponseFormatter;
 import codesquad.http.enums.StatusCode;
 import codesquad.reader.FileByteReader;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,31 +13,20 @@ import org.slf4j.LoggerFactory;
 public class HttpResponse {
 
     private static final Logger log = LoggerFactory.getLogger(HttpResponse.class);
+    private static final String DEFAULT_HTTP_VERSION = "HTTP/1.1";
 
-    private final String httpVersion;
-    private final StatusCode statusCode;
-    private final Map<String, String> headers;
+    private StatusCode statusCode;
+    private final Map<String, Object> headers;
     private byte[] body;
 
-    private HttpResponse(String httpVersion, StatusCode statusCode, Map<String, String> headers,
-        String requestUri) {
-        log.debug("httpVersion: {}, statusCode: {}, headers: {}, requestUri: {}", httpVersion,
-            statusCode,
-            headers, requestUri);
-        this.httpVersion = httpVersion;
-        this.statusCode = statusCode;
-        this.headers = headers;
-        try {
-            this.body = new FileByteReader(requestUri).readAllBytes();
-        } catch (Exception e) {
-            log.error(e.getMessage());
-            this.body = new byte[0];
-        }
+    private HttpResponse(String requestUri) {
+        log.debug("requestUri: {}", requestUri);
+        this.headers = createDefaultHeaders();
+        processRequestUri(requestUri);
     }
 
-    public static HttpResponse of(String httpVersion, StatusCode statusCode,
-        Map<String, String> headers, String requestUri) {
-        return new HttpResponse(httpVersion, statusCode, headers, requestUri);
+    public static HttpResponse from(String requestUri) {
+        return new HttpResponse(requestUri);
     }
 
     public byte[] generateResponse() {
@@ -45,13 +38,42 @@ public class HttpResponse {
     }
 
     private String generateResponseLine() {
-        return httpVersion + " " + statusCode.getCode() + " " + statusCode.name() + "\r\n";
+        return DEFAULT_HTTP_VERSION + " " + statusCode.getCode() + " " + statusCode.name() + "\r\n";
     }
 
     private String generateHeaders() {
         StringBuilder sb = new StringBuilder();
         headers.forEach((key, value) -> sb.append(key).append(": ").append(value).append("\r\n"));
         return sb.toString();
+    }
+
+    private Map<String, Object> createDefaultHeaders() {
+        var defaultHeader = new HashMap<String, Object>();
+        defaultHeader.put("Date",
+            DateTimeResponseFormatter.formatZonedDateTime(ZonedDateTime.now()));
+        defaultHeader.put("Server", "java-was");
+        return defaultHeader;
+    }
+
+    private void processRequestUri(String requestUri) {
+        try {
+            this.body = new FileByteReader(requestUri).readAllBytes();
+            this.statusCode = StatusCode.OK;
+            headers.put("Connection", "keep-alive");
+            headers.put("Content-Type", ContentTypeFormatter.formatContentType(
+                requestUri.substring(requestUri.lastIndexOf('.'))));
+            headers.put("Content-Length", body.length);
+        } catch (IllegalArgumentException e) {
+            log.error(e.getMessage());
+            handleNotFound();
+        }
+    }
+
+    private void handleNotFound() {
+        this.statusCode = StatusCode.NOT_FOUND;
+        headers.put("Content-Type", "text/html");
+        headers.put("Connection", "close");
+        this.body = "<h1>404 Not Found</h1>".getBytes();
     }
 
 }

--- a/src/test/java/codesquad/formatter/ContentTypeFormatterTest.java
+++ b/src/test/java/codesquad/formatter/ContentTypeFormatterTest.java
@@ -1,0 +1,46 @@
+package codesquad.formatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class ContentTypeFormatterTest {
+
+    @MethodSource
+    @ParameterizedTest
+    @DisplayName("파일 확장자에 따른 Content-Type을 반환한다.")
+    void formatContentType(String fileExtension, String expectedResult) {
+        // Act
+        var actualResult = ContentTypeFormatter.formatContentType(fileExtension);
+        // Assert
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+
+    private static Stream<Arguments> formatContentType() {
+        return Stream.of(
+            Arguments.of(".html", "text/html"),
+            Arguments.of(".css", "text/css"),
+            Arguments.of(".js", "text/javascript"),
+            Arguments.of(".ico", "image/x-icon"),
+            Arguments.of(".svg", "image/svg+xml"),
+            Arguments.of(".png", "image/png"),
+            Arguments.of(".jpg", "image/jpeg"),
+            Arguments.of(".jpeg", "image/jpeg"),
+            Arguments.of(".gif", "image/gif"),
+            Arguments.of(".pdf", "application/pdf"),
+            Arguments.of(".json", "application/json"),
+            Arguments.of(".xml", "application/xml"),
+            Arguments.of(".zip", "application/zip"),
+            Arguments.of(".mp3", "audio/mpeg"),
+            Arguments.of(".mp4", "video/mp4"),
+            Arguments.of(".webm", "video/webm"),
+            Arguments.of(".webp", "image/webp"),
+            Arguments.of(".txt", "text/plain")
+        );
+    }
+
+}

--- a/src/test/java/codesquad/formatter/DateTimeResponseFormatterTest.java
+++ b/src/test/java/codesquad/formatter/DateTimeResponseFormatterTest.java
@@ -1,0 +1,23 @@
+package codesquad.formatter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DateTimeResponseFormatterTest {
+
+    @Test
+    @DisplayName("HttpResponse Header Date 포멧에 맞게 포맷팅한다.")
+    void formatZonedDateTime() {
+        // Arrange
+        var expectedResult = "Fri, 01 Jan 2021 00:00:00 GMT";
+        var zonedDateTime = ZonedDateTime.of(2021, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC"));
+        // Act
+        var actualResult = DateTimeResponseFormatter.formatZonedDateTime(zonedDateTime);
+        // Assert
+        assertThat(actualResult).isEqualTo(expectedResult);
+    }
+}

--- a/src/test/java/codesquad/http/HttpRequestTest.java
+++ b/src/test/java/codesquad/http/HttpRequestTest.java
@@ -19,12 +19,15 @@ class HttpRequestTest {
         Sec-Fetch-Site: none
         Connection: keep-alive
         Upgrade-Insecure-Requests: 1
+        Content-Length: 6
         Sec-Fetch-Mode: navigate
         Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
         User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15
         Accept-Language: ko-KR,ko;q=0.9
         Sec-Fetch-Dest: document
         Accept-Encoding: gzip, deflate
+                
+        hello?
         """;
 
     private InputStream inputStream;
@@ -60,7 +63,8 @@ class HttpRequestTest {
                         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15"),
                     entry("Accept-Language", "ko-KR,ko;q=0.9"),
                     entry("Sec-Fetch-Dest", "document"),
-                    entry("Accept-Encoding", "gzip, deflate"))
+                    entry("Accept-Encoding", "gzip, deflate")),
+            () -> assertThat(actualResult.getBody()).isEqualTo("hello?")
         );
 
     }

--- a/src/test/java/codesquad/http/HttpResponseTest.java
+++ b/src/test/java/codesquad/http/HttpResponseTest.java
@@ -4,8 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-import codesquad.http.enums.StatusCode;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,13 +13,9 @@ class HttpResponseTest {
     @DisplayName("HttpResponse 객체를 생성한다.")
     void create() {
         // Arrange
-        var expectedHttpVersion = "HTTP/1.1";
-        var expectedStatusCode = StatusCode.OK;
-        var expectedHeaders = Map.of("Content-Type", "text/html");
         var expectedRequestUri = "/index.html";
         // Act
-        var actualResult = HttpResponse.of(expectedHttpVersion, expectedStatusCode, expectedHeaders,
-            expectedRequestUri);
+        var actualResult = HttpResponse.from(expectedRequestUri);
         // Assert
         assertAll(
             () -> assertNotNull(actualResult),


### PR DESCRIPTION
## 🔍 구현 내용

- 컨텐츠 타입 지원을 위해 `HttpResponse` 리팩토링을 진행했습니다.
  - 정적 컨텐츠 조회 결과에 따른 적절한 `Content-Type`을 헤더에 전달하기 위해 `ContentTypeFormatter` 를 구현했습니다.
  - Response 반환 시간을 헤더에 반환하기 위해 `DateTimeResponseFormatter`를 구현했습니다.
  - 페이지가 존재하는 경우 빈 페이지가 아닌 404 상태코드와 `Not Found`를 반환하도록 로직을 수정했습니다.
  - 리팩토링에 대한 테스트 로직을 수정했습니다.
 
- 스레드풀 생성 로직을 수정했습니다.
  - Unbounded Thread Pool을 사용하기에 `Executors`를 활용해 스레드풀을 생성하도록 로직을 수정했습니다.

- Request Body에 대한 처리가 가능하도록 `HttpResponse` 리팩토링을 진행했습니다.
  -  `Header`에 전달받는 `Content-Length`에 기반해 Body를 저장할 수 있도록 리팩토링을 진행했습니다.

## ❓ 고민 사항

- ThreadPool Size를 어떻게 정해야 할 지에 대한 학습이 필요하다고 생각합니다 :D 👍🏻 

## 🎸 기타

- `InputStreamReader` vs `BufferedReader` 에 대해서 공부해볼 예정입니다!