### PR TITLE
[고동훤] step-1 index.html 응답

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     testImplementation platform('org.junit:junit-bom:5.10.0')
     testImplementation 'org.junit.jupiter:junit-jupiter'
+    implementation 'ch.qos.logback:logback-classic:1.5.6'
 }
 
 test {

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -1,28 +1,21 @@
 package codesquad;
 
+import codesquad.server.FixedThreadWebServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
-import java.io.OutputStream;
-import java.net.ServerSocket;
-import java.net.Socket;
 
 
 public class Main {
+    private static final Logger logger = LoggerFactory.getLogger(Main.class);
+
     public static void main(String[] args) throws IOException {
-        ServerSocket serverSocket = new ServerSocket(8080); // 8080 포트에서 서버를 엽니다.
-        System.out.println("Listening for connection on port 8080 ....");
+        FixedThreadWebServer server = new FixedThreadWebServer(8080, 20);
+        run(server);
+    }
 
-        while (true) { // 무한 루프를 돌며 클라이언트의 연결을 기다립니다.
-            try (Socket clientSocket = serverSocket.accept()) { // 클라이언트 연결을 수락합니다.
-                System.out.println("Client connected");
-
-                // HTTP 응답을 생성합니다.
-                OutputStream clientOutput = clientSocket.getOutputStream();
-                clientOutput.write("HTTP/1.1 200 OK\r\n".getBytes());
-                clientOutput.write("Content-Type: text/html\r\n".getBytes());
-                clientOutput.write("\r\n".getBytes());
-                clientOutput.write("<h1>Hello</h1>\r\n".getBytes()); // 응답 본문으로 "Hello"를 보냅니다.
-                clientOutput.flush();
-            }
-        }
+    private static void run(FixedThreadWebServer server) {
+        server.start();
     }
 }

--- a/src/main/java/codesquad/exception/BadGrammarException.java
+++ b/src/main/java/codesquad/exception/BadGrammarException.java
@@ -1,0 +1,4 @@
+package codesquad.exception;
+
+public class BadGrammarException extends Exception {
+}

--- a/src/main/java/codesquad/exception/ConnectedSocketException.java
+++ b/src/main/java/codesquad/exception/ConnectedSocketException.java
@@ -1,0 +1,7 @@
+package codesquad.exception;
+
+public class ConnectedSocketException extends ServerException{
+    public ConnectedSocketException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/codesquad/exception/ConnectedSocketException.java
+++ b/src/main/java/codesquad/exception/ConnectedSocketException.java
@@ -1,6 +1,6 @@
 package codesquad.exception;
 
-public class ConnectedSocketException extends ServerException{
+public class ConnectedSocketException extends ServerException {
     public ConnectedSocketException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/codesquad/exception/ServerException.java
+++ b/src/main/java/codesquad/exception/ServerException.java
@@ -1,0 +1,7 @@
+package codesquad.exception;
+
+public class ServerException extends RuntimeException{
+    public ServerException(Throwable cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/codesquad/exception/ServerException.java
+++ b/src/main/java/codesquad/exception/ServerException.java
@@ -1,6 +1,6 @@
 package codesquad.exception;
 
-public class ServerException extends RuntimeException{
+public class ServerException extends RuntimeException {
     public ServerException(Throwable cause) {
         super(cause);
     }

--- a/src/main/java/codesquad/http/model/HttpRequest.java
+++ b/src/main/java/codesquad/http/model/HttpRequest.java
@@ -1,0 +1,51 @@
+package codesquad.http.model;
+
+import codesquad.http.model.body.Body;
+import codesquad.http.model.header.Header;
+import codesquad.http.model.header.Headers;
+import codesquad.http.model.startline.RequestLine;
+import codesquad.http.model.startline.Target;
+
+public class HttpRequest {
+    private final RequestLine requestLine;
+    private final Headers headers;
+    private final Body message;
+
+    public HttpRequest(RequestLine requestLine) {
+        this(requestLine, null);
+    }
+
+    public HttpRequest(RequestLine requestLine, Headers headers) {
+        this(requestLine, headers, null);
+    }
+
+    public HttpRequest(RequestLine requestLine, Headers headers, Body message) {
+        this.requestLine = requestLine;
+        this.headers = headers;
+        this.message = message;
+    }
+
+    public boolean hasBody() {
+        return headers.get(Header.CONTENT_LENGTH.getFieldName()) != null;
+    }
+
+    public int getContentLength() {
+        return (int) headers.get(Header.CONTENT_LENGTH.getFieldName());
+    }
+
+    public RequestLine getRequestLine() {
+        return requestLine;
+    }
+
+    public Headers getHeader() {
+        return headers;
+    }
+
+    public Body getMessage() {
+        return message;
+    }
+
+    public String getRequestPath() {
+        return requestLine.getTarget().getPath();
+    }
+}

--- a/src/main/java/codesquad/http/model/HttpRequest.java
+++ b/src/main/java/codesquad/http/model/HttpRequest.java
@@ -4,7 +4,6 @@ import codesquad.http.model.body.Body;
 import codesquad.http.model.header.Header;
 import codesquad.http.model.header.Headers;
 import codesquad.http.model.startline.RequestLine;
-import codesquad.http.model.startline.Target;
 
 public class HttpRequest {
     private final RequestLine requestLine;

--- a/src/main/java/codesquad/http/model/HttpResponse.java
+++ b/src/main/java/codesquad/http/model/HttpResponse.java
@@ -1,0 +1,43 @@
+package codesquad.http.model;
+
+import codesquad.http.model.body.Body;
+import codesquad.http.model.header.Headers;
+import codesquad.http.model.startline.StatusCode;
+import codesquad.http.model.startline.StatusLine;
+import codesquad.http.model.startline.Version;
+
+public class HttpResponse {
+    public static final HttpResponse BAD_REQUEST = new BadRequestHttpResponse();
+
+    private final StatusLine statusLine;
+    private final Headers headers;
+    private final Body body;
+
+    public HttpResponse(StatusLine statusLine, Headers headers, Body body) {
+        this.statusLine = statusLine;
+        this.headers = headers;
+        this.body = body;
+    }
+
+    public StatusLine getStatusLine() {
+        return statusLine;
+    }
+
+    public Headers getHeader() {
+        return headers;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+
+    public boolean hasBody() {
+        return body != null;
+    }
+
+    private static class BadRequestHttpResponse extends HttpResponse {
+        public BadRequestHttpResponse() {
+            super(new StatusLine(Version.HTTP_1_1, StatusCode.BAD_REQUEST), null, null);
+        }
+    }
+}

--- a/src/main/java/codesquad/http/model/body/Body.java
+++ b/src/main/java/codesquad/http/model/body/Body.java
@@ -1,0 +1,13 @@
+package codesquad.http.model.body;
+
+public class Body {
+    private final byte[] body;
+
+    public Body(byte[] body) {
+        this.body = body;
+    }
+
+    public byte[] getBody() {
+        return body;
+    }
+}

--- a/src/main/java/codesquad/http/model/header/Header.java
+++ b/src/main/java/codesquad/http/model/header/Header.java
@@ -1,0 +1,15 @@
+package codesquad.http.model.header;
+
+public enum Header {
+    CONNECTION("connection"), CONTENT_TYPE("Content-Type"), CONTENT_LENGTH("Content-Length");
+
+    private final String fieldName;
+
+    Header(String fieldName) {
+        this.fieldName = fieldName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+}

--- a/src/main/java/codesquad/http/model/header/Headers.java
+++ b/src/main/java/codesquad/http/model/header/Headers.java
@@ -1,0 +1,29 @@
+package codesquad.http.model.header;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class Headers {
+    private final Map<String, String> headers;
+
+    public Headers() {
+        this.headers = new HashMap<>();
+    }
+
+    public void addHeader(String key, String value) {
+        this.headers.put(key, value);
+    }
+
+    public Object get(String fieldName) {
+        return headers.get(fieldName);
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            sb.append(entry.getKey()).append(": ").append(entry.getValue()).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/Method.java
+++ b/src/main/java/codesquad/http/model/startline/Method.java
@@ -1,0 +1,14 @@
+package codesquad.http.model.startline;
+
+public enum Method {
+    GET, POST, PUT, DELETE;
+
+    public static Method of(String message) {
+        for (Method method : Method.values()) {
+            if (method.toString().equals(message)) {
+                return method;
+            }
+        }
+        throw new UnsupportedOperationException("Unsupported method: " + message);
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/RequestLine.java
+++ b/src/main/java/codesquad/http/model/startline/RequestLine.java
@@ -1,0 +1,25 @@
+package codesquad.http.model.startline;
+
+public class RequestLine {
+    private final Version version;
+    private final Method method;
+    private final Target target;
+
+    public RequestLine(Version version, Method method, Target target) {
+        this.version = version;
+        this.method = method;
+        this.target = target;
+    }
+
+    public Version getVersion() {
+        return version;
+    }
+
+    public Method getMethod() {
+        return method;
+    }
+
+    public Target getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/StatusCode.java
+++ b/src/main/java/codesquad/http/model/startline/StatusCode.java
@@ -1,0 +1,21 @@
+package codesquad.http.model.startline;
+
+public enum StatusCode {
+    OK(200, "OK"), BAD_REQUEST(400, "Bad Request");
+
+    private final int code;
+    private final String message;
+
+    StatusCode(int code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/StatusLine.java
+++ b/src/main/java/codesquad/http/model/startline/StatusLine.java
@@ -1,0 +1,16 @@
+package codesquad.http.model.startline;
+
+public class StatusLine {
+    private final Version version;
+    private final StatusCode statusCode;
+
+    public StatusLine(Version version, StatusCode statusCode) {
+        this.version = version;
+        this.statusCode = statusCode;
+    }
+
+    @Override
+    public String toString() {
+        return version.getMessage() + " " + statusCode.getCode() + " " + statusCode.getMessage() + "\n";
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/Target.java
+++ b/src/main/java/codesquad/http/model/startline/Target.java
@@ -1,0 +1,13 @@
+package codesquad.http.model.startline;
+
+public class Target {
+    private final String path;
+
+    public Target(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/codesquad/http/model/startline/Version.java
+++ b/src/main/java/codesquad/http/model/startline/Version.java
@@ -1,0 +1,24 @@
+package codesquad.http.model.startline;
+
+public enum Version {
+    HTTP_1_1("HTTP/1.1");
+
+    private final String message;
+
+    Version(String message) {
+        this.message = message;
+    }
+
+    public static Version of(String message) {
+        for (Version version : Version.values()) {
+            if (version.getMessage().equals(message)) {
+                return version;
+            }
+        }
+        throw new UnsupportedOperationException("Unsupported HTTP version: " + message);
+    }
+
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/codesquad/http/parser/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/parser/HttpRequestParser.java
@@ -1,0 +1,12 @@
+package codesquad.http.parser;
+
+import codesquad.exception.BadGrammarException;
+import codesquad.http.model.HttpRequest;
+
+public interface HttpRequestParser {
+    HttpRequest parseRequestLine(String requestLine) throws BadGrammarException;
+
+    HttpRequest parseHeader(HttpRequest httpRequest, String headers) throws BadGrammarException;
+
+    HttpRequest parseBody(HttpRequest httpRequest, String body) throws BadGrammarException;
+}

--- a/src/main/java/codesquad/http/parser/HttpRequestParserImpl.java
+++ b/src/main/java/codesquad/http/parser/HttpRequestParserImpl.java
@@ -1,0 +1,38 @@
+package codesquad.http.parser;
+
+import codesquad.exception.BadGrammarException;
+import codesquad.http.model.HttpRequest;
+import codesquad.http.model.body.Body;
+import codesquad.http.model.header.Headers;
+import codesquad.http.model.startline.Method;
+import codesquad.http.model.startline.RequestLine;
+import codesquad.http.model.startline.Target;
+import codesquad.http.model.startline.Version;
+
+import java.nio.charset.StandardCharsets;
+
+public class HttpRequestParserImpl implements HttpRequestParser {
+    @Override
+    public HttpRequest parseRequestLine(String requestLine) throws BadGrammarException {
+        Method method = Method.of(requestLine.split(" ")[0]);
+        Target target = new Target(requestLine.split(" ")[1]);
+        Version version = Version.of(requestLine.split(" ")[2]);
+        return new HttpRequest(new RequestLine(version, method, target));
+    }
+
+    @Override
+    public HttpRequest parseHeader(HttpRequest httpRequest, String headers) throws BadGrammarException {
+        Headers result = new Headers();
+        for (String header : headers.split("\n")) {
+            String fieldName = header.split(":")[0];
+            String fieldValue = header.split(":")[1].trim();
+            result.addHeader(fieldName, fieldValue);
+        }
+        return new HttpRequest(httpRequest.getRequestLine(), result);
+    }
+
+    @Override
+    public HttpRequest parseBody(HttpRequest httpRequest, String body) throws BadGrammarException {
+        return new HttpRequest(httpRequest.getRequestLine(), httpRequest.getHeader(), new Body(body.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/main/java/codesquad/server/FixedThreadWebServer.java
+++ b/src/main/java/codesquad/server/FixedThreadWebServer.java
@@ -1,0 +1,34 @@
+package codesquad.server;
+
+import codesquad.exception.ServerException;
+import codesquad.server.handler.HttpRequestHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class FixedThreadWebServer {
+    private static final Logger logger = LoggerFactory.getLogger(FixedThreadWebServer.class);
+
+    private final int port;
+    private final ExecutorService executorService;
+
+    public FixedThreadWebServer(int port, int nThreads) {
+        this.port = port;
+        this.executorService = Executors.newFixedThreadPool(nThreads);
+    }
+
+    public void start() {
+        try (ServerSocket serverSocket = new ServerSocket(port)) {
+            logger.info("Listening for connection on port 8080 ....");
+            while (true) {
+                executorService.execute(new HttpRequestHandler(serverSocket.accept()));
+            }
+        } catch (IOException e) {
+            throw new ServerException(e);
+        }
+    }
+}

--- a/src/main/java/codesquad/server/connection/ConnectionManager.java
+++ b/src/main/java/codesquad/server/connection/ConnectionManager.java
@@ -4,7 +4,9 @@ import codesquad.exception.ConnectedSocketException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.Socket;
 
 public abstract class ConnectionManager {

--- a/src/main/java/codesquad/server/connection/ConnectionManager.java
+++ b/src/main/java/codesquad/server/connection/ConnectionManager.java
@@ -1,0 +1,93 @@
+package codesquad.server.connection;
+
+import codesquad.exception.ConnectedSocketException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.*;
+import java.net.Socket;
+
+public abstract class ConnectionManager {
+    protected static final Logger logger = LoggerFactory.getLogger(ConnectionManager.class);
+
+    protected final Socket socket;
+    protected final KeepAliveManager keepAliveManager;
+
+    private BufferedReader in;
+
+    protected ConnectionManager(Socket socket, KeepAliveManager keepAliveManager) {
+        this.socket = socket;
+        this.keepAliveManager = keepAliveManager;
+    }
+
+    public boolean isAlive() {
+        if (socket.isOutputShutdown()) {
+            logger.info("Socket is closed");
+            return false;
+        }
+        return keepAliveManager.isAlive() && !keepAliveManager.isTimeout();
+    }
+
+    public void close() {
+        try {
+            logger.info("Closing socket");
+            socket.close();
+        } catch (IOException e) {
+            throw new ConnectedSocketException(e);
+        }
+    }
+
+    public String readLine() {
+        try {
+            return getInputStreamBufferedReader().readLine();
+        } catch (IOException e) {
+            throw new ConnectedSocketException(e);
+        }
+    }
+
+    public String readLines() {
+        StringBuilder sb = new StringBuilder();
+        String line;
+        try {
+            BufferedReader reader = getInputStreamBufferedReader();
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                sb.append(line).append("\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return sb.toString();
+    }
+
+    public byte[] readNBytes(int bytes) {
+        try {
+            return socket.getInputStream().readNBytes(bytes);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void write(byte[] response) {
+        try {
+            socket.getOutputStream().write(response);
+            socket.getOutputStream().flush();
+        } catch (IOException e) {
+            throw new ConnectedSocketException(e);
+        }
+    }
+
+    public void incrementRequestCounter() {
+        keepAliveManager.incrementRequest();
+    }
+
+    public BufferedReader getInputStreamBufferedReader() {
+        if (in == null) {
+            try {
+                in = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            } catch (IOException e) {
+                throw new ConnectedSocketException(e);
+            }
+        }
+        return in;
+    }
+}

--- a/src/main/java/codesquad/server/connection/KeepAliveManager.java
+++ b/src/main/java/codesquad/server/connection/KeepAliveManager.java
@@ -1,0 +1,10 @@
+package codesquad.server.connection;
+
+public interface KeepAliveManager {
+
+    boolean isAlive();
+
+    boolean isTimeout();
+
+    void incrementRequest();
+}

--- a/src/main/java/codesquad/server/connection/NoOpKeepAliveManager.java
+++ b/src/main/java/codesquad/server/connection/NoOpKeepAliveManager.java
@@ -1,0 +1,24 @@
+package codesquad.server.connection;
+
+public class NoOpKeepAliveManager implements KeepAliveManager {
+    private boolean firstRequest;
+
+    public NoOpKeepAliveManager() {
+        this.firstRequest = true;
+    }
+
+    @Override
+    public boolean isAlive() {
+        return firstRequest;
+    }
+
+    @Override
+    public boolean isTimeout() {
+        return false;
+    }
+
+    @Override
+    public void incrementRequest() {
+        firstRequest = false;
+    }
+}

--- a/src/main/java/codesquad/server/connection/OneTimeConnectionManager.java
+++ b/src/main/java/codesquad/server/connection/OneTimeConnectionManager.java
@@ -1,0 +1,9 @@
+package codesquad.server.connection;
+
+import java.net.Socket;
+
+public class OneTimeConnectionManager extends ConnectionManager {
+    public OneTimeConnectionManager(Socket socket) {
+        super(socket, new NoOpKeepAliveManager());
+    }
+}

--- a/src/main/java/codesquad/server/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/server/handler/HttpRequestHandler.java
@@ -68,7 +68,6 @@ public class HttpRequestHandler implements Runnable {
             outputStream.write('\n');
             if (response.hasBody()) {
                 Body body = response.getBody();
-                // TODO: encoding 타입에 맞게 응답
                 outputStream.write(body.getBody());
             }
             connectionManager.write(outputStream.toByteArray());

--- a/src/main/java/codesquad/server/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/server/handler/HttpRequestHandler.java
@@ -1,0 +1,89 @@
+package codesquad.server.handler;
+
+import codesquad.exception.BadGrammarException;
+import codesquad.http.model.HttpRequest;
+import codesquad.http.model.HttpResponse;
+import codesquad.http.model.body.Body;
+import codesquad.http.model.header.Headers;
+import codesquad.http.model.startline.StatusLine;
+import codesquad.http.parser.HttpRequestParser;
+import codesquad.http.parser.HttpRequestParserImpl;
+import codesquad.server.connection.ConnectionManager;
+import codesquad.server.connection.OneTimeConnectionManager;
+import codesquad.server.processor.HttpRequestProcessor;
+import codesquad.server.processor.HttpRequestProcessors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+public class HttpRequestHandler implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(HttpRequestHandler.class);
+
+    private final HttpRequestParser httpRequestParser;
+    private final HttpRequestProcessor processor;
+    private final ConnectionManager connectionManager;
+
+    public HttpRequestHandler(Socket connectedSocket) {
+        this.processor = new HttpRequestProcessors();
+        this.httpRequestParser = new HttpRequestParserImpl();
+        this.connectionManager = new OneTimeConnectionManager(connectedSocket);
+    }
+
+    @Override
+    public void run() {
+        logger.info("Client connected");
+
+        while (connectionManager.isAlive()) {
+            try {
+                HttpRequest httpRequest = getHttpRequest();
+                HttpResponse response = processor.process(httpRequest);
+                responseHttp(response);
+            } catch (BadGrammarException e) {
+                responseHttp(HttpResponse.BAD_REQUEST);
+            } catch (Exception exception) {
+                close();
+            } finally {
+                connectionManager.incrementRequestCounter();
+            }
+        }
+        close();
+    }
+
+    private void close() {
+        connectionManager.close();
+    }
+
+    private void responseHttp(HttpResponse response) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try {
+            StatusLine statusLine = response.getStatusLine();
+            outputStream.write(statusLine.toString().getBytes("US-ASCII"));
+            Headers headers = response.getHeader();
+            outputStream.write(headers.toString().getBytes("US-ASCII"));
+            outputStream.write('\r');
+            outputStream.write('\n');
+            if (response.hasBody()) {
+                Body body = response.getBody();
+                // TODO: encoding 타입에 맞게 응답
+                outputStream.write(body.getBody());
+            }
+            connectionManager.write(outputStream.toByteArray());
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private HttpRequest getHttpRequest() throws BadGrammarException {
+        HttpRequest httpRequest = httpRequestParser.parseRequestLine(connectionManager.readLine());
+        httpRequest = httpRequestParser.parseHeader(httpRequest, connectionManager.readLines());
+        if (httpRequest.hasBody()) {
+            byte[] read = connectionManager.readNBytes(httpRequest.getContentLength() * 2);
+            httpRequest = httpRequestParser.parseBody(httpRequest, new String(read, StandardCharsets.UTF_8));
+        }
+        return httpRequest;
+    }
+}

--- a/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
+++ b/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
@@ -1,0 +1,60 @@
+package codesquad.server.processor;
+
+import codesquad.http.model.HttpRequest;
+import codesquad.http.model.HttpResponse;
+import codesquad.http.model.body.Body;
+import codesquad.http.model.header.Headers;
+import codesquad.http.model.startline.Method;
+import codesquad.http.model.startline.StatusCode;
+import codesquad.http.model.startline.StatusLine;
+import codesquad.http.model.startline.Version;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class GetStaticResourceProcessor extends StaticResourceProcessor {
+    private static final String rootPath = "src/main/resources/static";
+
+    @Override
+    public HttpResponse process(HttpRequest request) {
+        File file = new File(rootPath, request.getRequestPath());
+        if (!file.exists()) {
+            return null;
+        }
+        byte[] bytes;
+        try {
+            FileInputStream fileInputStream = new FileInputStream(file);
+            try {
+                bytes = fileInputStream.readAllBytes();
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+
+        Headers headers = new Headers();
+        String extension = getExtension(file);
+        if("html".equals(extension)) {
+            headers.addHeader("content-type", "text/html");
+        }
+        return new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.OK), headers, new Body(bytes));
+    }
+
+    public static String getExtension(File file) {
+        String fileName = file.getName();
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < fileName.length() - 1) {
+            return fileName.substring(dotIndex + 1);
+        } else {
+            return ""; // 확장자가 없는 경우
+        }
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        return request.getRequestLine().getMethod() == Method.GET;
+    }
+}

--- a/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
+++ b/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
@@ -37,7 +37,7 @@ public class GetStaticResourceProcessor extends StaticResourceProcessor {
 
         Headers headers = new Headers();
         String extension = getExtension(file);
-        if("html".equals(extension)) {
+        if ("html".equals(extension)) {
             headers.addHeader("content-type", "text/html");
         }
         return new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.OK), headers, new Body(bytes));

--- a/src/main/java/codesquad/server/processor/HttpRequestProcessor.java
+++ b/src/main/java/codesquad/server/processor/HttpRequestProcessor.java
@@ -1,0 +1,10 @@
+package codesquad.server.processor;
+
+import codesquad.http.model.HttpRequest;
+import codesquad.http.model.HttpResponse;
+
+public interface HttpRequestProcessor {
+    HttpResponse process(HttpRequest request);
+
+    boolean supports(HttpRequest request);
+}

--- a/src/main/java/codesquad/server/processor/HttpRequestProcessors.java
+++ b/src/main/java/codesquad/server/processor/HttpRequestProcessors.java
@@ -1,0 +1,33 @@
+package codesquad.server.processor;
+
+import codesquad.http.model.HttpRequest;
+import codesquad.http.model.HttpResponse;
+
+import java.util.List;
+
+public class HttpRequestProcessors implements HttpRequestProcessor {
+    private final List<HttpRequestProcessor> processors;
+
+    public HttpRequestProcessors() {
+        this.processors = List.of(new GetStaticResourceProcessor());
+    }
+
+    @Override
+    public HttpResponse process(HttpRequest request) {
+        HttpResponse response;
+        for (HttpRequestProcessor processor : processors) {
+            if (processor.supports(request)) {
+                response = processor.process(request);
+                if (response != null) {
+                    return response;
+                }
+            }
+        }
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean supports(HttpRequest request) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/main/java/codesquad/server/processor/StaticResourceProcessor.java
+++ b/src/main/java/codesquad/server/processor/StaticResourceProcessor.java
@@ -1,0 +1,4 @@
+package codesquad.server.processor;
+
+public abstract class StaticResourceProcessor implements HttpRequestProcessor {
+}


### PR DESCRIPTION
## 구현 내용
 - 고정된 크기의 thread를 미리 할당해서 비동기로 http 요청을 처리하는 Server 구현
 - Http spec에 알맞게 startline/header/body 파싱 및 응답

## 고민 사항
 - 변경에 용이하고 확장하기 위한 구조?
    - 확장성 있는 구조를 만들기 위해서는 변경지점을 알아야 한다.
    - 변경지점을 알려면 Http spec을 알아야 한다. 그래서 RFC 문서를 읽는데 많은 시간이 소요되었다.
    - 추후 WAS로 발전될 가능성도 염두하여 구현
 - Http Response Spliting
    - header 내에는 CR/LF가 포함되어서는 안된다. 단, content-type이 media인 경우 허용된다.
    - header마다 규칙이 정해져 있는데 이를 어떻게 처리하면 좋을지 고민
