### PR TITLE
[김규원] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/codesquad/WasServer.java
+++ b/src/main/java/codesquad/WasServer.java
@@ -8,9 +8,7 @@ import codesquad.processor.Http11Processor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.util.concurrent.ExecutorService;
@@ -37,14 +35,13 @@ public class WasServer {
             while (true) {
                 InputStream clientInput;
 
-                try (Socket clientSocket = serverSocket.accept()) {
+                try (Socket clientSocket = serverSocket.accept();
+                     BufferedReader br = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()))) {
                     logger.debug("Client connected");
-
-                    clientInput = clientSocket.getInputStream();
-
+                    
                     //TODO http 버젼 별 분기처리 필요
                     Http11Processor processor = new Http11Processor();
-                    HttpRequest httpRequest = processor.parseRequest(clientInput);
+                    HttpRequest httpRequest = processor.parseRequest(br);
                     logger.debug(httpRequest.toString());
 
                     //TODO handler 별 분기처리 필요

--- a/src/main/java/codesquad/WasServer.java
+++ b/src/main/java/codesquad/WasServer.java
@@ -1,6 +1,7 @@
 package codesquad;
 
 import codesquad.handler.StaticFileHandler;
+import codesquad.handler.StaticFileReader;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
 import codesquad.processor.Http11Processor;
@@ -26,7 +27,7 @@ public class WasServer {
 
     public WasServer(int port) throws IOException {
         serverSocket = new ServerSocket(port);
-        staticFileHandler = new StaticFileHandler(resourceRootPath);
+        staticFileHandler = new StaticFileHandler(new StaticFileReader(resourceRootPath));
         executorService = Executors.newFixedThreadPool(MAX_THREAD_POOL_SIZE);
         logger.debug("Listening for connection on port 8080 ....");
     }

--- a/src/main/java/codesquad/handler/StaticFileReader.java
+++ b/src/main/java/codesquad/handler/StaticFileReader.java
@@ -1,0 +1,35 @@
+package codesquad.handler;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class StaticFileReader implements StaticFileReaderSpec {
+    private final String resourceRootPath;
+
+    public StaticFileReader(String resourceRootPath) {
+        this.resourceRootPath = resourceRootPath;
+    }
+
+    @Override
+    public byte[] readFile(String path) throws IOException {
+        File filePath = getFilePath(path);
+        byte[] bytes = new byte[(int) filePath.length()];
+
+        try (FileInputStream fis = new FileInputStream(filePath)) {
+            fis.read(bytes);
+        }
+
+        return bytes;
+    }
+
+    private File getFilePath(String path) {
+        return new File(resourceRootPath + "/" + path);
+    }
+
+    @Override
+    public boolean exists(String path) {
+        File filePath = getFilePath(path);
+        return filePath.exists();
+    }
+}

--- a/src/main/java/codesquad/handler/StaticFileReaderSpec.java
+++ b/src/main/java/codesquad/handler/StaticFileReaderSpec.java
@@ -1,0 +1,10 @@
+package codesquad.handler;
+
+import java.io.IOException;
+
+public interface StaticFileReaderSpec {
+
+    byte[] readFile(String path) throws IOException;
+
+    boolean exists(String path);
+}

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -12,6 +12,7 @@ public class HttpHeaders {
     public static String PATH = "Path";
     public static String HTTP_METHOD = "Http-Method";
     public static String CONTENT_TYPE = "Content-Type";
+    public static String CONTENT_LENGTH = "Content-Length";
 
     public HttpHeaders() {
         this.headers = new HashMap<>();

--- a/src/main/java/codesquad/http/MimeType.java
+++ b/src/main/java/codesquad/http/MimeType.java
@@ -1,0 +1,40 @@
+package codesquad.http;
+
+import java.nio.file.Path;
+
+public enum MimeType {
+    HTML("html", "text/html"),
+    CSS("css", "text/css"),
+    JS("js", "text/javascript"),
+    ICO("ico", "image/x-icon"),
+    PNG("png", "image/png"),
+    JPG("jpg", "image/jpeg"),
+    SVG("svg", "image/svg+xml");
+
+    private String ext;
+    private String mimeType;
+
+    MimeType(String ext, String mimeType) {
+        this.ext = ext;
+        this.mimeType = mimeType;
+    }
+
+    public String getExt() {
+        return ext;
+    }
+
+    public String getMimeType() {
+        return mimeType;
+    }
+
+    public static MimeType fromExt(Path fileName) {
+        String ext = String.valueOf(fileName).split("\\.", 2)[1];
+        for (MimeType mimeType : MimeType.values()) {
+            if (ext.equals(mimeType.ext)) {
+                return mimeType;
+            }
+        }
+
+        throw new IllegalArgumentException("No mimetype enum constant with extension" + ext);
+    }
+}

--- a/src/main/java/codesquad/http/MimeType.java
+++ b/src/main/java/codesquad/http/MimeType.java
@@ -1,7 +1,5 @@
 package codesquad.http;
 
-import java.nio.file.Path;
-
 public enum MimeType {
     HTML("html", "text/html"),
     CSS("css", "text/css"),
@@ -27,8 +25,8 @@ public enum MimeType {
         return mimeType;
     }
 
-    public static MimeType fromExt(Path fileName) {
-        String ext = String.valueOf(fileName).split("\\.", 2)[1];
+    public static MimeType fromExt(String file) {
+        String ext = file.split("\\.", 2)[1];
         for (MimeType mimeType : MimeType.values()) {
             if (ext.equals(mimeType.ext)) {
                 return mimeType;

--- a/src/main/java/codesquad/processor/Http11Processor.java
+++ b/src/main/java/codesquad/processor/Http11Processor.java
@@ -4,7 +4,9 @@ import codesquad.http.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.OutputStream;
 
 import static codesquad.utils.StringUtils.LINE_SEPERATOR;
 
@@ -12,9 +14,7 @@ public class Http11Processor implements HttpProcessor {
     public static Logger logger = LoggerFactory.getLogger(Http11Processor.class);
 
     @Override
-    public HttpRequest parseRequest(InputStream is) throws IOException {
-        //TODO br 닫기
-        BufferedReader br = new BufferedReader(new InputStreamReader(is));
+    public HttpRequest parseRequest(BufferedReader br) throws IOException {
         String[] startLineSplits = parseStartLine(br);
         HttpMethod method = HttpMethod.valueOf(startLineSplits[0]);
         String path = startLineSplits[1];
@@ -27,7 +27,6 @@ public class Http11Processor implements HttpProcessor {
         //TODO body 가 존재하는 경우 parse 로직 필요
         // content-length 에 따른 로직 구현 필요
         // trasfer-encoding 이 chunked 인 경우 구현 필요
-
         return new HttpRequest(method, path, httpVersion, headers, new HttpBody(null));
     }
 

--- a/src/main/java/codesquad/processor/Http11Processor.java
+++ b/src/main/java/codesquad/processor/Http11Processor.java
@@ -61,7 +61,9 @@ public class Http11Processor implements HttpProcessor {
 
         String contentType = response.getHeaders().get(HttpHeaders.CONTENT_TYPE);
         sb.append(HttpHeaders.CONTENT_TYPE).append(": ")
-                .append(contentType).append(LINE_SEPERATOR);
+                .append(contentType).append(",")
+                .append(HttpHeaders.CONTENT_LENGTH).append(": ")
+                .append(response.getBody().getBytes().length);
         sb.append(LINE_SEPERATOR);
 
         os.write(sb.toString().getBytes());

--- a/src/main/java/codesquad/processor/HttpProcessor.java
+++ b/src/main/java/codesquad/processor/HttpProcessor.java
@@ -3,12 +3,12 @@ package codesquad.processor;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
 
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 
 public interface HttpProcessor {
-    HttpRequest parseRequest(InputStream is) throws IOException;
+    HttpRequest parseRequest(BufferedReader br) throws IOException;
 
     void writeResponse(OutputStream os, HttpResponse response) throws IOException;
 }

--- a/src/test/java/codesquad/http/MimeTypeTest.java
+++ b/src/test/java/codesquad/http/MimeTypeTest.java
@@ -3,36 +3,30 @@ package codesquad.http;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.nio.file.Path;
-
 class MimeTypeTest {
     @Test
     void MimeType_Enum이_주어지고_css파일을_변환하면_MimeType_CSS로_변환된다() {
-        Path fileName = Path.of("index.css");
-        MimeType mimeType = MimeType.fromExt(fileName);
+        MimeType mimeType = MimeType.fromExt("index.css");
 
         Assertions.assertEquals(MimeType.CSS, mimeType);
     }
 
     @Test
     void MimeType_Enum이_주어지고_js파일을_변환하면_MimeType_JS로_변환된다() {
-        Path fileName = Path.of("index.js");
-        MimeType mimeType = MimeType.fromExt(fileName);
+        MimeType mimeType = MimeType.fromExt("index.js");
 
         Assertions.assertEquals(MimeType.JS, mimeType);
     }
 
     @Test
     void MimeType_Enum이_주어지고_html파일을_변환하면_MimeType_HTML로_변환된다() {
-        Path fileName = Path.of("index.html");
-        MimeType mimeType = MimeType.fromExt(fileName);
+        MimeType mimeType = MimeType.fromExt("index.html");
 
         Assertions.assertEquals(MimeType.HTML, mimeType);
     }
 
     @Test
     void MimeType_Enum이_주어지고_정의되지않은_확장자_파일을_변환하면_Illegal_Argument에러가_발생한다() {
-        Path fileName = Path.of("index.abcd");
-        Assertions.assertThrows(IllegalArgumentException.class, () -> MimeType.fromExt(fileName));
+        Assertions.assertThrows(IllegalArgumentException.class, () -> MimeType.fromExt("index.abcd"));
     }
 }

--- a/src/test/java/codesquad/http/MimeTypeTest.java
+++ b/src/test/java/codesquad/http/MimeTypeTest.java
@@ -1,0 +1,38 @@
+package codesquad.http;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+class MimeTypeTest {
+    @Test
+    void MimeType_Enum이_주어지고_css파일을_변환하면_MimeType_CSS로_변환된다() {
+        Path fileName = Path.of("index.css");
+        MimeType mimeType = MimeType.fromExt(fileName);
+
+        Assertions.assertEquals(MimeType.CSS, mimeType);
+    }
+
+    @Test
+    void MimeType_Enum이_주어지고_js파일을_변환하면_MimeType_JS로_변환된다() {
+        Path fileName = Path.of("index.js");
+        MimeType mimeType = MimeType.fromExt(fileName);
+
+        Assertions.assertEquals(MimeType.JS, mimeType);
+    }
+
+    @Test
+    void MimeType_Enum이_주어지고_html파일을_변환하면_MimeType_HTML로_변환된다() {
+        Path fileName = Path.of("index.html");
+        MimeType mimeType = MimeType.fromExt(fileName);
+
+        Assertions.assertEquals(MimeType.HTML, mimeType);
+    }
+
+    @Test
+    void MimeType_Enum이_주어지고_정의되지않은_확장자_파일을_변환하면_Illegal_Argument에러가_발생한다() {
+        Path fileName = Path.of("index.abcd");
+        Assertions.assertThrows(IllegalArgumentException.class, () -> MimeType.fromExt(fileName));
+    }
+}


### PR DESCRIPTION
## 구현 내용
- MimeType enum 으로 추가하여 확장자를 통해 유추 가능한 메소드를 제공
- 요청 Handler 인 `StaticFileHandler` 에서 `StaticFileReader` 클래스를 따로 분리
  - 테스트 코드에 유용하게 쓰이도록 인터페이스 분리 
- favicon.ico 이미지가 제대로 인식이 안되는 문제는 content-length 헤더를 추가하여 해결했습니다. ico 파일만 에러가 난 이유는 다음과 같습니다. 
  - SVG 파일: 텍스트 기반이며 XML 형식으로 저장됩니다. HTTP 응답에서 Content-Length 헤더가 없더라도 브라우저는 <svg> 태그의 끝을 감지하여 렌더링을 완료할 수 있습니다.
  - 바이너리 파일: 예를 들어 PNG 파일과 같은 바이너리 파일은 데이터를 바이트 단위로 처리하며, 명확한 끝 지점이 없습니다. 따라서 Content-Length 헤더가 없으면 브라우저는 전체 파일을 제대로 렌더링할 수 없습니다.

## 고민 사항
- 테스트 코드를 위해 protected 로 구현하였던 코드를 인터페이스 분리하여 정리했습니다. (코멘트에 기술)
