### PR TITLE
[최현식] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/codesquad/http/ContentType.java
+++ b/src/main/java/codesquad/http/ContentType.java
@@ -1,0 +1,44 @@
+package codesquad.http;
+
+import java.util.Arrays;
+
+public enum ContentType {
+    HTML("html", "text/html"),
+    CSS("css", "text/css"),
+    SVG("svg", "image/svg+xml"),
+    PNG("png", "image/png"),
+    JPG("jpg", "image/jpeg"),
+    JS("js", "text/javascript"),
+    ICO("ico", "image/x-icon"),
+    JSON("json", "application/json"),
+    XML("xml", "application/xml"),
+    TXT("txt", "text/plain");
+
+    private final String name;
+    private final String mimeType;
+
+    ContentType(String name, String type) {
+        this.name = name;
+        this.mimeType = type;
+    }
+
+    /**
+     * 이름에 해당하는 ContentType 타입을 반환합니다.
+     * @param name 파일 확장자에 해당하는 부분입니다. (e.g. *.html은 html)
+     * @return ContentType
+     */
+    public static ContentType from(String name) {
+        return Arrays.stream(ContentType.values())
+                .filter(v -> v.name.equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 ContentType입니다. name: " + name));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+}

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 public record HttpRequest(
         String method,
         String path,
+        Map<String, String> queryString,
         String protocol,
         Map<String, String> headers,
         String body

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -1,12 +1,15 @@
 package codesquad.http;
 
+import codesquad.http.type.HttpMethod;
+import codesquad.http.type.HttpProtocol;
+
 import java.util.Map;
 
 public record HttpRequest(
-        String method,
+        HttpMethod method,
         String path,
         Map<String, String> queryString,
-        String protocol,
+        HttpProtocol protocol,
         Map<String, String> headers,
         String body
 ) {

--- a/src/main/java/codesquad/http/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/HttpRequestParser.java
@@ -1,5 +1,8 @@
 package codesquad.http;
 
+import codesquad.http.type.HttpMethod;
+import codesquad.http.type.HttpProtocol;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,14 +14,14 @@ public class HttpRequestParser {
 
         // Start-Line
         String[] startLine = lines[0].split(" ");
-        String method = startLine[0];
+        HttpMethod method = HttpMethod.from(startLine[0]);
         String[] pathAndQueryString = startLine[1].split("\\?");
         String path = pathAndQueryString[0];
         Map<String, String> query = new HashMap<>();
         if (pathAndQueryString.length > 1) {
             query = parseQueryString(pathAndQueryString[1]);
         }
-        String protocol = startLine[2];
+        HttpProtocol protocol = HttpProtocol.from(startLine[2]);
 
         // Headers
         Map<String, String> headers = parseHeaders(lines);

--- a/src/main/java/codesquad/http/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/HttpRequestParser.java
@@ -21,7 +21,7 @@ public class HttpRequestParser {
         if (pathAndQueryString.length > 1) {
             query = parseQueryString(pathAndQueryString[1]);
         }
-        HttpProtocol protocol = HttpProtocol.from(startLine[2]);
+        HttpProtocol protocol = HttpProtocol.from(startLine[2].trim());
 
         // Headers
         Map<String, String> headers = parseHeaders(lines);

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -1,10 +1,13 @@
 package codesquad.http;
 
+import codesquad.http.type.HttpProtocol;
+import codesquad.http.type.HttpStatus;
+
 import java.util.Map;
 
 public record HttpResponse(
-        String protocol,
-        String status,
+        HttpProtocol protocol,
+        HttpStatus status,
         Map<String, String> headers,
         String body
 ) {

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -1,0 +1,11 @@
+package codesquad.http;
+
+import java.util.Map;
+
+public record HttpResponse(
+        String protocol,
+        String status,
+        Map<String, String> headers,
+        String body
+) {
+}

--- a/src/main/java/codesquad/http/ResponseConverter.java
+++ b/src/main/java/codesquad/http/ResponseConverter.java
@@ -1,0 +1,34 @@
+package codesquad.http;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Map;
+
+public class ResponseConverter {
+    private ResponseConverter() {}
+
+    public static byte[] toSocketBytes(HttpResponse response) {
+        StringBuilder sb = new StringBuilder();
+
+        // StartLine
+        String responseLine = response.protocol() + " " + response.status() + "\r\n";
+        sb.append(responseLine);
+
+        // Headers
+        for (Map.Entry<String, String> entry : response.headers().entrySet()) {
+            String header = entry.getKey() + ": " + entry.getValue() + "\r\n";
+            sb.append(header);
+        }
+
+        // Body
+        if (response.body() != null && !response.body().isEmpty()) {
+            sb.append("\r\n");
+            sb.append(response.body());
+        }
+
+        try {
+            return sb.toString().getBytes("UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("UTF-8를 사용할 수 없습니다.", e);
+        }
+    }
+}

--- a/src/main/java/codesquad/http/type/ContentType.java
+++ b/src/main/java/codesquad/http/type/ContentType.java
@@ -1,4 +1,4 @@
-package codesquad.http;
+package codesquad.http.type;
 
 import java.util.Arrays;
 

--- a/src/main/java/codesquad/http/type/HttpMethod.java
+++ b/src/main/java/codesquad/http/type/HttpMethod.java
@@ -1,0 +1,26 @@
+package codesquad.http.type;
+
+import java.util.Arrays;
+
+public enum HttpMethod {
+    GET,
+    POST,
+    PUT,
+    DELETE,
+    HEAD,
+    OPTIONS,
+    PATCH,
+    TRACE;
+
+    public static HttpMethod from(String name) {
+        return Arrays.stream(HttpMethod.values())
+                .filter(v -> v.name().equals(name))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 HttpMethod입니다. name: " + name));
+    }
+
+    @Override
+    public String toString() {
+        return this.name();
+    }
+}

--- a/src/main/java/codesquad/http/type/HttpProtocol.java
+++ b/src/main/java/codesquad/http/type/HttpProtocol.java
@@ -1,0 +1,27 @@
+package codesquad.http.type;
+
+import java.util.Arrays;
+
+public enum HttpProtocol {
+    HTTP_1_0("HTTP/1.0"),
+    HTTP_1_1("HTTP/1.1"),
+    HTTP_2_0("HTTP/2.0");
+
+    private final String protocol;
+
+    HttpProtocol(String protocol) {
+        this.protocol = protocol;
+    }
+
+    public static HttpProtocol from(String protocol) {
+        return Arrays.stream(HttpProtocol.values())
+                .filter(v -> v.protocol.equals(protocol))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 HttpProtocol입니다. protocol: " + protocol));
+    }
+
+    @Override
+    public String toString() {
+        return this.protocol;
+    }
+}

--- a/src/main/java/codesquad/http/type/HttpStatus.java
+++ b/src/main/java/codesquad/http/type/HttpStatus.java
@@ -1,0 +1,84 @@
+package codesquad.http.type;
+
+public enum HttpStatus {
+    // 1xx Informational
+    CONTINUE(100, "Continue"),
+    SWITCHING_PROTOCOLS(101, "Switching Protocols"),
+    PROCESSING(102, "Processing"),
+
+    // 2xx Success
+    OK(200, "OK"),
+    CREATED(201, "Created"),
+    ACCEPTED(202, "Accepted"),
+    NON_AUTHORITATIVE_INFORMATION(203, "Non-Authoritative Information"),
+    NO_CONTENT(204, "No Content"),
+    RESET_CONTENT(205, "Reset Content"),
+    PARTIAL_CONTENT(206, "Partial Content"),
+
+    // 3xx Redirection
+    MULTIPLE_CHOICES(300, "Multiple Choices"),
+    MOVED_PERMANENTLY(301, "Moved Permanently"),
+    FOUND(302, "Found"),
+    SEE_OTHER(303, "See Other"),
+    NOT_MODIFIED(304, "Not Modified"),
+    USE_PROXY(305, "Use Proxy"),
+    TEMPORARY_REDIRECT(307, "Temporary Redirect"),
+    PERMANENT_REDIRECT(308, "Permanent Redirect"),
+
+    // 4xx Client Error
+    BAD_REQUEST(400, "Bad Request"),
+    UNAUTHORIZED(401, "Unauthorized"),
+    PAYMENT_REQUIRED(402, "Payment Required"),
+    FORBIDDEN(403, "Forbidden"),
+    NOT_FOUND(404, "Not Found"),
+    METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
+    NOT_ACCEPTABLE(406, "Not Acceptable"),
+    PROXY_AUTHENTICATION_REQUIRED(407, "Proxy Authentication Required"),
+    REQUEST_TIMEOUT(408, "Request Timeout"),
+    CONFLICT(409, "Conflict"),
+    GONE(410, "Gone"),
+    LENGTH_REQUIRED(411, "Length Required"),
+    PRECONDITION_FAILED(412, "Precondition Failed"),
+    PAYLOAD_TOO_LARGE(413, "Payload Too Large"),
+    URI_TOO_LONG(414, "URI Too Long"),
+    UNSUPPORTED_MEDIA_TYPE(415, "Unsupported Media Type"),
+    RANGE_NOT_SATISFIABLE(416, "Range Not Satisfiable"),
+    EXPECTATION_FAILED(417, "Expectation Failed"),
+    IM_A_TEAPOT(418, "I'm a teapot"),
+    UNPROCESSABLE_ENTITY(422, "Unprocessable Entity"),
+    TOO_EARLY(425, "Too Early"),
+    UPGRADE_REQUIRED(426, "Upgrade Required"),
+    PRECONDITION_REQUIRED(428, "Precondition Required"),
+    TOO_MANY_REQUESTS(429, "Too Many Requests"),
+    REQUEST_HEADER_FIELDS_TOO_LARGE(431, "Request Header Fields Too Large"),
+    UNAVAILABLE_FOR_LEGAL_REASONS(451, "Unavailable For Legal Reasons"),
+
+    // 5xx Server Error
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    NOT_IMPLEMENTED(501, "Not Implemented"),
+    BAD_GATEWAY(502, "Bad Gateway"),
+    SERVICE_UNAVAILABLE(503, "Service Unavailable"),
+    GATEWAY_TIMEOUT(504, "Gateway Timeout"),
+    HTTP_VERSION_NOT_SUPPORTED(505, "HTTP Version Not Supported"),
+    VARIANT_ALSO_NEGOTIATES(506, "Variant Also Negotiates"),
+    INSUFFICIENT_STORAGE(507, "Insufficient Storage"),
+    LOOP_DETECTED(508, "Loop Detected"),
+    NOT_EXTENDED(510, "Not Extended"),
+    NETWORK_AUTHENTICATION_REQUIRED(511, "Network Authentication Required");
+
+    private final int code;
+    private final String message;
+
+    HttpStatus(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/codesquad/socket/HttpInputStream.java
+++ b/src/main/java/codesquad/socket/HttpInputStream.java
@@ -1,0 +1,30 @@
+package codesquad.socket;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+
+public class HttpInputStream {
+    private final Socket socket;
+
+    public HttpInputStream(Socket socket) {
+        this.socket = socket;
+    }
+
+    public String read() {
+        return getInputStream(socket);
+    }
+
+    private String getInputStream(Socket clientSocket) {
+        try {
+            InputStream input = clientSocket.getInputStream();
+            byte[] inputData = new byte[1024];
+
+            int length = input.read(inputData);
+            return new String(inputData, 0, length);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("올바르지 않은 입력입니다.");
+        }
+    }
+}

--- a/src/main/java/codesquad/socket/HttpOutputStream.java
+++ b/src/main/java/codesquad/socket/HttpOutputStream.java
@@ -1,0 +1,28 @@
+package codesquad.socket;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+
+public class HttpOutputStream {
+    private final Socket socket;
+
+    public HttpOutputStream(Socket socket) {
+        this.socket = socket;
+    }
+
+    public void write(String message) {
+        write(message.getBytes());
+    }
+
+    public void write(byte[] message) {
+        try {
+            OutputStream clientOutput = socket.getOutputStream();
+            clientOutput.write(message);
+            clientOutput.flush();
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new IllegalArgumentException("응답 반환중 문제가 발생했어요. ^_^");
+        }
+    }
+}

--- a/src/main/java/codesquad/util/StringUtil.java
+++ b/src/main/java/codesquad/util/StringUtil.java
@@ -9,6 +9,8 @@ public class StringUtil {
             return "";
         }
 
-        return split[split.length - 1];
+        String uri = split[split.length - 1];
+        split = uri.split("\\?");
+        return split[0];
     }
 }

--- a/src/main/java/codesquad/util/StringUtil.java
+++ b/src/main/java/codesquad/util/StringUtil.java
@@ -1,0 +1,14 @@
+package codesquad.util;
+
+public class StringUtil {
+    private StringUtil() {}
+
+    public static String getExtension(String path) {
+        String[] split = path.split("\\.");
+        if (split.length == 0) {
+            return "";
+        }
+
+        return split[split.length - 1];
+    }
+}

--- a/src/main/java/codesquad/util/StringUtil.java
+++ b/src/main/java/codesquad/util/StringUtil.java
@@ -5,7 +5,7 @@ public class StringUtil {
 
     public static String getExtension(String path) {
         String[] split = path.split("\\.");
-        if (split.length == 0) {
+        if (split.length <= 1) {
             return "";
         }
 

--- a/src/main/java/codesquad/webserver/HttpTask.java
+++ b/src/main/java/codesquad/webserver/HttpTask.java
@@ -5,6 +5,8 @@ import codesquad.http.HttpResponse;
 import codesquad.http.ResponseConverter;
 import codesquad.socket.HttpInputStream;
 import codesquad.socket.HttpOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.Socket;
@@ -16,6 +18,8 @@ import java.net.Socket;
  * @param responseHandler 적절한 HTTP Response를 생성하고 반환하는 객체
  */
 public record HttpTask(Socket clientSocket, RequestHandler requestHandler, ResponseHandler responseHandler) implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(HttpTask.class);
+
     @Override
     public void run() {
         try {
@@ -32,8 +36,9 @@ public record HttpTask(Socket clientSocket, RequestHandler requestHandler, Respo
 
             clientSocket.close();
         } catch (IOException e) {
+            logger.error("요청 처리를 실패했습니다. {}", e.getMessage());
             e.printStackTrace();
-            throw new IllegalArgumentException("잘못된 HTTP 요청입니다.");
+
         }
     }
 }

--- a/src/main/java/codesquad/webserver/HttpTask.java
+++ b/src/main/java/codesquad/webserver/HttpTask.java
@@ -1,5 +1,7 @@
 package codesquad.webserver;
 
+import codesquad.http.HttpRequest;
+
 import java.io.IOException;
 import java.net.Socket;
 
@@ -13,8 +15,8 @@ public record HttpTask(Socket clientSocket, RequestHandler requestHandler, Respo
     @Override
     public void run() {
         try {
-            requestHandler.handle(clientSocket);
-            responseHandler.handle(clientSocket);
+            HttpRequest request = requestHandler.handle(clientSocket);
+            responseHandler.handle(clientSocket, request);
             clientSocket.close();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/codesquad/webserver/RequestHandler.java
+++ b/src/main/java/codesquad/webserver/RequestHandler.java
@@ -5,20 +5,13 @@ import codesquad.http.HttpRequestParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.Socket;
-
 /**
  * Socket에서 HTTP 요청을 입력받고 파싱합니다.
  */
 public class RequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    public HttpRequest handle(Socket clientSocket) {
-        // 사용자 입력을 받는 부분
-        String message = getInputStream(clientSocket);
-
+    public HttpRequest handle(String message) {
         // HTTP 파싱
         HttpRequest request = parseHttpMessage(message);
         logger.debug("HTTP Request! {} {} {}", request.method(), request.path(), request.protocol());
@@ -26,18 +19,6 @@ public class RequestHandler {
         logger.debug("HTTP Body! {}", request.body());
 
         return request;
-    }
-
-    private String getInputStream(Socket clientSocket) {
-        try {
-            InputStream input = clientSocket.getInputStream();
-            byte[] inputData = new byte[1024];  // TODO ?? 이건 몇으로 하는게 좋죠?
-            int length = input.read(inputData);
-            return new String(inputData, 0, length);
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new IllegalArgumentException("올바르지 않은 입력입니다.");
-        }
     }
 
     private HttpRequest parseHttpMessage(String message) {

--- a/src/main/java/codesquad/webserver/RequestHandler.java
+++ b/src/main/java/codesquad/webserver/RequestHandler.java
@@ -15,7 +15,7 @@ import java.net.Socket;
 public class RequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    public void handle(Socket clientSocket) {
+    public HttpRequest handle(Socket clientSocket) {
         // 사용자 입력을 받는 부분
         String message = getInputStream(clientSocket);
 
@@ -24,6 +24,8 @@ public class RequestHandler {
         logger.debug("HTTP Request! {} {} {}", request.method(), request.path(), request.protocol());
         logger.debug("HTTP Headers! size: {}", request.headers().size());
         logger.debug("HTTP Body! {}", request.body());
+
+        return request;
     }
 
     private String getInputStream(Socket clientSocket) {

--- a/src/main/java/codesquad/webserver/ResponseHandler.java
+++ b/src/main/java/codesquad/webserver/ResponseHandler.java
@@ -29,10 +29,14 @@ public class ResponseHandler {
 
             Map<String, String> headers = new HashMap<>();
             headers.put("Content-Type", mimeType);
-            return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.OK, headers, fileData);
+            try {
+                return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.OK, headers, fileData);
+            } catch (Exception e) {
+                return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.NOT_FOUND, null, "못찾겠습니다~");
+            }
         }
 
-        return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.NOT_FOUND, null, "없음없음!!! 발생");
+        return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.BAD_REQUEST, null, "요청이 잘못된 것 같은데요?");
     }
 
     private boolean isStaticRequest(String resourcePath) {

--- a/src/main/java/codesquad/webserver/ResponseHandler.java
+++ b/src/main/java/codesquad/webserver/ResponseHandler.java
@@ -1,8 +1,10 @@
 package codesquad.webserver;
 
-import codesquad.http.ContentType;
+import codesquad.http.type.ContentType;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
+import codesquad.http.type.HttpProtocol;
+import codesquad.http.type.HttpStatus;
 import codesquad.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -19,7 +21,6 @@ public class ResponseHandler {
     private static final String STATIC_FILE_PATH = "src/main/resources/static";
 
     public HttpResponse handle(HttpRequest httpRequest) {
-        // TODO 정적파일만 고려해서 반환중!
         String resourcePath = httpRequest.path();
 
         if (isStaticRequest(resourcePath)) {
@@ -28,10 +29,10 @@ public class ResponseHandler {
 
             Map<String, String> headers = new HashMap<>();
             headers.put("Content-Type", mimeType);
-            return new HttpResponse("HTTP/1.1", "200 OK", headers, fileData);
+            return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.OK, headers, fileData);
         }
 
-        return new HttpResponse("HTTP/1.1", "404 Not Found", null, "NULL 발생");
+        return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.NOT_FOUND, null, "없음없음!!! 발생");
     }
 
     private boolean isStaticRequest(String resourcePath) {

--- a/src/main/java/codesquad/webserver/ResponseHandler.java
+++ b/src/main/java/codesquad/webserver/ResponseHandler.java
@@ -22,13 +22,24 @@ public class ResponseHandler {
         // TODO 정적파일만 고려해서 반환중!
         String resourcePath = httpRequest.path();
 
-        String mimeType = getContentType(resourcePath);
-        String fileData = getStaticFile(resourcePath);
+        if (isStaticRequest(resourcePath)) {
+            String mimeType = getContentType(resourcePath);
+            String fileData = getStaticFile(resourcePath);
 
-        Map<String, String> headers = new HashMap<>();
-        headers.put("Content-Type", mimeType);
-        return new HttpResponse("HTTP/1.1", "200 OK", headers, fileData);
+            Map<String, String> headers = new HashMap<>();
+            headers.put("Content-Type", mimeType);
+            return new HttpResponse("HTTP/1.1", "200 OK", headers, fileData);
+        }
 
+        return new HttpResponse("HTTP/1.1", "404 Not Found", null, "NULL 발생");
+    }
+
+    private boolean isStaticRequest(String resourcePath) {
+        String extension = StringUtil.getExtension(resourcePath);
+        if (extension == null || extension.isEmpty()) {
+            return false;
+        }
+        return true;
     }
 
     private String getContentType(String staticFilePath) {

--- a/src/main/java/codesquad/webserver/ResponseHandler.java
+++ b/src/main/java/codesquad/webserver/ResponseHandler.java
@@ -2,14 +2,14 @@ package codesquad.webserver;
 
 import codesquad.http.ContentType;
 import codesquad.http.HttpRequest;
+import codesquad.http.HttpResponse;
+import codesquad.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.net.Socket;
+import java.io.*;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Socket을 통해 HTTP 응답을 진행합니다.
@@ -18,44 +18,25 @@ public class ResponseHandler {
     private static final Logger logger = LoggerFactory.getLogger(ResponseHandler.class);
     private static final String STATIC_FILE_PATH = "src/main/resources/static";
 
-    public void handle(Socket clientSocket, HttpRequest httpRequest) {
+    public HttpResponse handle(HttpRequest httpRequest) {
         // TODO 정적파일만 고려해서 반환중!
         String resourcePath = httpRequest.path();
-        outputStream(clientSocket, resourcePath);
-    }
 
-    private void outputStream(Socket clientSocket, String staticFilePath) {
-        try {
-            OutputStream clientOutput = clientSocket.getOutputStream();
+        String mimeType = getContentType(resourcePath);
+        String fileData = getStaticFile(resourcePath);
 
-            String mimeType = getContentType(staticFilePath);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Content-Type", mimeType);
+        return new HttpResponse("HTTP/1.1", "200 OK", headers, fileData);
 
-            clientOutput.write("HTTP/1.1 200 OK\r\n".getBytes());
-            clientOutput.write(("Content-Type: " + mimeType + "\r\n").getBytes());
-            clientOutput.write("\r\n".getBytes());
-
-            byte[] fileData = getStaticFile(staticFilePath);
-            clientOutput.write(fileData);
-            clientOutput.flush();
-
-            logger.debug("정상 응답 완료");
-        } catch (IOException e) {
-            e.printStackTrace();
-            throw new IllegalArgumentException("응답 반환중 문제가 발생했어요. ^_^");
-        }
     }
 
     private String getContentType(String staticFilePath) {
-        String[] split = staticFilePath.split("\\.");
-        if (split.length == 0) {
-            return "";
-        }
-
-        String extension = split[split.length - 1];
+        String extension = StringUtil.getExtension(staticFilePath);
         return ContentType.from(extension).getMimeType();
     }
 
-    private byte[] getStaticFile(String path) throws IOException {
+    private String getStaticFile(String path) {
         String filePath = STATIC_FILE_PATH + path;
 
         File file = new File(filePath);
@@ -63,7 +44,13 @@ public class ResponseHandler {
             throw new IllegalArgumentException("파일이 존재하지 않습니다. path: " + filePath);
         }
 
-        FileInputStream fileInputStream = new FileInputStream(filePath);
-        return fileInputStream.readAllBytes();
+        try (FileInputStream fileInputStream = new FileInputStream(filePath)) {
+            byte[] fileBytes = fileInputStream.readAllBytes();
+            return new String(fileBytes, "UTF-8");
+        }  catch (FileNotFoundException e) {
+            throw new IllegalArgumentException("파일을 찾을 수 없습니다. path: " + filePath, e);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("파일을 읽는 중 오류가 발생했습니다. path: " + filePath, e);
+        }
     }
 }

--- a/src/test/java/HttpRequestParserTest.java
+++ b/src/test/java/HttpRequestParserTest.java
@@ -26,6 +26,27 @@ class HttpRequestParserTest {
     }
 
     @Test
+    @DisplayName("QueryString이 존재하는 경우")
+    public void test_handles_http_requests_with_malformed_headers_with_query_string() {
+        // Given
+        String message = "GET /index.html?param1=value1&param2=value2 HTTP/1.1\nHost www.example.com\n\n";
+
+        // When
+        HttpRequest request = HttpRequestParser.parse(message);
+
+        // Then
+        assertEquals("GET", request.method());
+        assertEquals("/index.html", request.path());
+        assertEquals("HTTP/1.1", request.protocol());
+        assertTrue(request.headers().isEmpty());
+        assertTrue(request.body().isEmpty());
+        assertTrue(request.queryString().containsKey("param1"));
+        assertTrue(request.queryString().containsValue("value1"));
+        assertTrue(request.queryString().containsKey("param2"));
+        assertTrue(request.queryString().containsValue("value2"));
+    }
+
+    @Test
     @DisplayName("Header와 Body가 없는 경우")
     public void test_handles_http_requests_with_no_headers() {
         // Given

--- a/src/test/java/HttpRequestParserTest.java
+++ b/src/test/java/HttpRequestParserTest.java
@@ -1,5 +1,7 @@
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpRequestParser;
+import codesquad.http.type.HttpMethod;
+import codesquad.http.type.HttpProtocol;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -10,16 +12,13 @@ class HttpRequestParserTest {
     @Test
     @DisplayName("Body까지 모두 존재하는 경우")
     public void test_correctly_parses_well_formed_http_post_request_with_body() {
-        // Given
         String message = "POST /submit HTTP/1.1\nHost: www.example.com\nContent-Length: 11\n\nHello World";
 
-        // When
         HttpRequest request = HttpRequestParser.parse(message);
 
-        // Then
-        assertEquals("POST", request.method());
+        assertEquals(HttpMethod.POST, request.method());
         assertEquals("/submit", request.path());
-        assertEquals("HTTP/1.1", request.protocol());
+        assertEquals(HttpProtocol.HTTP_1_1, request.protocol());
         assertEquals("www.example.com", request.headers().get("Host"));
         assertEquals("11", request.headers().get("Content-Length"));
         assertEquals("Hello World", request.body());
@@ -28,16 +27,13 @@ class HttpRequestParserTest {
     @Test
     @DisplayName("QueryString이 존재하는 경우")
     public void test_handles_http_requests_with_malformed_headers_with_query_string() {
-        // Given
         String message = "GET /index.html?param1=value1&param2=value2 HTTP/1.1\nHost www.example.com\n\n";
 
-        // When
         HttpRequest request = HttpRequestParser.parse(message);
 
-        // Then
-        assertEquals("GET", request.method());
+        assertEquals(HttpMethod.GET, request.method());
         assertEquals("/index.html", request.path());
-        assertEquals("HTTP/1.1", request.protocol());
+        assertEquals(HttpProtocol.HTTP_1_1, request.protocol());
         assertTrue(request.headers().isEmpty());
         assertTrue(request.body().isEmpty());
         assertTrue(request.queryString().containsKey("param1"));
@@ -49,16 +45,13 @@ class HttpRequestParserTest {
     @Test
     @DisplayName("Header와 Body가 없는 경우")
     public void test_handles_http_requests_with_no_headers() {
-        // Given
         String message = "GET /index.html HTTP/1.1\n\n";
 
-        // When
         HttpRequest request = HttpRequestParser.parse(message);
 
-        // Then
-        assertEquals("GET", request.method());
+        assertEquals(HttpMethod.GET, request.method());
         assertEquals("/index.html", request.path());
-        assertEquals("HTTP/1.1", request.protocol());
+        assertEquals(HttpProtocol.HTTP_1_1, request.protocol());
         assertTrue(request.headers().isEmpty());
         assertTrue(request.body().isEmpty());
     }
@@ -66,16 +59,13 @@ class HttpRequestParserTest {
     @Test
     @DisplayName("Body가 없는 경우")
     public void test_handles_http_requests_with_no_body() {
-        // Given
         String message = "GET /index.html HTTP/1.1\nHost: www.example.com\n\n";
 
-        // When
         HttpRequest request = HttpRequestParser.parse(message);
 
-        // Then
-        assertEquals("GET", request.method());
+        assertEquals(HttpMethod.GET, request.method());
         assertEquals("/index.html", request.path());
-        assertEquals("HTTP/1.1", request.protocol());
+        assertEquals(HttpProtocol.HTTP_1_1, request.protocol());
         assertEquals("www.example.com", request.headers().get("Host"));
         assertTrue(request.body().isEmpty());
     }

--- a/src/test/java/codesquad/webserver/ResponseHandlerTest.java
+++ b/src/test/java/codesquad/webserver/ResponseHandlerTest.java
@@ -1,0 +1,37 @@
+package codesquad.webserver;
+
+import codesquad.http.HttpRequest;
+import codesquad.http.HttpResponse;
+import codesquad.http.type.HttpMethod;
+import codesquad.http.type.HttpProtocol;
+import codesquad.http.type.HttpStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ResponseHandlerTest {
+    @Test
+    @DisplayName("요청에 해당하는 것이 없는 경우")
+    public void test_handles_request_for_static_file_with_no_extension() {
+        // 헤더가 존재하지 않는 요청은 뭐ㅏ고 해석해야하지?
+        ResponseHandler responseHandler = new ResponseHandler();
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, "/file", null, HttpProtocol.HTTP_1_1, null, null);
+
+        HttpResponse httpResponse = responseHandler.handle(httpRequest);
+
+        assertEquals(HttpStatus.BAD_REQUEST, httpResponse.status());
+    }
+
+    @Test
+    @DisplayName("요청에 해당하는 파일이 있는 경우")
+    public void test_returns_ok_for_valid_static_file_request() {
+        // 먼 훗날 파일이 사라지면 어떻게하지? 테스트용 파일을 만들어야하나?
+        ResponseHandler responseHandler = new ResponseHandler();
+        HttpRequest httpRequest = new HttpRequest(HttpMethod.GET, "/index.html", null, HttpProtocol.HTTP_1_1, null, null);
+
+        HttpResponse httpResponse = responseHandler.handle(httpRequest);
+
+        assertEquals(HttpStatus.OK, httpResponse.status());
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 더 다양한 정적 컨텐츠를 반환할 수 있습니다.
  - html, css, svg, png, jpg, js, ico, json, xml, txt
- HttpRequest에서 QueryString을 구분합니다.
- HTTP 관련 상수들을 별도로 분리하여 관리합니다.
  - HttpMethod, HttpProtocol, HttpStatus
- 요청에 대해 확장자 여부에 따라 정적요청인지 구분하는 분기를 추가합니다.
  - 정적 파일 요청이지만 찾지 못하는 경우에는 NOT_FOUND를 반환
  - 동적 요청인 경우 우선은 BAD_REQUEST를 반환 (현재 처리로직이 없음)

## 고민 사항
- 정적파일을 클래스로더를 통해 불러오신 분들이 계시던데, 파일에 경로를 입력하여 직접가져오는 것 대비해서 어떠한 이점이 있는지 확인해보고 있습니다. 
- Filter나 Handler를 통해 요청과 응답 행위들을 처리하는 패턴을 사용하면, 이후 늘어나는 로직들을 분리하기 좋을 것 같아서 고민이 됩니다!


## 기타
- 실제 브라우저에서 전송되는 요청과 테스트를 위해서 생성한 요청 사이에 공백 등 예상하기 힘든 차이를 처리해줘야했습니다. 이러한 케이스들을 포괄하여 서버에서 유연하게 처리하도록 노력해야겠습니다.

index.html 실행모습
![image](https://github.com/woowa-techcamp-2024/java-was/assets/10378777/b6d78e77-e174-46aa-a4c4-cf2d160c8e68)
