### PR TITLE
[유동근] hotfix - 회원가입 페이지 리다이렉트 실패

### DIFF
--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -19,7 +19,7 @@ public class StaticResourceHandler implements HttpHandler {
     @Override
     public boolean match(HttpRequest request) {
         URL resource = this.getClass().getResource("/static" + request.path);
-        return resource != null;
+        return resource != null && resource.getPath().contains(".");
     }
 
     @Override


### PR DESCRIPTION
## 구현 내용
- /registration 으로 요청시 리다이렉트가 실패하는 오류를 해결하였습니다.
