### PR TITLE
[고동훤] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/codesquad/http/model/header/ContentType.java
+++ b/src/main/java/codesquad/http/model/header/ContentType.java
@@ -1,0 +1,36 @@
+package codesquad.http.model.header;
+
+public enum ContentType {
+    HTML("html", "text/html"),
+    CSS("css", "text/css"),
+    JS("js", "text/javascript"),
+    ICO("ico", "image/x-icon"),
+    PNG("png", "image/png"),
+    JPG("jpg", "image/jpeg"),
+    SVG("svg", "image/svg+xml");
+
+    private final String extension;
+    private final String contentType;
+
+    ContentType(String extension, String contentType) {
+        this.extension = extension;
+        this.contentType = contentType;
+    }
+
+    public static ContentType ofExtension(String extension) {
+        for (ContentType contentType : ContentType.values()) {
+            if (contentType.extension.equals(extension)) {
+                return contentType;
+            }
+        }
+        return null;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
+++ b/src/main/java/codesquad/server/processor/GetStaticResourceProcessor.java
@@ -3,6 +3,7 @@ package codesquad.server.processor;
 import codesquad.http.model.HttpRequest;
 import codesquad.http.model.HttpResponse;
 import codesquad.http.model.body.Body;
+import codesquad.http.model.header.ContentType;
 import codesquad.http.model.header.Headers;
 import codesquad.http.model.startline.Method;
 import codesquad.http.model.startline.StatusCode;
@@ -23,6 +24,21 @@ public class GetStaticResourceProcessor extends StaticResourceProcessor {
         if (!file.exists()) {
             return null;
         }
+        byte[] bytes = getBytes(file);
+
+        Headers headers = new Headers();
+        addContentType(headers, getExtension(file));
+        return new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.OK), headers, new Body(bytes));
+    }
+
+    private static void addContentType(Headers headers, String extension) {
+        ContentType contentType = ContentType.ofExtension(extension);
+        if (contentType != null) {
+            headers.addHeader("content-type", contentType.getContentType());
+        }
+    }
+
+    private static byte[] getBytes(File file) {
         byte[] bytes;
         try {
             FileInputStream fileInputStream = new FileInputStream(file);
@@ -34,13 +50,7 @@ public class GetStaticResourceProcessor extends StaticResourceProcessor {
         } catch (FileNotFoundException e) {
             throw new RuntimeException(e);
         }
-
-        Headers headers = new Headers();
-        String extension = getExtension(file);
-        if ("html".equals(extension)) {
-            headers.addHeader("content-type", "text/html");
-        }
-        return new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.OK), headers, new Body(bytes));
+        return bytes;
     }
 
     public static String getExtension(File file) {


### PR DESCRIPTION
## 구현 내용
 - 확장자에 따른 Content-type field value를 enum으로 구현
 - 정적 리소스를 요청할 때 확장자를 확인해서 content-type header를 응답

## 고민 사항
 - message/http media type인 경우에만 예외로 header에 공백이 허용되는 규칙이 있다.
    - body에 담긴 데이터의 타입을 의미하는 content-type과는 무관한 내용으로 보인다.
