### PR TITLE
[김민주] step-3 GET으로 회원가입 - 추가 PR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,16 @@ plugins {
     id 'java'
 }
 
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'codesquad.Main'
+        )
+    }
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
 group = 'codesquad'
 version = '1.0-SNAPSHOT'
 

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -27,7 +27,7 @@ public class Main {
         handlerRegistry.registerHandler(HttpMethod.GET, "/create", registerUserHandler, registerUserLogic);
 
         // 기본 리소스 핸들러
-        ResourceHandlerAdapter<Void> defaultResourceHandler = new ResourceHandlerAdapter<>();
+        ResourceHandlerAdapter<Void, Void> defaultResourceHandler = new ResourceHandlerAdapter<>();
         HttpResponseSerializer httpResponseSerializer = new HttpResponseSerializer();
         HttpResponseWriter httpResponseWriter = new HttpResponseWriter(httpResponseSerializer);
         HttpRequestDispatcher httpRequestDispatcher = new HttpRequestDispatcher(httpHandler, defaultResourceHandler, httpResponseWriter, handlerRegistry);

--- a/src/main/java/codesquad/handler/ApiRequestHandlerAdapter.java
+++ b/src/main/java/codesquad/handler/ApiRequestHandlerAdapter.java
@@ -6,7 +6,7 @@ import codesquad.http.HttpStatus;
 import codesquad.processor.ArgumentResolver;
 import codesquad.processor.Triggerable;
 
-public class ApiRequestHandlerAdapter<T, R> implements HttpHandlerAdapter<R> {
+public class ApiRequestHandlerAdapter<T, R> implements HttpHandlerAdapter<T, R> {
 
     private final ArgumentResolver<T> argumentResolver;
 
@@ -15,7 +15,7 @@ public class ApiRequestHandlerAdapter<T, R> implements HttpHandlerAdapter<R> {
     }
 
     @Override
-    public void handle(HttpRequest httpRequest, HttpResponse response, Triggerable<R> triggerable) throws Exception {
+    public void handle(HttpRequest httpRequest, HttpResponse response, Triggerable<T, R> triggerable) throws Exception {
 
         T request = argumentResolver.resolve(httpRequest);
 

--- a/src/main/java/codesquad/handler/HttpHandlerAdapter.java
+++ b/src/main/java/codesquad/handler/HttpHandlerAdapter.java
@@ -4,6 +4,6 @@ import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
 import codesquad.processor.Triggerable;
 
-public interface HttpHandlerAdapter<R> {
-    void handle(HttpRequest httpRequest, HttpResponse response, Triggerable<R> triggerable) throws Exception;
+public interface HttpHandlerAdapter<T, R> {
+    void handle(HttpRequest httpRequest, HttpResponse response, Triggerable<T, R> triggerable) throws Exception;
 }

--- a/src/main/java/codesquad/handler/ResourceHandlerAdapter.java
+++ b/src/main/java/codesquad/handler/ResourceHandlerAdapter.java
@@ -12,13 +12,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 
-public class ResourceHandlerAdapter<R> implements HttpHandlerAdapter<R> {
+public class ResourceHandlerAdapter<T, R> implements HttpHandlerAdapter<T,R> {
 
     private static final String STATIC_PATH = "static";
     private static final Logger log = LoggerFactory.getLogger(ResourceHandlerAdapter.class);
 
     @Override
-    public void handle(HttpRequest request, HttpResponse response, Triggerable<R> triggerable) throws Exception {
+    public void handle(HttpRequest request, HttpResponse response, Triggerable<T, R> triggerable) throws Exception {
         final String filePath = request.getPath().getBasePath();
 
         ClassLoader classLoader = ResourceHandlerAdapter.class.getClassLoader();

--- a/src/main/java/codesquad/model/business/RegisterUserLogic.java
+++ b/src/main/java/codesquad/model/business/RegisterUserLogic.java
@@ -4,7 +4,7 @@ import codesquad.model.User;
 import codesquad.processor.Triggerable;
 import codesquad.web.user.RegisterRequest;
 
-public class RegisterUserLogic implements Triggerable<Void> {
+public class RegisterUserLogic implements Triggerable<RegisterRequest, Void> {
 
     // TODO 임시 비즈니스 로직
     public void registerUser(RegisterRequest registerRequest) {
@@ -18,8 +18,8 @@ public class RegisterUserLogic implements Triggerable<Void> {
     }
 
     @Override
-    public Void run(Object o) {
-        registerUser((RegisterRequest) o);
+    public Void run(RegisterRequest request) {
+        registerUser(request);
         return null;
     }
 }

--- a/src/main/java/codesquad/processor/HandlerMapping.java
+++ b/src/main/java/codesquad/processor/HandlerMapping.java
@@ -5,21 +5,21 @@ import codesquad.http.HttpMethod;
 
 import java.util.regex.Pattern;
 
-public class HandlerMapping<R> {
+public class HandlerMapping<T, R> {
 
     private final HttpMethod httpMethod;
     private final Pattern pattern;
-    private final HttpHandlerAdapter<R> handler;
-    private final Triggerable<R> triggerable;
+    private final HttpHandlerAdapter<T, R> handler;
+    private final Triggerable<T, R> triggerable;
 
-    public HandlerMapping(HttpMethod httpMethod, Pattern pattern, HttpHandlerAdapter<R> handler, Triggerable<R> triggerable) {
+    public HandlerMapping(HttpMethod httpMethod, Pattern pattern, HttpHandlerAdapter<T, R> handler, Triggerable<T, R> triggerable) {
         this.httpMethod = httpMethod;
         this.pattern = pattern;
         this.handler = handler;
         this.triggerable = triggerable;
     }
 
-    public Triggerable<R> getTrigger() {
+    public Triggerable<T, R> getTrigger() {
         return triggerable;
     }
 
@@ -31,7 +31,7 @@ public class HandlerMapping<R> {
         return httpMethod;
     }
 
-    public HttpHandlerAdapter<R> getHandler() {
+    public HttpHandlerAdapter<T, R> getHandler() {
         return handler;
     }
 

--- a/src/main/java/codesquad/processor/HandlerRegistry.java
+++ b/src/main/java/codesquad/processor/HandlerRegistry.java
@@ -10,9 +10,8 @@ import java.util.regex.Pattern;
 
 public class HandlerRegistry {
 
-    private final List<HandlerMapping<?>> handlerMappings;
-
-    public HandlerRegistry(List<HandlerMapping<?>> handlerMappings) {
+    private final List<HandlerMapping<?, ?>> handlerMappings;
+    public HandlerRegistry(List<HandlerMapping<?,?>> handlerMappings) {
         this.handlerMappings = handlerMappings;
     }
 
@@ -24,14 +23,14 @@ public class HandlerRegistry {
      * @param url        URL 패턴 (PathVariable은 {변수명}으로 표현)
      * @param handler    등록할 핸들러
      */
-    public <R> void registerHandler(HttpMethod httpMethod, String url, HttpHandlerAdapter<R> handler, Triggerable<R> triggerable) {
+    public <T, R> void registerHandler(HttpMethod httpMethod, String url, HttpHandlerAdapter<T, R> handler, Triggerable<T, R> triggerable) {
         // PathVariable의 경우 {변수명}으로 표현되어 있으므로 해당 부분을 정규표현식으로 변경
         String regexPattern = url.replaceAll("\\{[^/]+\\}", "([^/]+)");
         handlerMappings.add(new HandlerMapping<>(httpMethod, Pattern.compile(regexPattern), handler, triggerable));
     }
 
-    public HandlerMapping<?> getHandler(HttpMethod httpMethod, Path path) {
-        for (HandlerMapping<?> mapping : handlerMappings) {
+    public HandlerMapping<?, ?> getHandler(HttpMethod httpMethod, Path path) {
+        for (HandlerMapping<?, ?> mapping : handlerMappings) {
             Matcher matcher = mapping.getPattern().matcher(path.getBasePath());
             if (matcher.matches() && mapping.getHttpMethod() == httpMethod) {
                 return mapping;

--- a/src/main/java/codesquad/processor/HttpRequestDispatcher.java
+++ b/src/main/java/codesquad/processor/HttpRequestDispatcher.java
@@ -14,13 +14,13 @@ import java.net.Socket;
 public class HttpRequestDispatcher {
 
     private final HttpRequestBuilder httpRequestBuilder;
-    private final HttpHandlerAdapter<?> defaultHandler;
+    private final HttpHandlerAdapter<?, ?> defaultHandler;
     private final HttpResponseWriter httpResponseWriter;
     private final HandlerRegistry handlerRegistry;
     private static final Logger log = LoggerFactory.getLogger(HttpRequestDispatcher.class);
 
     public HttpRequestDispatcher(HttpRequestBuilder httpRequestBuilder,
-                                 HttpHandlerAdapter<?> defaultHandler,
+                                 HttpHandlerAdapter<?,?> defaultHandler,
                                  HttpResponseWriter httpResponseWriter,
                                  HandlerRegistry handlerRegistry
     ) {
@@ -37,7 +37,7 @@ public class HttpRequestDispatcher {
 
         // 핸들러를 찾아서 실행 (현재는 리소스 핸들러만 존재)
         try {
-            HandlerMapping<?> mapping = handlerRegistry.getHandler(httpRequest.getMethod(), httpRequest.getPath());
+            HandlerMapping<?, ?> mapping = handlerRegistry.getHandler(httpRequest.getMethod(), httpRequest.getPath());
 
             if(mapping != null) {
                 handleRequestWithMapping(httpRequest, httpResponse, mapping);
@@ -56,9 +56,9 @@ public class HttpRequestDispatcher {
         httpResponseWriter.writeResponse(clientSocket, httpResponse);
     }
 
-    private <R> void handleRequestWithMapping(HttpRequest httpRequest, HttpResponse httpResponse, HandlerMapping<R> mapping) throws Exception {
-        HttpHandlerAdapter<R> handler = mapping.getHandler();
-        Triggerable<R> triggerable = mapping.getTrigger();
+    private <T, R> void handleRequestWithMapping(HttpRequest httpRequest, HttpResponse httpResponse, HandlerMapping<T, R> mapping) throws Exception {
+        HttpHandlerAdapter<T, R> handler = mapping.getHandler();
+        Triggerable<T, R> triggerable = mapping.getTrigger();
         handler.handle(httpRequest, httpResponse, triggerable);
     }
 

--- a/src/main/java/codesquad/processor/Triggerable.java
+++ b/src/main/java/codesquad/processor/Triggerable.java
@@ -1,7 +1,7 @@
 package codesquad.processor;
 
-public interface Triggerable<R> {
+public interface Triggerable<T, R> {
 
-    R run(Object t);
+    R run(T t);
 
 }

--- a/src/test/java/codesquad/handler/ResourceHandlerTest.java
+++ b/src/test/java/codesquad/handler/ResourceHandlerTest.java
@@ -17,11 +17,11 @@ class ResourceHandlerTest {
     @Test
     void readFileAsStream() throws Exception {
         // given
-        ResourceHandlerAdapter<Void> resourceHandler = new ResourceHandlerAdapter();
+        ResourceHandlerAdapter<Void, Void> resourceHandler = new ResourceHandlerAdapter<>();
         String filePath = "/readStaticFileOf.txt";
         HttpRequest request = TestHttpRequestFactory.createGetResourceRequest(filePath);
         HttpResponse response = new HttpResponse(HttpVersion.HTTP_1_1);
-        Triggerable<Void> triggerable = o -> null;
+        Triggerable<Void, Void> triggerable = o -> null;
 
         // when
         resourceHandler.handle(request, response, triggerable);
@@ -37,12 +37,12 @@ class ResourceHandlerTest {
     @Test
     void readFileAsStream_notFound() {
         // given
-        ResourceHandlerAdapter<Void> resourceHandler = new ResourceHandlerAdapter();
+        ResourceHandlerAdapter<Void, Void> resourceHandler = new ResourceHandlerAdapter<>();
         String filePath = "/invalid.txt";
         HttpRequest request = TestHttpRequestFactory.createGetResourceRequest(filePath);
 
         HttpResponse response = new HttpResponse(HttpVersion.HTTP_1_1);
-        Triggerable<Void> triggerable = o -> null;
+        Triggerable<Void, Void> triggerable = o -> null;
 
 
         // when & then


### PR DESCRIPTION
## 구현 내용
- `Triggerable`의 제네릭 타입을 <T, R>로 변경했습니다
- jar 빌드 시 Slf4j 의존성이 포함되지 않는 점을 해결하기 위해 build.gradle을 수정했습니다.

## 고민 사항
- 현재 제네릭 메서드를 통해 컴파일러가 타입추론은 가능하게 하지만 결국 `Registry`는 다양한 제네릭 타입을 가지고 있고, 이것이 진정으로 제네릭을 이용한 타입 안정성을 보장할 수 있을 지 의심되는 상황입니다. 
- 다양한 제네릭 타입을 가지는 `HandlerMapping`을 `Registry`에 저장하는데, 런타임에 타입 소거가 일어났을 떄 타입 안정성이 보장될까? instanceOf를 구현하는 메서드를 만들면 되려나
- 생각해보면 instanceOf로는 제네릭 타입의 안정성을 확인하기 어려울 거 같다

## 기타
