### PR TITLE
[김현욱] step-3 GET으로 회원가입

### DIFF
--- a/src/main/java/codesquad/http/exception/Http4XXException.java
+++ b/src/main/java/codesquad/http/exception/Http4XXException.java
@@ -1,0 +1,9 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class Http4XXException extends HttpException{
+    public Http4XXException(HttpStatus status, String errorMessage) {
+        super(status, errorMessage);
+    }
+}

--- a/src/main/java/codesquad/http/exception/Http5XXException.java
+++ b/src/main/java/codesquad/http/exception/Http5XXException.java
@@ -1,0 +1,9 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class Http5XXException extends HttpException {
+    public Http5XXException(HttpStatus status,String errorMessage){
+        super(status, errorMessage);
+    }
+}

--- a/src/main/java/codesquad/http/exception/HttpBadRequestException.java
+++ b/src/main/java/codesquad/http/exception/HttpBadRequestException.java
@@ -1,0 +1,9 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class HttpBadRequestException extends Http4XXException{
+    public HttpBadRequestException( String errorMessage) {
+        super(HttpStatus.BAD_REQUEST, errorMessage);
+    }
+}

--- a/src/main/java/codesquad/http/exception/HttpException.java
+++ b/src/main/java/codesquad/http/exception/HttpException.java
@@ -1,0 +1,20 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class HttpException extends RuntimeException {
+    private final HttpStatus status;
+    private final String errorMessage;
+    public HttpException(HttpStatus status,String errorMessage){
+        this.status = status;
+        this.errorMessage = errorMessage;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/codesquad/http/exception/HttpInternalServerErrorException.java
+++ b/src/main/java/codesquad/http/exception/HttpInternalServerErrorException.java
@@ -1,0 +1,9 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class HttpInternalServerErrorException extends Http5XXException{
+    public HttpInternalServerErrorException(String errorMessage) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage);
+    }
+}

--- a/src/main/java/codesquad/http/exception/HttpNotFoundException.java
+++ b/src/main/java/codesquad/http/exception/HttpNotFoundException.java
@@ -1,0 +1,9 @@
+package codesquad.http.exception;
+
+import codesquad.http.message.response.HttpStatus;
+
+public class HttpNotFoundException extends Http4XXException{
+    public HttpNotFoundException(String errorMessage) {
+        super(HttpStatus.NOT_FOUND, errorMessage);
+    }
+}

--- a/src/main/java/codesquad/http/handler/RequestHandlerMapper.java
+++ b/src/main/java/codesquad/http/handler/RequestHandlerMapper.java
@@ -1,5 +1,7 @@
 package codesquad.http.handler;
 
+import codesquad.http.exception.HttpBadRequestException;
+
 import java.util.Map;
 
 public class RequestHandlerMapper {
@@ -21,7 +23,7 @@ public class RequestHandlerMapper {
                 .filter(entry -> entry.getKey().equals(path))
                 .map(Map.Entry::getValue)
                 .findFirst()
-                .orElseThrow(() -> new IllegalArgumentException(path.concat(" : request can not found")));
+                .orElseThrow(() -> new HttpBadRequestException(path.concat(" : request can not found")));
     }
 
     private boolean isStaticFileRequest(String path) {

--- a/src/main/java/codesquad/http/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/http/handler/StaticResourceHandler.java
@@ -1,5 +1,7 @@
 package codesquad.http.handler;
 
+import codesquad.http.exception.Http4XXException;
+import codesquad.http.exception.HttpNotFoundException;
 import codesquad.http.message.request.HttpRequestMessage;
 import codesquad.http.message.response.HttpResponseMessage;
 import codesquad.http.message.response.HttpStatus;
@@ -15,7 +17,7 @@ public class StaticResourceHandler implements RequestHandler {
             res.setBody(resourceBasePath.readAllBytes());
             res.setStatus(HttpStatus.OK);
         } catch (IOException e) {
-            throw new IllegalArgumentException("could't find this static file");
+            throw new HttpNotFoundException("could't find this static file");
         }
     }
 }

--- a/src/main/java/codesquad/http/message/response/HttpResponseMessage.java
+++ b/src/main/java/codesquad/http/message/response/HttpResponseMessage.java
@@ -1,4 +1,5 @@
 package codesquad.http.message.response;
+import codesquad.http.exception.HttpException;
 import codesquad.http.message.request.HttpMethod;
 import codesquad.http.message.vo.HttpBody;
 import codesquad.http.message.vo.HttpHeader;
@@ -12,7 +13,12 @@ public class HttpResponseMessage {
     private final HttpHeader header;
     private final HttpBody body;
     private final String NEW_LINE = "\r\n";
-
+    public HttpResponseMessage(HttpException httpException){
+        this.startLine = new HttpResponseStartLine("HTTP/1.1",httpException.getStatus());
+        this.header = new HttpHeader();
+        this.body = new HttpBody();
+        setBody(httpException.getErrorMessage());
+    }
     public HttpResponseMessage(HttpResponseStartLine startLine,HttpHeader header,HttpBody body){
         this.startLine = startLine;
         this.header = header;


### PR DESCRIPTION
## 구현 내용
이전 pr : #68 #73 

기존 socket을 처리하는 클래스에서 모두 처리했던 구조를 request, request 와 관련된 parser, response 로 나눈 뒤, 각각의 책임을 분담했습니다.

또한, request 요청이 들어올때마다 해당 요청에 따른 메서드를 추상화하여 handler로 구현했으며, 요청과 핸들러를 매핑시켜주는 RequestHandlerMapper를 구현했습니다.
![image](https://github.com/woowa-techcamp-2024/java-was/assets/43038815/224dad95-668a-4594-b53d-a10b7271febf)
 


handler 에서는 request를 이용하여 필요한 정보를 읽고, response에 header 추가 및 redirect를 쉽게 할 수 있도록 메서드를 추가했습니다.

HttpException을 상속받는 Http4XXException, 5XXException등을 구현하고, 그를 상속하는 디테일한 exception을 구현한 뒤, 소켓 핸들러에서 catch하여 해당 포멧에 맞게 handling하도록 구현.

## 고민 사항
추상화와 책임 분리에 대한 고민이 가장 컸습니다.

exception을 핸들링하여 client socket에게 error에 맞는 response를 전달해주고싶은데, try with resource를 이용하면 catch 부분에서 socket이 닫힙니다. 따라서 2중 try-catch 구문을 사용했는데, 이를 어떻게 최적화 할 지 고민됩니다.
```java
@Override
    public void run() {
        HttpResponseMessage errorResponse = null;
        try (BufferedReader br = new BufferedReader(new InputStreamReader(socket.getInputStream()));) {
            try {
                String requestMessage = readRequestMessage(br);
                Map<String, List<String>> header = new HashMap<>();
                HttpRequestMessage request = requestParser.parse(requestMessage);
                HttpResponseMessage response = new HttpResponseMessage(request.getHttpVersion(), header);

                RequestHandler handler = requestHandlerMapper.getRequestHandler(request.getUri());
                handler.handle(request, response);

                byte[] parse = response.parse(timer);
                socket.getOutputStream().write(parse);
                socket.getOutputStream().flush();
            }catch(HttpException httpException) {
                logger.error(httpException.getMessage());
                errorResponse = new HttpResponseMessage(httpException);
                socket.getOutputStream().write(errorResponse.parse(timer));
                socket.getOutputStream().flush();
            }catch(Exception e){
                logger.error(e.getMessage());
                //internal server error response
                errorResponse = new HttpResponseMessage(new HttpInternalServerErrorException("Internal Server Exception"));
                socket.getOutputStream().write(errorResponse.parse(timer));
                socket.getOutputStream().flush();
            }finally{
                socket.close();
            }
        } catch(Exception e){
            logger.error(e.getMessage());
        } finally{
            if(socket!=null&&!socket.isClosed()){
                try {
                    socket.close();
                } catch (IOException e) {
                    logger.error(e.getMessage());
                }
            }
        }
    }
   ```

## 기타
테스트코드를 수정하고, logging 및 MIME type과 header의 key값에 대한 enum을 추가적으로 구현하여 좀 더 깔끔하게 리팩토링할 예정입니다.