### PR TITLE
[김수현] step-2 다양한 컨텐츠 타입 지원 

### DIFF
--- a/src/main/java/codesquad/MimeTypes.java
+++ b/src/main/java/codesquad/MimeTypes.java
@@ -1,0 +1,34 @@
+package codesquad;
+
+public enum MimeTypes {
+
+    aac("audio/aac"),
+    abw("application/x-abiword"),
+    apng("image/apng"),
+    arc("application/x-freearc"),
+    avif("image/avif"),
+    avi("video/x-msvideo"),
+    svg("image/svg+xml"),
+    css("text/css"),
+    html("text/html"),
+    ico("image/x-icon"),
+    js("application/javascript"),
+    png("image/png"),
+    jpg("image/jpeg");
+
+
+    private String MIMEType;
+
+    MimeTypes(String MIMEType) {
+        this.MIMEType = MIMEType;
+    }
+
+    public static String getMimeType(String fileName) {
+        String extension = fileName.split("\\.")[1];
+        return valueOf(extension).getMIMEType();
+    }
+
+    public String getMIMEType() {
+        return MIMEType;
+    }
+}

--- a/src/main/java/codesquad/http/HttpHeader.java
+++ b/src/main/java/codesquad/http/HttpHeader.java
@@ -1,0 +1,44 @@
+package codesquad.http;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class HttpHeader {
+    public static final String CONTENT_LENGTH_HEADER = "Content-Length";
+
+    public static final String CONTENT_TYPE_HEADER = "Content-Type";
+
+    public static final String HOST_HEADER = "Host";
+
+    public static final String DATE_HEADER = "Date";
+
+    public static final String CONNECTION_HEADER = "Connection";
+
+    private final Map<String, String> headers;
+
+    public HttpHeader() {
+        this.headers = new HashMap<>();
+    }
+
+    public HttpHeader(Map<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
+    public Optional<String> getHeader(String name) {
+        return Optional.ofNullable(headers.get(name));
+    }
+
+    public boolean containsKey(String name) {
+        return headers.containsKey(name);
+    }
+
+    public void setHeader(String name, String value) {
+        headers.put(name, value);
+    }
+}

--- a/src/main/java/codesquad/http/HttpProcessor.java
+++ b/src/main/java/codesquad/http/HttpProcessor.java
@@ -21,7 +21,7 @@ public class HttpProcessor {
 
     private static final String STATIC_FOLDER = "static";
 
-    private static final String DEFAULT_PATH = "/";
+    private static final String INDEX_PAGE = "/index.html";
 
     public void process(Socket socket) throws IOException {
         try (
@@ -80,6 +80,9 @@ public class HttpProcessor {
         File file = new File(resource.getFile());
         if (!file.exists()) {
             return Optional.empty();
+        }
+        if (file.isDirectory()) {
+            file = new File(file, INDEX_PAGE);
         }
         return file.exists() ? Optional.of(file) : Optional.empty();
     }

--- a/src/main/java/codesquad/http/HttpProcessor.java
+++ b/src/main/java/codesquad/http/HttpProcessor.java
@@ -2,6 +2,7 @@ package codesquad.http;
 
 import codesquad.HttpSCStatus;
 import codesquad.IOUtil;
+import codesquad.MimeTypes;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -10,8 +11,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.Socket;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,16 +23,13 @@ public class HttpProcessor {
 
     private static final String DEFAULT_PATH = "/";
 
-    private static final String DEFAULT_PAGE = "/main/index.html";
-
     public void process(Socket socket) throws IOException {
         try (
                 BufferedInputStream inputStream = new BufferedInputStream(socket.getInputStream());
                 BufferedOutputStream outputStream = new BufferedOutputStream(socket.getOutputStream());
         ) {
             Request request = processRequest(inputStream);
-            String fileName = request.getPath().equals(DEFAULT_PATH) ? DEFAULT_PAGE : request.getPath();
-            processResponse(outputStream, request, fileName);
+            processResponse(outputStream, request, request.getPath());
         }
     }
 
@@ -42,37 +39,49 @@ public class HttpProcessor {
         return request;
     }
 
-    public void processResponse(OutputStream outputStream, Request request, String fileName) throws IOException {
+    public void processResponse(OutputStream outputStream, Request request, String path) throws IOException {
         Response<?> response = null;
 
-        HashMap<String, String> headers = new HashMap<>();
-        addCommonHeader(headers);
+        HttpHeader header = new HttpHeader();
+        addCommonHeader(header);
 
-        URL resource = getClass().getClassLoader().getResource(STATIC_FOLDER + fileName);
+        Optional<File> file = getFile(path);
 
-        if (resource != null) {
-            File file = new File(resource.getFile());
-            if (file.exists() && file.isFile()) {
-                headers.put(HttpResponseWriter.CONTENT_LENGTH_HEADER, String.valueOf(file.length()));
-                response = new WasResponse<File>(
-                        request.getProtocol(),
-                        HttpSCStatus.OK,
-                        headers,
-                        file
-                );
-            }
+        if (file.isEmpty()) {
+            response = WasResponse.fail(request.getProtocol(), HttpSCStatus.NOT_FOUND, header);
+        } else {
+            File fileToResponse = file.get();
+            header.setHeader(HttpHeader.CONTENT_LENGTH_HEADER, String.valueOf(fileToResponse.length()));
+            header.setHeader(HttpHeader.CONTENT_TYPE_HEADER, MimeTypes.getMimeType(fileToResponse.getName()));
+            response = new WasResponse<File>(
+                    request.getProtocol(),
+                    HttpSCStatus.OK,
+                    header,
+                    fileToResponse
+            );
         }
 
-        if (response == null) {
-            response = WasResponse.fail(request.getProtocol(), HttpSCStatus.NOT_FOUND, headers);
-        }
         log.info(response.toString());
         HttpResponseWriter.write(outputStream, response);
     }
 
-    private void addCommonHeader(Map<String, String> headers) {
-        headers.put("Date", IOUtil.getDateStringUtc());
-        headers.put("Connection", "close");
+    private void addCommonHeader(HttpHeader headers) {
+        headers.setHeader(HttpHeader.DATE_HEADER, IOUtil.getDateStringUtc());
+        headers.setHeader(HttpHeader.CONNECTION_HEADER, "close");
+    }
+
+    private Optional<File> getFile(String path) {
+        URL resource = getClass().getClassLoader().getResource(STATIC_FOLDER + path);
+
+        if (resource == null) {
+            return Optional.empty();
+        }
+
+        File file = new File(resource.getFile());
+        if (!file.exists()) {
+            return Optional.empty();
+        }
+        return file.exists() ? Optional.of(file) : Optional.empty();
     }
 
 }

--- a/src/main/java/codesquad/http/HttpResponseWriter.java
+++ b/src/main/java/codesquad/http/HttpResponseWriter.java
@@ -11,10 +11,6 @@ import java.util.Map;
 
 public class HttpResponseWriter {
 
-    public static final String CONTENT_LENGTH_HEADER = "Content-Length";
-
-    public static final String CONTENT_TYPE_HEADER = "Content-Type";
-
     public static final int BUFFER_SIZE = 8192;
 
     public static void write(OutputStream output, Response<?> response) throws IOException {
@@ -31,7 +27,7 @@ public class HttpResponseWriter {
 
         writeLine(output, null);
 
-        if (response.getHeader(CONTENT_LENGTH_HEADER).isPresent()
+        if (response.getHeader(HttpHeader.CONTENT_LENGTH_HEADER).isPresent()
                 && response.getBody() != null
                 && response.getBody().getClass().equals(File.class)
         ) {

--- a/src/main/java/codesquad/http/JIoEndpoint.java
+++ b/src/main/java/codesquad/http/JIoEndpoint.java
@@ -4,6 +4,7 @@ import codesquad.http.JIoEndpoint.SocketProcessor;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -19,7 +20,7 @@ public final class JIoEndpoint implements Endpoint<Socket, SocketProcessor> {
 
     private final ExecutorService workerExecutorService;
 
-    private final LinkedBlockingQueue<HttpProcessor> processors;
+    private final ArrayBlockingQueue<HttpProcessor> processors;
 
     private final int port;
 
@@ -38,7 +39,7 @@ public final class JIoEndpoint implements Endpoint<Socket, SocketProcessor> {
         log.info("acceptor thread created");
         log.info("{} worker threads created", workers);
 
-        this.processors = new LinkedBlockingQueue<>(workers);
+        this.processors = new ArrayBlockingQueue<>(workers);
     }
 
     @Override

--- a/src/main/java/codesquad/http/WasRequest.java
+++ b/src/main/java/codesquad/http/WasRequest.java
@@ -15,7 +15,7 @@ public class WasRequest implements Request {
 
     private String host;
 
-    private Map<String, String> headers;
+    private HttpHeader headers;
 
     private Map<String, String> parameters;
 
@@ -25,7 +25,7 @@ public class WasRequest implements Request {
                       String path,
                       String protocol,
                       String host,
-                      Map<String, String> headers,
+                      HttpHeader headers,
                       Map<String, String> parameters,
                       byte[] body) {
         this.method = method;
@@ -39,12 +39,12 @@ public class WasRequest implements Request {
 
     @Override
     public Map<String, String> getHeaders() {
-        return Collections.unmodifiableMap(headers);
+        return headers.getHeaders();
     }
 
     @Override
     public Optional<String> getHeader(String name) {
-        return Optional.of(headers.get(name));
+        return headers.getHeader(name);
     }
 
     @Override

--- a/src/main/java/codesquad/http/WasResponse.java
+++ b/src/main/java/codesquad/http/WasResponse.java
@@ -8,18 +8,18 @@ import java.util.Optional;
 public class WasResponse<T> implements Response<T> {
     private final String protocol;
     private final HttpSCStatus status;
-    private final Map<String, String> headers;
+    private final HttpHeader header;
     private final T body;
 
-    public WasResponse(String protocol, HttpSCStatus status, Map<String, String> headers, T body) {
+    public WasResponse(String protocol, HttpSCStatus status, HttpHeader header, T body) {
         this.protocol = protocol;
         this.status = status;
-        this.headers = headers;
+        this.header = header;
         this.body = body;
     }
 
-    public static WasResponse<Void> fail(String protocol, HttpSCStatus status, Map<String, String> headers) {
-        return new WasResponse<>(protocol, status, headers, null);
+    public static WasResponse<Void> fail(String protocol, HttpSCStatus status, HttpHeader header) {
+        return new WasResponse<>(protocol, status, header, null);
     }
 
     @Override
@@ -39,12 +39,12 @@ public class WasResponse<T> implements Response<T> {
 
     @Override
     public Map<String, String> getHeaders() {
-        return Collections.unmodifiableMap(headers);
+        return header.getHeaders();
     }
 
     @Override
     public Optional<String> getHeader(String key) {
-        return Optional.ofNullable(headers.get(key));
+        return header.getHeader(key);
     }
 
     @Override
@@ -59,7 +59,7 @@ public class WasResponse<T> implements Response<T> {
         sb.append("protocol='").append(protocol).append('\'').append(System.lineSeparator());
         sb.append("statusCode='").append(getStatusCode()).append('\'').append(System.lineSeparator());
         sb.append("statusMeessage='").append(getStatusMessage()).append('\'').append(System.lineSeparator());
-        sb.append("headers=").append(headers).append(System.lineSeparator());
+        sb.append("headers=").append(header.getHeaders()).append(System.lineSeparator());
         sb.append("body=").append(body).append(System.lineSeparator());
         sb.append("}").append(System.lineSeparator());
         return sb.toString();


### PR DESCRIPTION
## 구현 내용
### 컨텐츠 타입 헤더 추가
+ 지원할 컨텐츠 타입 확장자 Enum으로 관리
+ 파일의 확장자로 해당하는 MIMEType 객체 얻을 수 있는 기능 구현
+ 경로에 해당하는 파일이 있다면 파일을 응답 본문에 추가. Content-Length, Content-Type 헤더 추가

### 기타 수정 사항
+ HttpProcessor 재사용하기 위해서 LinkedBlockingQueue로 관리하던 것을  ArrayBlockingQueue로 수정. 고정된 스레드 풀의 사이즈만큼의 객체만 생성하기 때문에 ArrayBlockingQueue가 성능과 메모리 효율이 좋기 때문
+ 디렉토리 경로 요청시 index.html 반환
## 기타
+ 테스트 추가 필요. 
+ 정적 유틸리티 클래스의 경우 테스트하기 어렵기 때문에 정말로 정적 클래스로 만들 필요가 있는지 검토해보기.