### PR TITLE
[김현우] chore: 서버에서도 배포 가능하게 프로젝트 수정

### DIFF
--- a/.idea/artifacts/java_was_jar.xml
+++ b/.idea/artifacts/java_was_jar.xml
@@ -1,0 +1,18 @@
+<component name="ArtifactManager">
+  <artifact type="jar" name="java-was:jar">
+    <output-path>$PROJECT_DIR$/out/artifacts/java_was_jar</output-path>
+    <root id="archive" name="java-was.jar">
+      <element id="module-output" name="java-was.main" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-api/5.10.0/2fe4ba3d31d5067878e468c96aa039005a9134d3/junit-jupiter-api-5.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.7/41eb7184ea9d556f23e18b5cb99cad1f8581fc00/slf4j-api-2.0.7.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-core/1.4.12/670c77fc6e71cbb24dfabc9fc125f7536ed7a4ab/logback-core-1.4.12.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-engine/1.10.0/276c4edcf64fabb5a139fa7b4f99330d7a93b804/junit-platform-engine-1.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-params/5.10.0/9041c7365495a897a64782ea5a6fdb99dab1814e/junit-jupiter-params-5.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter/5.10.0/8fea1d9c58b2156f1b998f2f18da04bc9e087f74/junit-jupiter-5.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-commons/1.10.0/d533ff2c286eaf963566f92baf5f8a06628d2609/junit-platform-commons-1.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.opentest4j/opentest4j/1.3.0/152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e/opentest4j-1.3.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.10.0/90587932d718fc51a48112d33045a18476c542ad/junit-jupiter-engine-5.10.0.jar" path-in-jar="/" />
+      <element id="extracted-dir" path="$USER_HOME$/.gradle/caches/modules-2/files-2.1/ch.qos.logback/logback-classic/1.4.12/dc5e9d2b4f338034fd04c0e9f93dd5fff108544f/logback-classic-1.4.12.jar" path-in-jar="/" />
+    </root>
+  </artifact>
+</component>

--- a/build.gradle
+++ b/build.gradle
@@ -19,3 +19,14 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+tasks.register('fatJar', Jar) {
+    manifest {
+        attributes(
+                'Main-Class': 'codesquad.Main'
+        )
+    }
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    with jar
+}

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,3 @@
+./gradlew clean fatJar
+chmod +x $(pwd)/build/libs/java-was-1.0-SNAPSHOT.jar
+java -jar $(pwd)/build/libs/java-was-1.0-SNAPSHOT.jar

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: codesquad.Main
+


### PR DESCRIPTION
## 구현 내용

* java 파일을 서버에 배포하기 위한 빌드 설정
* `gradle.build` 수정함으로써 빌드를 하면 바로 jar파일 실행할 수 있음
* 루트디렉토리에서 `script/run.sh`를 실행하면 바로 실행가능한 jar파일 빌드 가능

## 고민 사항

## 기타
