### PR TITLE
[김준기] step-1 index.html 응답

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleHome" value="" />
+        <option name="gradleJvm" value="zulu-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="corretto-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="zulu-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/uiDesigner.xml
+++ b/.idea/uiDesigner.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Palette2">
+    <group name="Swing">
+      <item class="com.intellij.uiDesigner.HSpacer" tooltip-text="Horizontal Spacer" icon="/com/intellij/uiDesigner/icons/hspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="1" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="com.intellij.uiDesigner.VSpacer" tooltip-text="Vertical Spacer" icon="/com/intellij/uiDesigner/icons/vspacer.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="1" anchor="0" fill="2" />
+      </item>
+      <item class="javax.swing.JPanel" icon="/com/intellij/uiDesigner/icons/panel.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JScrollPane" icon="/com/intellij/uiDesigner/icons/scrollPane.svg" removable="false" auto-create-binding="false" can-attach-label="true">
+        <default-constraints vsize-policy="7" hsize-policy="7" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JButton" icon="/com/intellij/uiDesigner/icons/button.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="0" fill="1" />
+        <initial-values>
+          <property name="text" value="Button" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JRadioButton" icon="/com/intellij/uiDesigner/icons/radioButton.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="RadioButton" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JCheckBox" icon="/com/intellij/uiDesigner/icons/checkBox.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="3" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="CheckBox" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JLabel" icon="/com/intellij/uiDesigner/icons/label.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="8" fill="0" />
+        <initial-values>
+          <property name="text" value="Label" />
+        </initial-values>
+      </item>
+      <item class="javax.swing.JTextField" icon="/com/intellij/uiDesigner/icons/textField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JPasswordField" icon="/com/intellij/uiDesigner/icons/passwordField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JFormattedTextField" icon="/com/intellij/uiDesigner/icons/formattedTextField.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1">
+          <preferred-size width="150" height="-1" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextArea" icon="/com/intellij/uiDesigner/icons/textArea.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTextPane" icon="/com/intellij/uiDesigner/icons/textPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JEditorPane" icon="/com/intellij/uiDesigner/icons/editorPane.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JComboBox" icon="/com/intellij/uiDesigner/icons/comboBox.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="2" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JTable" icon="/com/intellij/uiDesigner/icons/table.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JList" icon="/com/intellij/uiDesigner/icons/list.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="2" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTree" icon="/com/intellij/uiDesigner/icons/tree.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3">
+          <preferred-size width="150" height="50" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JTabbedPane" icon="/com/intellij/uiDesigner/icons/tabbedPane.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSplitPane" icon="/com/intellij/uiDesigner/icons/splitPane.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="3" hsize-policy="3" anchor="0" fill="3">
+          <preferred-size width="200" height="200" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JSpinner" icon="/com/intellij/uiDesigner/icons/spinner.svg" removable="false" auto-create-binding="true" can-attach-label="true">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSlider" icon="/com/intellij/uiDesigner/icons/slider.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="8" fill="1" />
+      </item>
+      <item class="javax.swing.JSeparator" icon="/com/intellij/uiDesigner/icons/separator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="6" anchor="0" fill="3" />
+      </item>
+      <item class="javax.swing.JProgressBar" icon="/com/intellij/uiDesigner/icons/progressbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JToolBar" icon="/com/intellij/uiDesigner/icons/toolbar.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="6" anchor="0" fill="1">
+          <preferred-size width="-1" height="20" />
+        </default-constraints>
+      </item>
+      <item class="javax.swing.JToolBar$Separator" icon="/com/intellij/uiDesigner/icons/toolbarSeparator.svg" removable="false" auto-create-binding="false" can-attach-label="false">
+        <default-constraints vsize-policy="0" hsize-policy="0" anchor="0" fill="1" />
+      </item>
+      <item class="javax.swing.JScrollBar" icon="/com/intellij/uiDesigner/icons/scrollbar.svg" removable="false" auto-create-binding="true" can-attach-label="false">
+        <default-constraints vsize-policy="6" hsize-policy="0" anchor="0" fill="2" />
+      </item>
+    </group>
+  </component>
+</project>

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
 test {

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,8 @@ repositories {
 }
 
 dependencies {
+    implementation 'ch.qos.logback:logback-classic:1.5.6'
+
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
 }

--- a/src/main/java/codesquad/HttpProcessor.java
+++ b/src/main/java/codesquad/HttpProcessor.java
@@ -1,0 +1,81 @@
+package codesquad;
+
+import static codesquad.utils.StringUtils.CRLF;
+
+import codesquad.handler.HttpRequestHandler;
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpRequestMapper;
+import codesquad.http.HttpResponse;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
+
+    private final HttpRequestHandler httpRequestHandler;
+    private final Socket socket;
+
+    public HttpProcessor(HttpRequestHandler httpRequestHandler, Socket socket) {
+        this.httpRequestHandler = httpRequestHandler;
+        this.socket = socket;
+    }
+
+    public void process() {
+        try (InputStream inputStream = socket.getInputStream();
+             OutputStream outputStream = socket.getOutputStream()
+        ) {
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+            HttpRequest httpRequest = HttpRequestMapper.from(bufferedReader);
+
+            logger.debug("[Http Request] {}", httpRequest);
+            HttpResponse httpResponse = httpRequestHandler.handle(httpRequest);
+            logger.debug("[Http Response] {}", httpResponse);
+
+            sendResponse(outputStream, httpResponse);
+        } catch (IOException | RuntimeException e) {
+            logger.error(e.getMessage(), e);
+        } finally {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                logger.error("Socket Close Error");
+            }
+        }
+    }
+
+    public void sendResponse(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
+        sendStatus(outputStream, httpResponse);
+        sendHeaders(outputStream, httpResponse);
+        sendBody(outputStream, httpResponse);
+    }
+
+    private void sendStatus(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
+        String status = httpResponse.getHttpVersion() + " " + httpResponse.getHttpStatus().getCode() + " "
+                + httpResponse.getHttpStatus().getRepresentation();
+        outputStream.write(status.getBytes());
+        outputStream.write(CRLF.getBytes());
+    }
+
+    private void sendHeaders(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
+        Map<String, String> headers = httpResponse.getHeaders();
+        for (String headerName : headers.keySet()) {
+            String headerValue = headers.get(headerName);
+            String header = headerName + ": " + headerValue;
+            outputStream.write(header.getBytes());
+        }
+        outputStream.write(CRLF.getBytes());
+        outputStream.write(CRLF.getBytes());
+    }
+
+    private void sendBody(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
+        outputStream.write(httpResponse.getBody().getBytes());
+    }
+}

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -1,28 +1,11 @@
 package codesquad;
 
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.ServerSocket;
-import java.net.Socket;
-
+import codesquad.handler.HttpRequestHandler;
 
 public class Main {
-    public static void main(String[] args) throws IOException {
-        ServerSocket serverSocket = new ServerSocket(8080); // 8080 포트에서 서버를 엽니다.
-        System.out.println("Listening for connection on port 8080 ....");
-
-        while (true) { // 무한 루프를 돌며 클라이언트의 연결을 기다립니다.
-            try (Socket clientSocket = serverSocket.accept()) { // 클라이언트 연결을 수락합니다.
-                System.out.println("Client connected");
-
-                // HTTP 응답을 생성합니다.
-                OutputStream clientOutput = clientSocket.getOutputStream();
-                clientOutput.write("HTTP/1.1 200 OK\r\n".getBytes());
-                clientOutput.write("Content-Type: text/html\r\n".getBytes());
-                clientOutput.write("\r\n".getBytes());
-                clientOutput.write("<h1>Hello</h1>\r\n".getBytes()); // 응답 본문으로 "Hello"를 보냅니다.
-                clientOutput.flush();
-            }
-        }
+    public static void main(String[] args) {
+        HttpRequestHandler httpRequestHandler = new HttpRequestHandler();
+        WebApplicationServer webApplicationServer = new WebApplicationServer(httpRequestHandler);
+        webApplicationServer.start();
     }
 }

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -1,11 +1,8 @@
 package codesquad;
 
-import codesquad.handler.HttpRequestHandler;
-
 public class Main {
     public static void main(String[] args) {
-        HttpRequestHandler httpRequestHandler = new HttpRequestHandler();
-        WebApplicationServer webApplicationServer = new WebApplicationServer(httpRequestHandler);
+        WebApplicationServer webApplicationServer = new WebApplicationServer();
         webApplicationServer.start();
     }
 }

--- a/src/main/java/codesquad/WebApplicationServer.java
+++ b/src/main/java/codesquad/WebApplicationServer.java
@@ -1,0 +1,54 @@
+package codesquad;
+
+import codesquad.handler.HttpRequestHandler;
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpRequestMapper;
+import codesquad.http.HttpResponse;
+import codesquad.http.HttpVersion;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class WebApplicationServer {
+
+    public static final String CRLF = "\r\n";
+    public static final int PORT = 8080;
+    private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
+
+    private final HttpRequestHandler httpRequestHandler;
+
+    public WebApplicationServer(HttpRequestHandler httpRequestHandler) {
+        this.httpRequestHandler = httpRequestHandler;
+    }
+
+    public void start() {
+        try (ServerSocket serverSocket = new ServerSocket(PORT)) {
+            System.out.println("Listening for connection on port 8080 ....");
+            run(serverSocket);
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+        }
+    }
+
+    private void run(ServerSocket serverSocket) {
+        while (true) {
+            try (Socket socket = serverSocket.accept();
+                 InputStream inputStream = socket.getInputStream();
+                 OutputStream outputStream = socket.getOutputStream()
+            ) {
+                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
+
+            } catch (IOException | RuntimeException e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/codesquad/WebApplicationServer.java
+++ b/src/main/java/codesquad/WebApplicationServer.java
@@ -1,36 +1,24 @@
 package codesquad;
 
 import codesquad.handler.HttpRequestHandler;
-import codesquad.http.HttpRequest;
-import codesquad.http.HttpRequestMapper;
-import codesquad.http.HttpResponse;
-import codesquad.http.HttpVersion;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
-import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WebApplicationServer {
 
-    public static final String CRLF = "\r\n";
     public static final int PORT = 8080;
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
 
-    private final HttpRequestHandler httpRequestHandler;
-
-    public WebApplicationServer(HttpRequestHandler httpRequestHandler) {
-        this.httpRequestHandler = httpRequestHandler;
-    }
+    private final ExecutorService executorService = Executors.newFixedThreadPool(10);
 
     public void start() {
         try (ServerSocket serverSocket = new ServerSocket(PORT)) {
-            System.out.println("Listening for connection on port 8080 ....");
+            logger.debug("Listening for connection on port 8080 ....");
             run(serverSocket);
         } catch (IOException e) {
             logger.error(e.getMessage(), e);
@@ -39,46 +27,14 @@ public class WebApplicationServer {
 
     private void run(ServerSocket serverSocket) {
         while (true) {
-            try (Socket socket = serverSocket.accept();
-                 InputStream inputStream = socket.getInputStream();
-                 OutputStream outputStream = socket.getOutputStream()
-            ) {
-                BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-                HttpRequest httpRequest = HttpRequestMapper.from(bufferedReader);
-                HttpResponse httpResponse = httpRequestHandler.handle(httpRequest);
-                sendResponse(outputStream, httpResponse);
+            try {
+                Socket socket = serverSocket.accept();
+                HttpProcessor httpProcessor = new HttpProcessor(new HttpRequestHandler(), socket);
+                executorService.execute(httpProcessor::process);
             } catch (IOException | RuntimeException e) {
                 logger.error(e.getMessage(), e);
             }
         }
-    }
-
-    public void sendResponse(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        sendStatus(outputStream, httpResponse);
-        sendHeaders(outputStream, httpResponse);
-        sendBody(outputStream, httpResponse);
-    }
-
-    private void sendStatus(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        String status = HttpVersion.HTTP1_1.getName() + httpResponse.getHttpStatus().getCode()
-                + httpResponse.getHttpStatus().getRepresentation();
-        outputStream.write(status.getBytes());
-        outputStream.write(CRLF.getBytes());
-    }
-
-    private void sendHeaders(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        Map<String, String> headers = httpResponse.getHeaders();
-        for (String headerName : headers.keySet()) {
-            String headerValue = headers.get(headerName);
-            String header = headerName + ": " + headerValue;
-            outputStream.write(header.getBytes());
-        }
-        outputStream.write(CRLF.getBytes());
-        outputStream.write(CRLF.getBytes());
-    }
-
-    private void sendBody(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        outputStream.write(httpResponse.getBody().getBytes());
     }
 
 }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -1,17 +1,19 @@
 package codesquad.handler;
 
-import codesquad.http.HttpRequest;
-import codesquad.http.HttpResponse;
 import codesquad.http.HttpHeaders;
 import codesquad.http.HttpMediaType;
 import codesquad.http.HttpMethod;
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpResponse;
 import codesquad.http.HttpStatus;
+import codesquad.http.HttpVersion;
 import java.io.IOException;
 
 public class HttpRequestHandler {
 
     public HttpResponse handle(final HttpRequest httpRequest) throws IOException {
         // TODO: reuqetURL 이 API인지, 정적 리소스 요청인지 구분하는 로직 필요
+        HttpVersion httpVersion = httpRequest.getVersion();
         HttpMethod method = httpRequest.getMethod();
         String path = httpRequest.getPath();
 
@@ -19,10 +21,10 @@ public class HttpRequestHandler {
             String content = StaticResourceHandler.getFileContents(StaticResourceHandler.STATIC_PATH + path);
             HttpHeaders httpHeaders = HttpHeaders.empty();
             httpHeaders.setContentType(HttpMediaType.TEXT_HTML);
-            return new HttpResponse(HttpStatus.OK, httpHeaders, content);
+            return new HttpResponse(httpVersion, HttpStatus.OK, httpHeaders, content);
         }
 
-        return new HttpResponse(HttpStatus.BAD_REQUEST, HttpHeaders.empty(), "");
+        return new HttpResponse(httpVersion, HttpStatus.BAD_REQUEST, HttpHeaders.empty(), "");
     }
 
 }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -1,0 +1,28 @@
+package codesquad.handler;
+
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpResponse;
+import codesquad.http.HttpHeaders;
+import codesquad.http.HttpMediaType;
+import codesquad.http.HttpMethod;
+import codesquad.http.HttpStatus;
+import java.io.IOException;
+
+public class HttpRequestHandler {
+
+    public HttpResponse handle(final HttpRequest httpRequest) throws IOException {
+        // TODO: reuqetURL 이 API인지, 정적 리소스 요청인지 구분하는 로직 필요
+        HttpMethod method = httpRequest.getMethod();
+        String path = httpRequest.getPath();
+
+        if (method == HttpMethod.GET && path.equals("/index.html")) {
+            String content = StaticResourceHandler.getFileContents(StaticResourceHandler.STATIC_PATH + path);
+            HttpHeaders httpHeaders = HttpHeaders.empty();
+            httpHeaders.setContentType(HttpMediaType.TEXT_HTML);
+            return new HttpResponse(HttpStatus.OK, httpHeaders, content);
+        }
+
+        return new HttpResponse(HttpStatus.BAD_REQUEST, HttpHeaders.empty(), "");
+    }
+
+}

--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -1,0 +1,21 @@
+package codesquad.handler;
+
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
+
+public class StaticResourceHandler {
+
+    public static final String STATIC_PATH = "src/main/resources/static/";
+
+    public static String getFileContents(String path) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -1,0 +1,56 @@
+package codesquad.http;
+
+import static codesquad.http.HttpHeaders.HeaderName.CONTENT_TYPE;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpHeaders {
+
+    //TODO: Map<String, List<String>> 으로 변경 -> ex) Accept 헤더에 여러 value가 존재함
+    private final Map<String, String> headers;
+
+    private HttpHeaders(final Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public static HttpHeaders of(final Map<String, String> headers) {
+        return new HttpHeaders(headers);
+    }
+
+    public static HttpHeaders empty() {
+        return new HttpHeaders(new HashMap<>());
+    }
+
+    public void setContentType(final HttpMediaType mediaType) {
+        headers.put(CONTENT_TYPE.getName(), mediaType.getName());
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (String s : headers.keySet()) {
+            sb.append(s).append(": ").append(headers.get(s)).append("\n");
+        }
+        return sb.toString();
+    }
+
+    public enum HeaderName {
+        CONTENT_TYPE("Content-Type");
+
+        private final String name;
+
+        HeaderName(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpMediaType.java
+++ b/src/main/java/codesquad/http/HttpMediaType.java
@@ -1,0 +1,16 @@
+package codesquad.http;
+
+public enum HttpMediaType {
+
+    TEXT_HTML("text/html");
+
+    private final String name;
+
+    HttpMediaType(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/codesquad/http/HttpMethod.java
+++ b/src/main/java/codesquad/http/HttpMethod.java
@@ -1,0 +1,13 @@
+package codesquad.http;
+
+public enum HttpMethod {
+
+    GET("GET");
+
+    private final String name;
+
+    HttpMethod(String name) {
+        this.name = name;
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -10,6 +10,10 @@ public class HttpRequest {
         this.headers = headers;
     }
 
+    public HttpVersion getVersion() {
+        return httpRequestFirstLine.getVersion();
+    }
+
     public HttpMethod getMethod() {
         return httpRequestFirstLine.getMethod();
     }

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -1,5 +1,8 @@
 package codesquad.http;
 
+import java.util.Map;
+import java.util.Optional;
+
 public class HttpRequest {
 
     private final HttpRequestFirstLine httpRequestFirstLine;
@@ -20,6 +23,11 @@ public class HttpRequest {
 
     public String getPath() {
         return httpRequestFirstLine.getPath();
+    }
+
+    public Optional<String> getHeaderValue(String headerName) {
+        Map<String, String> header = headers.getHeaders();
+        return Optional.ofNullable(header.get(headerName));
     }
 
     @Override

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -1,0 +1,25 @@
+package codesquad.http;
+
+public class HttpRequest {
+
+    private final HttpRequestFirstLine httpRequestFirstLine;
+    private final HttpHeaders headers;
+
+    public HttpRequest(HttpRequestFirstLine httpRequestFirstLine, HttpHeaders headers) {
+        this.httpRequestFirstLine = httpRequestFirstLine;
+        this.headers = headers;
+    }
+
+    public HttpMethod getMethod() {
+        return httpRequestFirstLine.getMethod();
+    }
+
+    public String getPath() {
+        return httpRequestFirstLine.getPath();
+    }
+
+    @Override
+    public String toString() {
+        return httpRequestFirstLine + "\n" + headers;
+    }
+}

--- a/src/main/java/codesquad/http/HttpRequestFirstLine.java
+++ b/src/main/java/codesquad/http/HttpRequestFirstLine.java
@@ -2,14 +2,18 @@ package codesquad.http;
 
 public class HttpRequestFirstLine {
 
+    private final HttpVersion version;
     private final HttpMethod method;
     private final String path;
-    private final String version;
 
-    public HttpRequestFirstLine(HttpMethod method, String path, String version) {
+    public HttpRequestFirstLine(HttpVersion version, HttpMethod method, String path) {
+        this.version = version;
         this.method = method;
         this.path = path;
-        this.version = version;
+    }
+
+    public HttpVersion getVersion() {
+        return version;
     }
 
     public HttpMethod getMethod() {

--- a/src/main/java/codesquad/http/HttpRequestFirstLine.java
+++ b/src/main/java/codesquad/http/HttpRequestFirstLine.java
@@ -1,0 +1,27 @@
+package codesquad.http;
+
+public class HttpRequestFirstLine {
+
+    private final HttpMethod method;
+    private final String path;
+    private final String version;
+
+    public HttpRequestFirstLine(HttpMethod method, String path, String version) {
+        this.method = method;
+        this.path = path;
+        this.version = version;
+    }
+
+    public HttpMethod getMethod() {
+        return method;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String toString() {
+        return method + " " + path + " " + version + "\n";
+    }
+}

--- a/src/main/java/codesquad/http/HttpRequestMapper.java
+++ b/src/main/java/codesquad/http/HttpRequestMapper.java
@@ -22,8 +22,8 @@ public class HttpRequestMapper {
 
         HttpMethod method = HttpMethod.valueOf(startLineParts[0]);
         String path = startLineParts[1];
-        String version = startLineParts[2];
-        return new HttpRequestFirstLine(method, path, version);
+        HttpVersion version = HttpVersion.of(startLineParts[2]);
+        return new HttpRequestFirstLine(version, method, path);
     }
 
     private static HttpHeaders parseHeaders(BufferedReader bufferedReader) throws IOException {

--- a/src/main/java/codesquad/http/HttpRequestMapper.java
+++ b/src/main/java/codesquad/http/HttpRequestMapper.java
@@ -1,0 +1,39 @@
+package codesquad.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequestMapper {
+
+    public static HttpRequest from(final BufferedReader bufferedReader) throws IOException {
+        String requestLine;
+
+        requestLine = bufferedReader.readLine();
+        HttpRequestFirstLine firstLine = parseHttpRequestFirstLine(requestLine);
+        HttpHeaders headers = parseHeaders(bufferedReader);
+
+        return new HttpRequest(firstLine, headers);
+    }
+
+    private static HttpRequestFirstLine parseHttpRequestFirstLine(String requestLine) {
+        String[] startLineParts = requestLine.split(" ");
+
+        HttpMethod method = HttpMethod.valueOf(startLineParts[0]);
+        String path = startLineParts[1];
+        String version = startLineParts[2];
+        return new HttpRequestFirstLine(method, path, version);
+    }
+
+    private static HttpHeaders parseHeaders(BufferedReader bufferedReader) throws IOException {
+        String requestLine;
+        Map<String, String> headers = new HashMap<>();
+        while (!(requestLine = bufferedReader.readLine()).isBlank()) {
+            String[] headerParts = requestLine.split(": ", 2);
+            headers.put(headerParts[0], headerParts[1]);
+        }
+        return HttpHeaders.of(headers);
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -4,14 +4,20 @@ import java.util.Map;
 
 public class HttpResponse {
 
+    private final HttpVersion httpVersion;
     private final HttpStatus httpStatus;
     private final HttpHeaders headers;
     private final String body;
 
-    public HttpResponse(HttpStatus httpStatus, HttpHeaders headers, String body) {
+    public HttpResponse(HttpVersion httpVersion, HttpStatus httpStatus, HttpHeaders headers, String body) {
+        this.httpVersion = httpVersion;
         this.httpStatus = httpStatus;
         this.headers = headers;
         this.body = body;
+    }
+
+    public HttpVersion getHttpVersion() {
+        return httpVersion;
     }
 
     public HttpStatus getHttpStatus() {
@@ -24,5 +30,14 @@ public class HttpResponse {
 
     public String getBody() {
         return body;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Status: ").append(httpStatus);
+        sb.append("Headers: ").append(headers);
+        sb.append("Response Body: ").append(body);
+        return sb.toString();
     }
 }

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -1,0 +1,28 @@
+package codesquad.http;
+
+import java.util.Map;
+
+public class HttpResponse {
+
+    private final HttpStatus httpStatus;
+    private final HttpHeaders headers;
+    private final String body;
+
+    public HttpResponse(HttpStatus httpStatus, HttpHeaders headers, String body) {
+        this.httpStatus = httpStatus;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+
+    public Map<String, String> getHeaders() {
+        return headers.getHeaders();
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/src/main/java/codesquad/http/HttpStatus.java
+++ b/src/main/java/codesquad/http/HttpStatus.java
@@ -1,0 +1,23 @@
+package codesquad.http;
+
+public enum HttpStatus {
+
+    OK(200, "OK"),
+    BAD_REQUEST(400, "Bad Request");
+
+    private final int code;
+    private final String representation;
+
+    HttpStatus(int code, String representation) {
+        this.code = code;
+        this.representation = representation;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getRepresentation() {
+        return representation;
+    }
+}

--- a/src/main/java/codesquad/http/HttpVersion.java
+++ b/src/main/java/codesquad/http/HttpVersion.java
@@ -1,0 +1,17 @@
+package codesquad.http;
+
+public enum HttpVersion {
+
+    HTTP1_1("HTTP/1.1");
+
+    private final String name;
+
+    HttpVersion(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpVersion.java
+++ b/src/main/java/codesquad/http/HttpVersion.java
@@ -1,5 +1,7 @@
 package codesquad.http;
 
+import java.util.Arrays;
+
 public enum HttpVersion {
 
     HTTP1_1("HTTP/1.1");
@@ -12,6 +14,14 @@ public enum HttpVersion {
 
     public String getName() {
         return name;
+    }
+
+    // FIXME: HashMap 캐시하는 로직으로 변경
+    public static HttpVersion of(String version) {
+        return Arrays.stream(values())
+                .filter(httpVersion -> httpVersion.name.equals(version))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 HttpVersion 입니다."));
     }
 
 }

--- a/src/main/java/codesquad/utils/StringUtils.java
+++ b/src/main/java/codesquad/utils/StringUtils.java
@@ -1,0 +1,7 @@
+package codesquad.utils;
+
+public class StringUtils {
+
+    public static final String CRLF = System.lineSeparator();
+
+}

--- a/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
+++ b/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
@@ -1,0 +1,40 @@
+package codesquad.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import codesquad.http.HttpHeaders;
+import codesquad.http.HttpMethod;
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpRequestFirstLine;
+import codesquad.http.HttpResponse;
+import codesquad.http.HttpStatus;
+import codesquad.http.HttpVersion;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestHandlerTest {
+
+    HttpRequestHandler httpRequestHandler = new HttpRequestHandler();
+
+    @Test
+    @DisplayName("[Success] /index.html로 요청을 보내면 200 OK 응답이 발생한다.")
+    void requestIndex() throws IOException {
+        HttpResponse httpResponse = httpRequestHandler.handle(new HttpRequest(
+                new HttpRequestFirstLine(HttpVersion.HTTP1_1, HttpMethod.GET, "/index.html"),
+                HttpHeaders.empty()
+        ));
+        assertThat(httpResponse.getHttpStatus()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("[Success] /indexx.html로 요청을 보내면 400 응답이 발생한다.")
+    void incorrectFileNameIndex() throws IOException {
+        HttpResponse httpResponse = httpRequestHandler.handle(new HttpRequest(
+                new HttpRequestFirstLine(HttpVersion.HTTP1_1, HttpMethod.GET, "/indexx.html"),
+                HttpHeaders.empty()
+        ));
+        assertThat(httpResponse.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+}

--- a/src/test/java/codesquad/http/HttpRequestMapperTest.java
+++ b/src/test/java/codesquad/http/HttpRequestMapperTest.java
@@ -1,0 +1,42 @@
+package codesquad.http;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class HttpRequestMapperTest {
+
+    @Test
+    @DisplayName("[Success] HTTP 규약에 맞는 요청")
+    void parserTest() throws IOException {
+        String request = "GET /index.html HTTP/1.1\r\n" +
+                "Host: localhost:8080\r\n" +
+                "User-Agent: Mozilla/5.0\r\n" +
+                "\r\n";
+
+        BufferedReader bufferedReader = new BufferedReader(new StringReader(request));
+        HttpRequest httpRequest = HttpRequestMapper.from(bufferedReader);
+
+        assertFirstLine(httpRequest);
+        assertHeaders(httpRequest);
+    }
+
+    private static void assertFirstLine(HttpRequest httpRequest) {
+        assertThat(httpRequest.getMethod()).isEqualTo(HttpMethod.GET);
+        assertThat(httpRequest.getPath()).isEqualTo("/index.html");
+        assertThat(httpRequest.getVersion()).isEqualTo(HttpVersion.HTTP1_1);
+    }
+
+    private void assertHeaders(HttpRequest httpRequest) {
+        assertThat(httpRequest.getHeaderValue("Host"))
+                .isPresent()
+                .get().isEqualTo("localhost:8080");
+        assertThat(httpRequest.getHeaderValue("User-Agent"))
+                .isPresent()
+                .get().isEqualTo("Mozilla/5.0");
+    }
+}


### PR DESCRIPTION
## 구현 내용
- [x] `http://localhost:8080/index.html` 로 접속했을 때 `src/main/resources/static` 디렉토리의 index.html 파일을 읽어 클라이언트에 응답하는 기능
- [x] HTTP 요청을 `method`, `path`, `version`, `headers`로 파싱하는 기능
- [x] 파싱한 결과 및 에러 로그 출력
- [x] 멀티 스레딩으로 HTTP 요청을 처리하는 기능

## 고민 사항
### 서버측 소켓의 구조적 고민
```java
ServerSocket serverSocket = new ServerSocket(8080);
Socket clientSocket = serverSocket.accept();
```
위의 코드와 같이, **`ServerSocket`과 `Socket`으로 나뉘는 이유** 및 **서로의 역할이 다른 이유**에 대해 고민을 많이 했습니다. clientSocket이라는 네이밍때문에 혼동이 있었기 때문입니다.

소켓은 `<src IP/Port, dest IP/Port>`로 식별해야하며, 여러 클라이언트 요청에 대한 각각의 유일한 소켓을 관리해야하므로 위와 같은 구조로 소켓이 나뉘게 되는 것을 인지했습니다. 하지만 소켓의 역할 분리만으로는 아직 여러 요청에 대한 처리를 수행하는데 제약이 있고, 멀티 스레드 + 비동기 방식으로 요청/응답을 위임하는 절차가 필요함을 알게 되었습니다.

<br>

### 워커 스레드에게 위임해야하는 로직
워커 스레드에게 어떤 로직부터 위임을 시작해야 하는지 고민했습니다. 결론적으로 클라이어트 요청에 대한 소켓을 생성하는 것 까지가 메인 스레드의 역할이며, 해당 소켓에 대한 (요청에 대한) 응답을 처리하는 절차가 워커 스레드의 역할임을 인지 및 개발에 적용했습니다.

<br>

### 예외 핸들링
멀티 스레드 + 비동기 방식에서 예외를 핸들링하는 것에 대한 고민이 아직 남아있으며, 금주 미션을 수행하며 지속적으로 실험해볼 예정입니다.

## 기타
### 버전
- JDK 17

### 설계
<img width="700" src="https://github.com/woowa-techcamp-2024/java-was/assets/68291395/28e772e9-5629-4b77-922e-a744db14c6c3">

### 결과
<img width="450" alt="image" src="https://github.com/woowa-techcamp-2024/java-was/assets/68291395/d375dd01-c4e3-415c-b812-24ee58bfece7">
