### PR TITLE
[김수현] step-1 index.html 응답

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,14 @@ build/
 .idea/jarRepositories.xml
 .idea/compiler.xml
 .idea/libraries/
+.idea/*.xml
 *.iws
 *.iml
 *.ipr
 out/
 !**/src/main/**/out/
 !**/src/test/**/out/
+.idea/
 
 ### Eclipse ###
 .apt_generated
@@ -40,3 +42,4 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,11 @@ plugins {
     id 'java'
 }
 
+java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+}
+
 group = 'codesquad'
 version = '1.0-SNAPSHOT'
 
@@ -12,6 +17,8 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'ch.qos.logback:logback-classic:1.4.1'
+    implementation 'org.slf4j:slf4j-api:2.0.3'
 }
 
 test {

--- a/src/main/java/codesquad/HttpSCStatus.java
+++ b/src/main/java/codesquad/HttpSCStatus.java
@@ -1,0 +1,25 @@
+package codesquad;
+
+public enum HttpSCStatus {
+    OK("200"),
+    CREATED("201"),
+    MOVED_PERMANENTLY("301"),
+    FOUND("302"),
+    NOT_MODIFIED("304"),
+    BAD_REQUEST("400"),
+    UNAUTHORIZED("401"),
+    FORBIDDEN("403"),
+    NOT_FOUND("404"),
+    INTERNAL_SERVER_ERROR("500"),
+    BAD_GATEWAY("502");
+
+    private final String code;
+
+    HttpSCStatus(String code) {
+        this.code = code;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/src/main/java/codesquad/IOUtil.java
+++ b/src/main/java/codesquad/IOUtil.java
@@ -1,0 +1,56 @@
+package codesquad;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.util.Locale;
+
+public class IOUtil {
+
+    private static final char CR = '\r';
+
+    private static final char LF = '\n';
+
+    private static final int BUFFER_SIZE = 4096;
+
+    public static String readLine(InputStream input) throws IOException {
+        int ch;
+        StringBuffer sb = new StringBuffer();
+        while ((ch = input.read()) != -1) {
+            if (ch == CR) {
+                continue;
+            } else if (ch == LF) {
+                break;
+            } else {
+                sb.append((char) ch);
+            }
+        }
+
+        return ch == -1 && sb.isEmpty() ? null : sb.toString();
+    }
+
+    public static void writeLine(OutputStream output, String str) throws IOException {
+        if (!(str == null || str.isEmpty())) {
+            output.write(str.getBytes(StandardCharsets.UTF_8));
+        }
+        output.write(CR);
+        output.write(LF);
+    }
+
+    public static String getDateStringUtc() {
+        LocalDateTime now = LocalDateTime.now(ZoneId.of("UTC"));
+        DateTimeFormatter formatter = new DateTimeFormatterBuilder()
+                .appendPattern("EEE, dd MMM yyyy HH:mm:ss")
+                .toFormatter(Locale.US);
+        return now.format(formatter) + "GMT";
+    }
+}

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -1,28 +1,13 @@
 package codesquad;
 
+import codesquad.http.HttpProtocol;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.ServerSocket;
-import java.net.Socket;
 
 
 public class Main {
+
     public static void main(String[] args) throws IOException {
-        ServerSocket serverSocket = new ServerSocket(8080); // 8080 포트에서 서버를 엽니다.
-        System.out.println("Listening for connection on port 8080 ....");
-
-        while (true) { // 무한 루프를 돌며 클라이언트의 연결을 기다립니다.
-            try (Socket clientSocket = serverSocket.accept()) { // 클라이언트 연결을 수락합니다.
-                System.out.println("Client connected");
-
-                // HTTP 응답을 생성합니다.
-                OutputStream clientOutput = clientSocket.getOutputStream();
-                clientOutput.write("HTTP/1.1 200 OK\r\n".getBytes());
-                clientOutput.write("Content-Type: text/html\r\n".getBytes());
-                clientOutput.write("\r\n".getBytes());
-                clientOutput.write("<h1>Hello</h1>\r\n".getBytes()); // 응답 본문으로 "Hello"를 보냅니다.
-                clientOutput.flush();
-            }
-        }
+        HttpProtocol httpProtocol = new HttpProtocol();
+        httpProtocol.start();
     }
 }

--- a/src/main/java/codesquad/http/Endpoint.java
+++ b/src/main/java/codesquad/http/Endpoint.java
@@ -1,0 +1,26 @@
+package codesquad.http;
+
+import java.io.IOException;
+
+public interface Endpoint<S, U> {
+
+    void bind() throws IOException;
+
+    void startInternal() throws IOException;
+
+    void stopInternal() throws IOException;
+
+    void setRunning(boolean isRunning);
+
+    default void start() throws IOException {
+        bind();
+        setRunning(true);
+        startInternal();
+    }
+
+    default void stop() throws IOException {
+        setRunning(false);
+        stopInternal();
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpProcessor.java
+++ b/src/main/java/codesquad/http/HttpProcessor.java
@@ -1,0 +1,78 @@
+package codesquad.http;
+
+import codesquad.HttpSCStatus;
+import codesquad.IOUtil;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class HttpProcessor {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private static final String STATIC_FOLDER = "static";
+
+    private static final String DEFAULT_PATH = "/";
+
+    private static final String DEFAULT_PAGE = "/main/index.html";
+
+    public void process(Socket socket) throws IOException {
+        try (
+                BufferedInputStream inputStream = new BufferedInputStream(socket.getInputStream());
+                BufferedOutputStream outputStream = new BufferedOutputStream(socket.getOutputStream());
+        ) {
+            Request request = processRequest(inputStream);
+            String fileName = request.getPath().equals(DEFAULT_PATH) ? DEFAULT_PAGE : request.getPath();
+            processResponse(outputStream, request, fileName);
+        }
+    }
+
+    public Request processRequest(InputStream input) throws IOException {
+        Request request = HttpRequestParser.parse(input);
+        log.info(request.toString());
+        return request;
+    }
+
+    public void processResponse(OutputStream outputStream, Request request, String fileName) throws IOException {
+        Response<?> response = null;
+
+        HashMap<String, String> headers = new HashMap<>();
+        addCommonHeader(headers);
+
+        URL resource = getClass().getClassLoader().getResource(STATIC_FOLDER + fileName);
+
+        if (resource != null) {
+            File file = new File(resource.getFile());
+            if (file.exists() && file.isFile()) {
+                headers.put(HttpResponseWriter.CONTENT_LENGTH_HEADER, String.valueOf(file.length()));
+                response = new WasResponse<File>(
+                        request.getProtocol(),
+                        HttpSCStatus.OK,
+                        headers,
+                        file
+                );
+            }
+        }
+
+        if (response == null) {
+            response = WasResponse.fail(request.getProtocol(), HttpSCStatus.NOT_FOUND, headers);
+        }
+        log.info(response.toString());
+        HttpResponseWriter.write(outputStream, response);
+    }
+
+    private void addCommonHeader(Map<String, String> headers) {
+        headers.put("Date", IOUtil.getDateStringUtc());
+        headers.put("Connection", "close");
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpProtocol.java
+++ b/src/main/java/codesquad/http/HttpProtocol.java
@@ -1,0 +1,38 @@
+package codesquad.http;
+
+import codesquad.http.JIoEndpoint.SocketProcessor;
+import java.io.IOException;
+import java.net.Socket;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class HttpProtocol {
+    private static final String namePrefix = "http-bio";
+
+    private final Endpoint<Socket, SocketProcessor> endpoint;
+
+    public HttpProtocol() {
+        NamedThreadFactory acceptorThreadFactory = new NamedThreadFactory("http-bio-acceptor");
+        NamedThreadFactory workerThreadFactory = new NamedThreadFactory(namePrefix);
+
+        this.endpoint = new JIoEndpoint(
+                8080,
+                50,
+                Executors.newSingleThreadExecutor(acceptorThreadFactory),
+                Executors.newFixedThreadPool(calculateOptimalThreads(), workerThreadFactory));
+    }
+
+    private int calculateOptimalThreads() {
+        int availableProcessor = Runtime.getRuntime().availableProcessors();
+        return availableProcessor * 2;
+    }
+
+    public void start() throws IOException {
+        endpoint.start();
+    }
+
+    public void stop() throws IOException {
+        endpoint.stop();
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/HttpRequestParser.java
@@ -1,0 +1,96 @@
+package codesquad.http;
+
+import static codesquad.IOUtil.readLine;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpRequestParser {
+
+    private static final String CONTENT_LENGTH_HEADER = "Content-Length";
+
+    private static final String HOST_HEADER = "Host";
+
+    public static Request parse(InputStream inputStream) throws IOException {
+        BufferedInputStream input = new BufferedInputStream(inputStream);
+
+        String requestLine = parseRequestLine(input);
+        String[] requestLineParts = splitRequestLine(requestLine);
+        String method = requestLineParts[0];
+        String path = requestLineParts[1];
+        String protocol = requestLineParts[2];
+
+        Map<String, String> headers = parseHeaders(input);
+        if (!headers.containsKey(HOST_HEADER)) {
+            throw new IOException("host header not exist");
+        }
+
+        String host = headers.get(HOST_HEADER);
+
+        Map<String, String> parameters = parseParameters(input);
+
+        byte[] body = null;
+        if (headers.containsKey(CONTENT_LENGTH_HEADER)) {
+            int contentLength = Integer.parseInt(headers.get(CONTENT_LENGTH_HEADER));
+            body = parseBody(input, contentLength);
+        }
+
+        return new WasRequest(
+                method,
+                path,
+                protocol,
+                host,
+                headers,
+                parameters,
+                body
+        );
+    }
+
+    private static String parseRequestLine(BufferedInputStream input) throws IOException {
+        String requestLine = readLine(input);
+        if (requestLine == null || requestLine.isEmpty()) {
+            throw new IOException("empty request line");
+        }
+        return requestLine;
+    }
+
+    private static String[] splitRequestLine(String requestLine) throws IOException {
+        String[] parts = requestLine.split(" ");
+        if (parts.length != 3) {
+            throw new IOException("invalid request line");
+        }
+        return parts;
+    }
+
+    private static Map<String, String> parseHeaders(BufferedInputStream input) throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        String headerLine;
+        while (!(headerLine = readLine(input)).isEmpty()) {
+            String[] headerParts = headerLine.split(": ");
+            if (headerParts.length != 2) {
+                throw new IOException("invalid header line");
+            }
+            headers.put(headerParts[0], headerParts[1]);
+        }
+        return headers;
+    }
+
+    private static Map<String, String> parseParameters(BufferedInputStream input) throws IOException {
+        //todo parameter 있는 경우 parameter로 파싱 필요
+        Map<String, String> parameters = new HashMap<>();
+        return parameters;
+    }
+
+    private static byte[] parseBody(BufferedInputStream input, int contentLength) throws IOException {
+        byte[] body = new byte[contentLength];
+        int read = input.read(body, 0, contentLength);
+        if (read != contentLength) {
+            throw new IOException("incomplete body read");
+        }
+        return body;
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/HttpRequestParser.java
@@ -14,9 +14,7 @@ public class HttpRequestParser {
 
     private static final String HOST_HEADER = "Host";
 
-    public static Request parse(InputStream inputStream) throws IOException {
-        BufferedInputStream input = new BufferedInputStream(inputStream);
-
+    public static Request parse(InputStream input) throws IOException {
         String requestLine = parseRequestLine(input);
         String[] requestLineParts = splitRequestLine(requestLine);
         String method = requestLineParts[0];
@@ -49,7 +47,7 @@ public class HttpRequestParser {
         );
     }
 
-    private static String parseRequestLine(BufferedInputStream input) throws IOException {
+    private static String parseRequestLine(InputStream input) throws IOException {
         String requestLine = readLine(input);
         if (requestLine == null || requestLine.isEmpty()) {
             throw new IOException("empty request line");
@@ -78,16 +76,16 @@ public class HttpRequestParser {
         return headers;
     }
 
-    private static Map<String, String> parseParameters(BufferedInputStream input) throws IOException {
+    private static Map<String, String> parseParameters(InputStream input) throws IOException {
         //todo parameter 있는 경우 parameter로 파싱 필요
         Map<String, String> parameters = new HashMap<>();
         return parameters;
     }
 
-    private static byte[] parseBody(BufferedInputStream input, int contentLength) throws IOException {
+    private static byte[] parseBody(InputStream input, int contentLength) throws IOException {
         byte[] body = new byte[contentLength];
         int read = input.read(body, 0, contentLength);
-        if (read != contentLength) {
+        if (read != contentLength || input.available() > 0) {
             throw new IOException("incomplete body read");
         }
         return body;

--- a/src/main/java/codesquad/http/HttpResponseWriter.java
+++ b/src/main/java/codesquad/http/HttpResponseWriter.java
@@ -1,0 +1,51 @@
+package codesquad.http;
+
+import static codesquad.IOUtil.writeLine;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+
+public class HttpResponseWriter {
+
+    public static final String CONTENT_LENGTH_HEADER = "Content-Length";
+
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+
+    public static final int BUFFER_SIZE = 4096;
+
+    public static void write(OutputStream output, Response<?> response) throws IOException {
+
+        String statusLine = String.join(" ",
+                response.getProtocol(),
+                response.getStatusCode(),
+                response.getStatusMessage());
+        writeLine(output, statusLine);
+
+        for (Map.Entry<String, String> header : response.getHeaders().entrySet()) {
+            writeLine(output, String.join(": ", header.getKey(), header.getValue()));
+        }
+
+        writeLine(output, null);
+
+        if (response.getHeader(CONTENT_LENGTH_HEADER).isPresent()
+                && response.getBody() != null
+                && response.getBody().getClass().equals(File.class)
+        ) {
+            File file = (File) response.getBody();
+            try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file))) {
+                byte[] buffer = new byte[BUFFER_SIZE]; // 4KB 버퍼 크기 사용
+                int bytesRead;
+                while ((bytesRead = bis.read(buffer)) != -1) {
+                    output.write(buffer, 0, bytesRead);
+                }
+            }
+        }
+
+        output.flush();
+    }
+
+}

--- a/src/main/java/codesquad/http/HttpResponseWriter.java
+++ b/src/main/java/codesquad/http/HttpResponseWriter.java
@@ -15,7 +15,7 @@ public class HttpResponseWriter {
 
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
 
-    public static final int BUFFER_SIZE = 4096;
+    public static final int BUFFER_SIZE = 8192;
 
     public static void write(OutputStream output, Response<?> response) throws IOException {
 
@@ -37,7 +37,7 @@ public class HttpResponseWriter {
         ) {
             File file = (File) response.getBody();
             try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(file))) {
-                byte[] buffer = new byte[BUFFER_SIZE]; // 4KB 버퍼 크기 사용
+                byte[] buffer = new byte[BUFFER_SIZE];
                 int bytesRead;
                 while ((bytesRead = bis.read(buffer)) != -1) {
                     output.write(buffer, 0, bytesRead);

--- a/src/main/java/codesquad/http/JIoEndpoint.java
+++ b/src/main/java/codesquad/http/JIoEndpoint.java
@@ -1,0 +1,133 @@
+package codesquad.http;
+
+import codesquad.http.JIoEndpoint.SocketProcessor;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class JIoEndpoint implements Endpoint<Socket, SocketProcessor> {
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    private ServerSocket serverSocket;
+
+    private final ExecutorService acceptorExecutorService;
+
+    private final ExecutorService workerExecutorService;
+
+    private final LinkedBlockingQueue<HttpProcessor> processors;
+
+    private final int port;
+
+    private final int backlog;
+
+    private boolean running = false;
+
+
+    public JIoEndpoint(int port, int backlog, ExecutorService acceptorExecutorService,
+                       ExecutorService workerExecutorService) {
+        this.port = port;
+        this.backlog = backlog;
+        this.acceptorExecutorService = acceptorExecutorService;
+        this.workerExecutorService = workerExecutorService;
+        int workers = ((ThreadPoolExecutor) workerExecutorService).getCorePoolSize();
+        log.info("acceptor thread created");
+        log.info("{} worker threads created", workers);
+
+        this.processors = new LinkedBlockingQueue<>(workers);
+    }
+
+    @Override
+    public void bind() throws IOException {
+        serverSocket = new ServerSocket(port, backlog);
+        log.info("Listening on port {}", port);
+    }
+
+    @Override
+    public void startInternal() throws IOException {
+        acceptorExecutorService.execute(new Acceptor());
+    }
+
+
+    @Override
+    public void stopInternal() throws IOException {
+        serverSocket.close();
+        if (workerExecutorService != null) {
+            workerExecutorService.shutdown();
+        }
+        if (acceptorExecutorService != null) {
+            acceptorExecutorService.shutdown();
+        }
+        log.info("exit: executor services are shutdown and server socket is closed");
+    }
+
+    @Override
+    public void setRunning(boolean isRunning) {
+        this.running = isRunning;
+    }
+
+    public SocketProcessor createWorker(Socket socket) {
+        return new SocketProcessor(socket);
+    }
+
+    private HttpProcessor getProcessor() {
+        HttpProcessor processor = processors.poll();
+        if (processor == null) {
+            processor = new HttpProcessor();
+        }
+        return processor;
+    }
+
+    private void recycleProcessor(HttpProcessor processor) {
+        processors.offer(processor);
+    }
+
+    public class Acceptor implements Runnable {
+        @Override
+        public void run() {
+            while (running) {
+                try {
+                    Socket socket = serverSocket.accept();
+                    SocketProcessor worker = createWorker(socket);
+                    workerExecutorService.execute(worker);
+                } catch (IOException exception) {
+                    log.warn("fail while accepting socket and allocating it to worker thread");
+                }
+            }
+        }
+    }
+
+    public class SocketProcessor implements Runnable {
+        private final Socket socket;
+
+        public SocketProcessor(
+                Socket socket
+        ) {
+            this.socket = socket;
+        }
+
+        @Override
+        public void run() {
+            HttpProcessor processor = getProcessor();
+            try {
+                log.info("httpProcessor start socket processing in thread({}) ",
+                        Thread.currentThread().getName());
+                processor.process(socket);
+            } catch (IOException exception) {
+                log.warn("fail while processing socket");
+            } finally {
+                recycleProcessor(processor);
+                try {
+                    socket.close();
+                } catch (IOException e) {
+                    log.warn("exception closing socket", e);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/codesquad/http/JIoEndpoint.java
+++ b/src/main/java/codesquad/http/JIoEndpoint.java
@@ -91,6 +91,7 @@ public final class JIoEndpoint implements Endpoint<Socket, SocketProcessor> {
         public void run() {
             while (running) {
                 try {
+                    log.info("acceptor accepts connection and delegating it to worker thread");
                     Socket socket = serverSocket.accept();
                     SocketProcessor worker = createWorker(socket);
                     workerExecutorService.execute(worker);
@@ -114,8 +115,6 @@ public final class JIoEndpoint implements Endpoint<Socket, SocketProcessor> {
         public void run() {
             HttpProcessor processor = getProcessor();
             try {
-                log.info("httpProcessor start socket processing in thread({}) ",
-                        Thread.currentThread().getName());
                 processor.process(socket);
             } catch (IOException exception) {
                 log.warn("fail while processing socket");

--- a/src/main/java/codesquad/http/NamedThreadFactory.java
+++ b/src/main/java/codesquad/http/NamedThreadFactory.java
@@ -1,0 +1,18 @@
+package codesquad.http;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class NamedThreadFactory implements ThreadFactory {
+    private final String baseName;
+    private final AtomicInteger threadNumber = new AtomicInteger(1);
+
+    public NamedThreadFactory(String baseName) {
+        this.baseName = baseName;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return new Thread(r, baseName + "-" + threadNumber.getAndIncrement());
+    }
+}

--- a/src/main/java/codesquad/http/Request.java
+++ b/src/main/java/codesquad/http/Request.java
@@ -1,0 +1,24 @@
+package codesquad.http;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface Request {
+    Map<String, String> getHeaders();
+
+    Optional<String> getHeader(String name);
+
+    Map<String, String> getParameters();
+
+    Optional<String> getParameter(String name);
+
+    byte[] getBody();
+
+    String getProtocol();
+
+    String getPath();
+
+    String getMethod();
+
+    String getHost();
+}

--- a/src/main/java/codesquad/http/Response.java
+++ b/src/main/java/codesquad/http/Response.java
@@ -1,0 +1,19 @@
+package codesquad.http;
+
+import java.util.Map;
+import java.util.Optional;
+
+public interface Response<T> {
+
+    String getProtocol();
+
+    String getStatusCode();
+
+    String getStatusMessage();
+
+    Map<String, String> getHeaders();
+
+    Optional<String> getHeader(String key);
+
+    T getBody();
+}

--- a/src/main/java/codesquad/http/WasRequest.java
+++ b/src/main/java/codesquad/http/WasRequest.java
@@ -1,0 +1,99 @@
+package codesquad.http;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class WasRequest implements Request {
+
+    private String method;
+
+    private String path;
+
+    private String protocol;
+
+    private String host;
+
+    private Map<String, String> headers;
+
+    private Map<String, String> parameters;
+
+    private byte[] body;
+
+    public WasRequest(String method,
+                      String path,
+                      String protocol,
+                      String host,
+                      Map<String, String> headers,
+                      Map<String, String> parameters,
+                      byte[] body) {
+        this.method = method;
+        this.path = path;
+        this.protocol = protocol;
+        this.host = host;
+        this.headers = headers;
+        this.parameters = parameters;
+        this.body = body;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    @Override
+    public Optional<String> getHeader(String name) {
+        return Optional.of(headers.get(name));
+    }
+
+    @Override
+    public Map<String, String> getParameters() {
+        return Collections.unmodifiableMap(parameters);
+    }
+
+    @Override
+    public Optional<String> getParameter(String name) {
+        return Optional.of(parameters.get(name));
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public String getHost() {
+        return host;
+    }
+
+    @Override
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getMethod() {
+        return method;
+    }
+
+    @Override
+    public byte[] getBody() {
+        return body;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("WasRequest { ").append(System.lineSeparator());
+        sb.append("method='").append(method).append('\'').append(System.lineSeparator());
+        sb.append("path='").append(path).append('\'').append(System.lineSeparator());
+        sb.append("protocol='").append(protocol).append('\'').append(System.lineSeparator());
+        sb.append("host='").append(host).append('\'').append(System.lineSeparator());
+        sb.append("headers=").append(headers).append(System.lineSeparator());
+        sb.append("parameters=").append(parameters).append(System.lineSeparator());
+        sb.append("body=").append(Arrays.toString(body)).append(System.lineSeparator());
+        sb.append("}").append(System.lineSeparator());
+        return sb.toString();
+    }
+}

--- a/src/main/java/codesquad/http/WasResponse.java
+++ b/src/main/java/codesquad/http/WasResponse.java
@@ -1,0 +1,69 @@
+package codesquad.http;
+
+import codesquad.HttpSCStatus;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+
+public class WasResponse<T> implements Response<T> {
+    private final String protocol;
+    private final HttpSCStatus status;
+    private final Map<String, String> headers;
+    private final T body;
+
+    public WasResponse(String protocol, HttpSCStatus status, Map<String, String> headers, T body) {
+        this.protocol = protocol;
+        this.status = status;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    public static WasResponse<Void> fail(String protocol, HttpSCStatus status, Map<String, String> headers) {
+        return new WasResponse<>(protocol, status, headers, null);
+    }
+
+    @Override
+    public String getProtocol() {
+        return protocol;
+    }
+
+    @Override
+    public String getStatusCode() {
+        return status.getCode();
+    }
+
+    @Override
+    public String getStatusMessage() {
+        return status.name();
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    @Override
+    public Optional<String> getHeader(String key) {
+        return Optional.ofNullable(headers.get(key));
+    }
+
+    @Override
+    public T getBody() {
+        return body;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("WasResponse { ").append(System.lineSeparator());
+        sb.append("protocol='").append(protocol).append('\'').append(System.lineSeparator());
+        sb.append("statusCode='").append(getStatusCode()).append('\'').append(System.lineSeparator());
+        sb.append("statusMeessage='").append(getStatusMessage()).append('\'').append(System.lineSeparator());
+        sb.append("headers=").append(headers).append(System.lineSeparator());
+        sb.append("body=").append(body).append(System.lineSeparator());
+        sb.append("}").append(System.lineSeparator());
+        return sb.toString();
+    }
+}
+
+


### PR DESCRIPTION
## 구현 내용
### 정적 파일 반환
+ url path 에서 파싱해서 해당하는 파일 반환
+ **성공시** 200 OK 응답. 본문에 파일.  **실패시** 404 NOT FOUND 응답. 본문 없음
+ Request, Response를 인터페이스로 선언한 이유: 인터페이스로 분리하면 다양한 유형의 요청을 처리할 수 있는 유연성을 확보. 예를 들어, HTTP 요청뿐만 아니라 WebSocket, gRPC, FTP 등의 다른 요청도 동일한 방식으로 처리할 수 있습니다. 새로운 요청 유형을 추가할 때 기존 코드를 변경하지 않고도 쉽게 확장할 수 있음. 이는 SOLID 원칙 중 하나인 개방-폐쇄 원칙(Open/Closed Principle) 따른다.
+ Response를 제네릭으로 선언한 이유: 응답 본문에 여러가지 Object가 담길 수 있기 때문에(json, file) 다양한 타입의 본문을 지원할 수 있도록 제네릭으로 선언해 본문 타입에 따라서 불필요한 타입캐스팅 필요 없도록.
+ 기본적으로 한줄씩 읽고 쓰지만(IOUtil에서 유틸성 함수 제공), body의 경우에는 버퍼스트림 사용해서 읽고 써서 IO 성능을 높였다.
   + 기본 버퍼 크기: BufferedInputStream, BufferedOutputStream의 기본 버퍼 크기인 8192(8KB) 사용.

### 로그 출력
+ 모든 출력은 INFO 레벨을 사용. (에러시에만 WARN 레벨 출력)
출력되는 로그 내용
1. 어플리케이션 시작 후 _HttpProtocol.start()_ 가 호출되어서 서버 소켓이 요청을 받아들일 준비가 되었을때
<img width="750" alt="스크린샷 2024-07-03 오전 9 31 51" src="https://github.com/woowa-techcamp-2024/java-was/assets/73276447/d2a22c98-c13a-4db9-8f41-300f6b55b884">

2. Acceptor가 연결된 소켓을 워커 스레드에 할당할때
+ 스레드명 : http-bio-acceptor-1(싱글 스레드)
<img width="1056" alt="스크린샷 2024-07-03 오전 9 31 58" src="https://github.com/woowa-techcamp-2024/java-was/assets/73276447/717edfaa-5589-4969-b9f6-ec5ef0662a00">

4. 워커 스레드가 파싱된 요청, 생성된 응답을 출력
+ http 메시지가 아니라 WasRequest, WasResponse 객체 형태로 출력
+ 워커 스레드명 : http-bio-숫자(총 32개)
<img width="1318" alt="스크린샷 2024-07-03 오전 9 32 09" src="https://github.com/woowa-techcamp-2024/java-was/assets/73276447/41dbbc8b-4b62-4565-9e8b-559815d591ef">


### 멀티스레드
+ tomcat nio-connector의 구조를 참고하여 설계
+ _HttpProtocol_ 이 Endpoint의 생명주기(start(), stop())를 관리한다. Endpoint를 start() 하면 서버 소켓이 요청을 받기 시작하고, stop()을 하면 소켓을 닫고 더 이상 연결을 허용하지 않으며 관련된 executor service을 종료한다. 
+ _JIoEndpoint_ 는 java의 기본 io(블로킹 io)를 사용해서 _Endpoint_를 구현한다.
+ _JIoEndpoint_ 의 역할
    1.  서버 소켓을 바인딩.
    2.  클라이언트와 연결을 맺는 acceptor 스레드 시작.  Acceptor는 싱글 스레드로 동작하고 클라이언트 연결을 수락하고 각 연결을 처리할 스레드에 넘기는 역할만 한다.  ServerSocket에서 클라이언트 연결을 수락하고, 수락된 소켓을 SocketProcessor에 전달하여 Executor를 통해 실행합니다. Socket을 넘기고 나서 계속해서 새로운 요청을 받는다.
    3.  workerExecutorService 스레드풀의 스레드가 각 소켓을 처리하는 SocketProcessor를 실행한다. SocketProcessor는 HttpProcessor를 사용해서 처리하는데 HttpProcessor는 상태를 가지지 않아 재사용가능하다. 따라서 workerExecutorService의 스레드풀 사이즈와 일치하는 개수만큼 생성해서 LinkedBlockingQueue로 관리하고 재사용한다.
 + ServerSocket의 backlog는 기본적으로 50으로 한다. 추후 성능 관찰 후 변경 가능하다.
  + worker 스레드풀의 사이즈는 현재 시스템의 논리 프로세서의 수 * 2개로 고정한다. io 작업이 일어나 스레드가 블로킹 되면 cpu가 다른 스레드를 실행할 수 있도록 해 스루풋을 늘린다. FixedThreadPool을 사용해서 스레드를 실행 중에 생성하지 않도록 해서 스레드 생성하느라 스레드들이 블로킹되지 않도록 한다.
 + 현재 시스템에서 workerExecutorService의 스레드풀에 가용한 스레드가 없으면, 새로 제출된 작업(여기서는 SocketProcessor 인스턴스)이 스레드풀의 작업 큐에 저장된다.  작업 큐가 꽉 차면 그 이후에 제출된 작업은 거부 처리되며, 기본적으로 RejectedExecutionException 예외가 발생한다.
+ acceptor를 메인 스레드가 아닌 별도의 스레드로 처리하는 이유: 메인 스레드가 Acceptor의 역할을 하게 되면, 연결 수락 과정에서 문제가 발생할 경우 서버 전체가 영향을 받을 수 있음. 메인 스레드가 처리하게 되면 다른 초기화 작업이나 관리 작업과 충돌할 수 있습니다.

## 고민 사항
- 요청 파싱하는 것을 여러 함수로 나누어도 괜찮은가? 함수 호출 순서가 중요한데, 잘못 사용되는 것을 막을 수 없지 않나?
- 흩어져있는 헤더 이름 상수로 하나의 차일로 관리 필요 Header클래스 생성하는 것이 필요할 것 같다.
- 백로그 제한할 필요가 있을까. 스레드풀보다 많은 요청이 들어오면 Executor Service의 내부 큐에 저장되는데

## 기타
+ 테스트 추가 필요
+ 멀티 스레딩으로 잘 작동하는지 성능 테스트 필요. 