### PR TITLE
[김준기] step-2 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/codesquad/HttpProcessor.java
+++ b/src/main/java/codesquad/HttpProcessor.java
@@ -52,30 +52,22 @@ public class HttpProcessor {
     }
 
     public void sendResponse(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        sendStatus(outputStream, httpResponse);
+        sendResponseLine(outputStream, httpResponse);
         sendHeaders(outputStream, httpResponse);
         sendBody(outputStream, httpResponse);
     }
 
-    private void sendStatus(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        String status = httpResponse.getHttpVersion() + " " + httpResponse.getHttpStatus().getCode() + " "
-                + httpResponse.getHttpStatus().getRepresentation();
-        outputStream.write(status.getBytes());
+    private void sendResponseLine(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
+        outputStream.write(httpResponse.getResponseLine().getBytes());
         outputStream.write(CRLF.getBytes());
     }
 
     private void sendHeaders(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        Map<String, String> headers = httpResponse.getHeaders();
-        for (String headerName : headers.keySet()) {
-            String headerValue = headers.get(headerName);
-            String header = headerName + ": " + headerValue;
-            outputStream.write(header.getBytes());
-        }
-        outputStream.write(CRLF.getBytes());
+        outputStream.write(httpResponse.getHeaders().getBytes());
         outputStream.write(CRLF.getBytes());
     }
 
     private void sendBody(OutputStream outputStream, HttpResponse httpResponse) throws IOException {
-        outputStream.write(httpResponse.getBody().getBytes());
+        outputStream.write(httpResponse.getBody());
     }
 }

--- a/src/main/java/codesquad/HttpProcessor.java
+++ b/src/main/java/codesquad/HttpProcessor.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
-import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,10 +19,12 @@ public class HttpProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
 
+    private final HttpRequestMapper httpRequestMapper;
     private final HttpRequestHandler httpRequestHandler;
     private final Socket socket;
 
-    public HttpProcessor(HttpRequestHandler httpRequestHandler, Socket socket) {
+    public HttpProcessor(HttpRequestMapper httpRequestMapper, HttpRequestHandler httpRequestHandler, Socket socket) {
+        this.httpRequestMapper = httpRequestMapper;
         this.httpRequestHandler = httpRequestHandler;
         this.socket = socket;
     }
@@ -33,20 +34,19 @@ public class HttpProcessor {
              OutputStream outputStream = socket.getOutputStream()
         ) {
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(inputStream));
-            HttpRequest httpRequest = HttpRequestMapper.from(bufferedReader);
-
-            logger.debug("[Http Request] {}", httpRequest);
+            HttpRequest httpRequest = httpRequestMapper.from(bufferedReader);
             HttpResponse httpResponse = httpRequestHandler.handle(httpRequest);
-            logger.debug("[Http Response] {}", httpResponse);
 
             sendResponse(outputStream, httpResponse);
         } catch (IOException | RuntimeException e) {
             logger.error(e.getMessage(), e);
+            e.printStackTrace();
         } finally {
             try {
                 socket.close();
             } catch (IOException e) {
                 logger.error("Socket Close Error");
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/codesquad/WebApplicationServer.java
+++ b/src/main/java/codesquad/WebApplicationServer.java
@@ -1,6 +1,9 @@
 package codesquad;
 
 import codesquad.handler.HttpRequestHandler;
+import codesquad.handler.MappingMediaTypeFileExtensionResolver;
+import codesquad.handler.StaticResourceHandler;
+import codesquad.http.HttpRequestMapper;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
@@ -14,6 +17,9 @@ public class WebApplicationServer {
     public static final int PORT = 8080;
     private static final Logger logger = LoggerFactory.getLogger(WebApplicationServer.class);
 
+    private final HttpRequestMapper httpRequestMapper = new HttpRequestMapper();
+    private final HttpRequestHandler httpRequestHandler =
+            new HttpRequestHandler(new StaticResourceHandler(), new MappingMediaTypeFileExtensionResolver());
     private final ExecutorService executorService = Executors.newFixedThreadPool(10);
 
     public void start() {
@@ -29,10 +35,11 @@ public class WebApplicationServer {
         while (true) {
             try {
                 Socket socket = serverSocket.accept();
-                HttpProcessor httpProcessor = new HttpProcessor(new HttpRequestHandler(), socket);
+                HttpProcessor httpProcessor = new HttpProcessor(httpRequestMapper, httpRequestHandler, socket);
                 executorService.execute(httpProcessor::process);
             } catch (IOException | RuntimeException e) {
                 logger.error(e.getMessage(), e);
+                e.printStackTrace();
             }
         }
     }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -27,14 +27,28 @@ public class HttpRequestHandler {
         HttpMethod method = httpRequest.getMethod();
         String path = httpRequest.getPath();
 
-        if (method == HttpMethod.GET && path.equals("/index.html")) {
-            String content = StaticResourceHandler.getFileContents(StaticResourceHandler.STATIC_PATH + path);
+        if (method == HttpMethod.GET) {
+            String fileExtension = getFileExtension(path);
+            HttpMediaType httpMediaType = mappingMediaTypeFileExtensionResolver.resolve(fileExtension);
+
+            byte[] body = staticResourceHandler.getFileContents(path);
+
             HttpHeaders httpHeaders = HttpHeaders.empty();
-            httpHeaders.setContentType(HttpMediaType.TEXT_HTML);
-            return new HttpResponse(httpVersion, HttpStatus.OK, httpHeaders, content);
+            httpHeaders.setContentType(httpMediaType);
+            httpHeaders.setContentLength(body.length);
+
+            return new HttpResponse(httpVersion, HttpStatus.OK, httpHeaders, body);
         }
 
-        return new HttpResponse(httpVersion, HttpStatus.BAD_REQUEST, HttpHeaders.empty(), "");
+        return new HttpResponse(httpVersion, HttpStatus.BAD_REQUEST, HttpHeaders.empty(), new byte[0]);
+    }
+
+    private String getFileExtension(String path) {
+        int lastIndexOfDot = path.lastIndexOf('.');
+        if (lastIndexOfDot == -1) {
+            return "";
+        }
+        return path.substring(lastIndexOfDot + 1);
     }
 
 }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -11,6 +11,16 @@ import java.io.IOException;
 
 public class HttpRequestHandler {
 
+    private final StaticResourceHandler staticResourceHandler;
+    private final MappingMediaTypeFileExtensionResolver mappingMediaTypeFileExtensionResolver;
+
+    public HttpRequestHandler(StaticResourceHandler staticResourceHandler,
+                              MappingMediaTypeFileExtensionResolver mappingMediaTypeFileExtensionResolver
+    ) {
+        this.staticResourceHandler = staticResourceHandler;
+        this.mappingMediaTypeFileExtensionResolver = mappingMediaTypeFileExtensionResolver;
+    }
+
     public HttpResponse handle(final HttpRequest httpRequest) throws IOException {
         // TODO: reuqetURL 이 API인지, 정적 리소스 요청인지 구분하는 로직 필요
         HttpVersion httpVersion = httpRequest.getVersion();

--- a/src/main/java/codesquad/handler/MappingMediaTypeFileExtensionResolver.java
+++ b/src/main/java/codesquad/handler/MappingMediaTypeFileExtensionResolver.java
@@ -1,0 +1,28 @@
+package codesquad.handler;
+
+import codesquad.http.HttpMediaType;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class MappingMediaTypeFileExtensionResolver {
+
+    private final Map<String, HttpMediaType> mediaTypes = new ConcurrentHashMap<>();
+
+    public MappingMediaTypeFileExtensionResolver() {
+        mediaTypes.put("html", HttpMediaType.TEXT_HTML);
+        mediaTypes.put("css", HttpMediaType.TEXT_CSS);
+        mediaTypes.put("json", HttpMediaType.APPLICATION_JSON);
+        mediaTypes.put("ico", HttpMediaType.IMAGE_X_ICON);
+        mediaTypes.put("png", HttpMediaType.IMAGE_PNG);
+        mediaTypes.put("jpeg", HttpMediaType.IMAGE_JPEG);
+        mediaTypes.put("svg", HttpMediaType.IMAGE_SVG);
+    }
+
+    public HttpMediaType resolve(String extension) {
+        if (mediaTypes.containsKey(extension)) {
+            return mediaTypes.get(extension);
+        }
+        return HttpMediaType.APPLICATION_OCTET_STREAM;
+    }
+
+}

--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -1,21 +1,18 @@
 package codesquad.handler;
 
-import java.io.BufferedReader;
-import java.io.FileReader;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 
 public class StaticResourceHandler {
 
     public static final String STATIC_PATH = "src/main/resources/static/";
 
-    public static String getFileContents(String path) throws IOException {
-        StringBuilder sb = new StringBuilder();
-        try (BufferedReader reader = new BufferedReader(new FileReader(path))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                sb.append(line).append("\n");
-            }
+    public byte[] getFileContents(String path) throws IOException {
+        String targetPath = STATIC_PATH + path;
+        File file = new File(targetPath);
+        try (FileInputStream fileInputStream = new FileInputStream(file)) {
+            return fileInputStream.readAllBytes();
         }
-        return sb.toString();
     }
 }

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -1,5 +1,6 @@
 package codesquad.http;
 
+import static codesquad.http.HttpHeaders.HeaderName.CONTENT_LENGTH;
 import static codesquad.http.HttpHeaders.HeaderName.CONTENT_TYPE;
 
 import java.util.Collections;
@@ -27,6 +28,10 @@ public class HttpHeaders {
         headers.put(CONTENT_TYPE.getName(), mediaType.getName());
     }
 
+    public void setContentLength(final long contentLength) {
+        headers.put(CONTENT_LENGTH.getName(), String.valueOf(contentLength));
+    }
+
     public Map<String, String> getHeaders() {
         return Collections.unmodifiableMap(headers);
     }
@@ -40,7 +45,8 @@ public class HttpHeaders {
     }
 
     public enum HeaderName {
-        CONTENT_TYPE("Content-Type");
+        CONTENT_TYPE("Content-Type"),
+        CONTENT_LENGTH("Content-Length");
 
         private final String name;
 

--- a/src/main/java/codesquad/http/HttpMediaType.java
+++ b/src/main/java/codesquad/http/HttpMediaType.java
@@ -2,7 +2,14 @@ package codesquad.http;
 
 public enum HttpMediaType {
 
-    TEXT_HTML("text/html");
+    TEXT_HTML("text/html"),
+    TEXT_CSS("text/css"),
+    APPLICATION_JSON("application/json"),
+    APPLICATION_OCTET_STREAM("application/octet-stream"),
+    IMAGE_X_ICON("image/x-icon"),
+    IMAGE_PNG("image/png"),
+    IMAGE_JPEG("image/jpeg"),
+    IMAGE_SVG("image/svg+xml");
 
     private final String name;
 

--- a/src/main/java/codesquad/http/HttpRequestFirstLine.java
+++ b/src/main/java/codesquad/http/HttpRequestFirstLine.java
@@ -2,18 +2,14 @@ package codesquad.http;
 
 public class HttpRequestFirstLine {
 
-    private final HttpVersion version;
     private final HttpMethod method;
     private final String path;
+    private final HttpVersion version;
 
-    public HttpRequestFirstLine(HttpVersion version, HttpMethod method, String path) {
-        this.version = version;
+    public HttpRequestFirstLine(HttpMethod method, String path, HttpVersion version) {
         this.method = method;
         this.path = path;
-    }
-
-    public HttpVersion getVersion() {
-        return version;
+        this.version = version;
     }
 
     public HttpMethod getMethod() {
@@ -22,6 +18,10 @@ public class HttpRequestFirstLine {
 
     public String getPath() {
         return path;
+    }
+
+    public HttpVersion getVersion() {
+        return version;
     }
 
     @Override

--- a/src/main/java/codesquad/http/HttpRequestMapper.java
+++ b/src/main/java/codesquad/http/HttpRequestMapper.java
@@ -23,7 +23,7 @@ public class HttpRequestMapper {
         HttpMethod method = HttpMethod.valueOf(startLineParts[0]);
         String path = startLineParts[1];
         HttpVersion version = HttpVersion.of(startLineParts[2]);
-        return new HttpRequestFirstLine(version, method, path);
+        return new HttpRequestFirstLine(method, path, version);
     }
 
     private static HttpHeaders parseHeaders(BufferedReader bufferedReader) throws IOException {

--- a/src/main/java/codesquad/http/HttpRequestMapper.java
+++ b/src/main/java/codesquad/http/HttpRequestMapper.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class HttpRequestMapper {
 
-    public static HttpRequest from(final BufferedReader bufferedReader) throws IOException {
+    public HttpRequest from(final BufferedReader bufferedReader) throws IOException {
         String requestLine;
 
         requestLine = bufferedReader.readLine();
@@ -17,7 +17,7 @@ public class HttpRequestMapper {
         return new HttpRequest(firstLine, headers);
     }
 
-    private static HttpRequestFirstLine parseHttpRequestFirstLine(String requestLine) {
+    private HttpRequestFirstLine parseHttpRequestFirstLine(String requestLine) {
         String[] startLineParts = requestLine.split(" ");
 
         HttpMethod method = HttpMethod.valueOf(startLineParts[0]);
@@ -26,7 +26,7 @@ public class HttpRequestMapper {
         return new HttpRequestFirstLine(method, path, version);
     }
 
-    private static HttpHeaders parseHeaders(BufferedReader bufferedReader) throws IOException {
+    private HttpHeaders parseHeaders(BufferedReader bufferedReader) throws IOException {
         String requestLine;
         Map<String, String> headers = new HashMap<>();
         while (!(requestLine = bufferedReader.readLine()).isBlank()) {

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -1,5 +1,8 @@
 package codesquad.http;
 
+import static codesquad.utils.StringUtils.CRLF;
+
+import java.util.Arrays;
 import java.util.Map;
 
 public class HttpResponse {
@@ -7,28 +10,39 @@ public class HttpResponse {
     private final HttpVersion httpVersion;
     private final HttpStatus httpStatus;
     private final HttpHeaders headers;
-    private final String body;
+    private final byte[] body;
 
-    public HttpResponse(HttpVersion httpVersion, HttpStatus httpStatus, HttpHeaders headers, String body) {
+    public HttpResponse(HttpVersion httpVersion, HttpStatus httpStatus, HttpHeaders headers, byte[] body) {
         this.httpVersion = httpVersion;
         this.httpStatus = httpStatus;
         this.headers = headers;
         this.body = body;
     }
 
-    public HttpVersion getHttpVersion() {
-        return httpVersion;
+    public String getResponseLine() {
+        String delimiter = " ";
+        StringBuilder sb = new StringBuilder();
+        sb.append(httpVersion.getName()).append(delimiter)
+                .append(httpStatus.getCode()).append(delimiter)
+                .append(httpStatus.getRepresentation());
+        return sb.toString();
     }
 
     public HttpStatus getHttpStatus() {
         return httpStatus;
     }
 
-    public Map<String, String> getHeaders() {
-        return headers.getHeaders();
+    public String getHeaders() {
+        String delimiter = ": ";
+        Map<String, String> headers = this.headers.getHeaders();
+        StringBuilder sb = new StringBuilder();
+        for (String headerName : headers.keySet()) {
+            sb.append(headerName).append(delimiter).append(headers.get(headerName)).append(CRLF);
+        }
+        return sb.toString();
     }
 
-    public String getBody() {
+    public byte[] getBody() {
         return body;
     }
 
@@ -37,7 +51,7 @@ public class HttpResponse {
         StringBuilder sb = new StringBuilder();
         sb.append("Status: ").append(httpStatus);
         sb.append("Headers: ").append(headers);
-        sb.append("Response Body: ").append(body);
+        sb.append("Response Body: ").append(Arrays.toString(body));
         return sb.toString();
     }
 }

--- a/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
+++ b/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
@@ -1,14 +1,14 @@
 package codesquad.handler;
 
+import static codesquad.http.HttpMethod.GET;
+import static codesquad.http.HttpVersion.HTTP1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import codesquad.http.HttpHeaders;
-import codesquad.http.HttpMethod;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpRequestFirstLine;
 import codesquad.http.HttpResponse;
 import codesquad.http.HttpStatus;
-import codesquad.http.HttpVersion;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +21,7 @@ class HttpRequestHandlerTest {
     @DisplayName("[Success] /index.html로 요청을 보내면 200 OK 응답이 발생한다.")
     void requestIndex() throws IOException {
         HttpResponse httpResponse = httpRequestHandler.handle(new HttpRequest(
-                new HttpRequestFirstLine(HttpVersion.HTTP1_1, HttpMethod.GET, "/index.html"),
+                new HttpRequestFirstLine(GET, "/index.html", HTTP1_1),
                 HttpHeaders.empty()
         ));
         assertThat(httpResponse.getHttpStatus()).isEqualTo(HttpStatus.OK);
@@ -31,7 +31,7 @@ class HttpRequestHandlerTest {
     @DisplayName("[Success] /indexx.html로 요청을 보내면 400 응답이 발생한다.")
     void incorrectFileNameIndex() throws IOException {
         HttpResponse httpResponse = httpRequestHandler.handle(new HttpRequest(
-                new HttpRequestFirstLine(HttpVersion.HTTP1_1, HttpMethod.GET, "/indexx.html"),
+                new HttpRequestFirstLine(GET, "/indexx.html", HTTP1_1),
                 HttpHeaders.empty()
         ));
         assertThat(httpResponse.getHttpStatus()).isEqualTo(HttpStatus.BAD_REQUEST);

--- a/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
+++ b/src/test/java/codesquad/handler/HttpRequestHandlerTest.java
@@ -15,7 +15,8 @@ import org.junit.jupiter.api.Test;
 
 class HttpRequestHandlerTest {
 
-    HttpRequestHandler httpRequestHandler = new HttpRequestHandler();
+    HttpRequestHandler httpRequestHandler = new HttpRequestHandler(new StaticResourceHandler(),
+            new MappingMediaTypeFileExtensionResolver());
 
     @Test
     @DisplayName("[Success] /index.html로 요청을 보내면 200 OK 응답이 발생한다.")

--- a/src/test/java/codesquad/http/HttpRequestMapperTest.java
+++ b/src/test/java/codesquad/http/HttpRequestMapperTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 class HttpRequestMapperTest {
 
+    HttpRequestMapper httpRequestMapper = new HttpRequestMapper();
+
     @Test
     @DisplayName("[Success] HTTP 규약에 맞는 요청")
     void parserTest() throws IOException {
@@ -19,7 +21,7 @@ class HttpRequestMapperTest {
                 "\r\n";
 
         BufferedReader bufferedReader = new BufferedReader(new StringReader(request));
-        HttpRequest httpRequest = HttpRequestMapper.from(bufferedReader);
+        HttpRequest httpRequest = httpRequestMapper.from(bufferedReader);
 
         assertFirstLine(httpRequest);
         assertHeaders(httpRequest);


### PR DESCRIPTION
## 구현 내용
- [x] MediaType Enum 구현
- [x] 확장자에 따라 적절한d MediaType으로 매핑하는 리졸버 구현
- [x] 정적 파일의 데이터 형식과 상관없이 읽을 수 있도록 변경
  - [x] `.ico` 이진 데이터가 읽히지 않는 이슈 해결 


## 고민 사항
### 설계의 구조적 간결함과 확장성을 고려한 추상화 사이의 고민
현재 어디까지 기능이 추가될지 가늠이 잡히지 않는 상황이라, 공통 기능들에 대한 정의를 내릴 수가 없었습니다. 따라서 현재 단계에서는 구조적 간결함을 가져가고, 추후에 요구사항에 따라 추상화를 고민하는 것이 낫겠다는 판단을 내렸습니다.

<br>

### 확장자명에 따른 MediaType 변환 로직
확장자명 → Media Type 반환하는 로직이 필요고, 선택지는 `Enum으로 관리`, `Switch문으로 관리`, `Map으로 관리` 3가지가 있었습니다. WAS를 개발하는 것이 목적이므로, 다른 사용자가 MediaType을 동적으로 추가할 수 있도록 할 필요가 있겠다 생각하여 `Map으로 관리` 하였습니다. 동시성 이슈를 고려하여 ConcurrentHashMap을 사용했습니다.


## 기타
### 설계
![image](https://github.com/woowa-techcamp-2024/java-was/assets/68291395/1caec4bb-d0f2-4866-b41b-b2cdf930ce30)

<br>

### 결과
<img width="1792" alt="image" src="https://github.com/woowa-techcamp-2024/java-was/assets/68291395/07938df5-e840-42b1-8c07-574688a9e503">