### PR TITLE
[김민주] step-4 POST로 회원 가입

### DIFF
--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -24,7 +24,7 @@ public class Main {
         RegisterUserLogic registerUserLogic = new RegisterUserLogic();
         ArgumentResolver<RegisterRequest> registerArgumentResolver = new RegisterArgumentResolver();
         ApiRequestHandlerAdapter<RegisterRequest, Void> registerUserHandler = new ApiRequestHandlerAdapter<>(registerArgumentResolver);
-        handlerRegistry.registerHandler(HttpMethod.GET, "/create", registerUserHandler, registerUserLogic);
+        handlerRegistry.registerHandler(HttpMethod.POST, "/users/create", registerUserHandler, registerUserLogic);
 
         // 기본 리소스 핸들러
         ResourceHandlerAdapter<Void, Void> defaultResourceHandler = new ResourceHandlerAdapter<>();

--- a/src/main/java/codesquad/handler/ApiRequestHandlerAdapter.java
+++ b/src/main/java/codesquad/handler/ApiRequestHandlerAdapter.java
@@ -24,7 +24,7 @@ public class ApiRequestHandlerAdapter<T, R> implements HttpHandlerAdapter<T, R> 
         // 결과를 response에 담아서 반환
         response.setStatus(HttpStatus.FOUND);
 
-        response.getHttpHeaders().addHeader("Location", "/login");
+        response.getHttpHeaders().addHeader("Location", "/");
 
         // 이걸 HttpHandler에 default 메서드로 두고 필요한 경우 오버라이드해서 사용하도록 하면 어떨까?
     }

--- a/src/main/java/codesquad/processor/HandlerMapping.java
+++ b/src/main/java/codesquad/processor/HandlerMapping.java
@@ -12,11 +12,11 @@ public class HandlerMapping<T, R> {
     private final HttpHandlerAdapter<T, R> handler;
     private final Triggerable<T, R> triggerable;
 
-    public HandlerMapping(HttpMethod httpMethod, Pattern pattern, HttpHandlerAdapter<T, R> handler, Triggerable<T, R> triggerable) {
-        this.httpMethod = httpMethod;
-        this.pattern = pattern;
-        this.handler = handler;
-        this.triggerable = triggerable;
+    public HandlerMapping(HttpMethod httpMethod, String url, HttpHandlerAdapter<T, R> handler, Triggerable<T, R> triggerable) {
+        this.httpMethod = validateHttpMethod(httpMethod);
+        this.pattern = transformUrlToRegexPattern(url);
+        this.handler = validateHandler(handler);
+        this.triggerable = validateTriggerable(triggerable);
     }
 
     public Triggerable<T, R> getTrigger() {
@@ -35,5 +35,35 @@ public class HandlerMapping<T, R> {
         return handler;
     }
 
+    private HttpMethod validateHttpMethod(HttpMethod httpMethod) {
+        if(httpMethod == null) {
+            throw new IllegalArgumentException("httpMethod이 null입니다.");
+        }
+        return httpMethod;
+    }
+
+    private HttpHandlerAdapter<T, R> validateHandler(HttpHandlerAdapter<T, R> handler) {
+        if(handler == null) {
+            throw new IllegalArgumentException("handler가 null입니다.");
+        }
+        return handler;
+    }
+
+    private Pattern transformUrlToRegexPattern(String url) {
+        if(url == null || url.isEmpty()) {
+            throw new IllegalArgumentException("url이 null이거나 비어있습니다.");
+        }
+
+        // PathVariable의 경우 {변수명}으로 표현되어 있으므로 해당 부분을 정규표현식으로 변경
+        String regexPattern = url.replaceAll("\\{[^/]+\\}", "([^/]+)");
+        return Pattern.compile(regexPattern);
+    }
+
+    private Triggerable<T, R> validateTriggerable(Triggerable<T, R> triggerable) {
+        if(triggerable == null) {
+            throw new IllegalArgumentException("triggerable이 null입니다.");
+        }
+        return triggerable;
+    }
 
 }

--- a/src/main/java/codesquad/processor/HandlerRegistry.java
+++ b/src/main/java/codesquad/processor/HandlerRegistry.java
@@ -6,7 +6,6 @@ import codesquad.http.Path;
 
 import java.util.List;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class HandlerRegistry {
 
@@ -24,9 +23,7 @@ public class HandlerRegistry {
      * @param handler    등록할 핸들러
      */
     public <T, R> void registerHandler(HttpMethod httpMethod, String url, HttpHandlerAdapter<T, R> handler, Triggerable<T, R> triggerable) {
-        // PathVariable의 경우 {변수명}으로 표현되어 있으므로 해당 부분을 정규표현식으로 변경
-        String regexPattern = url.replaceAll("\\{[^/]+\\}", "([^/]+)");
-        handlerMappings.add(new HandlerMapping<>(httpMethod, Pattern.compile(regexPattern), handler, triggerable));
+        handlerMappings.add(new HandlerMapping<>(httpMethod, url, handler, triggerable));
     }
 
     public HandlerMapping<?, ?> getHandler(HttpMethod httpMethod, Path path) {

--- a/src/main/java/codesquad/processor/HttpRequestBuilder.java
+++ b/src/main/java/codesquad/processor/HttpRequestBuilder.java
@@ -6,6 +6,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -36,12 +37,22 @@ public class HttpRequestBuilder {
         char[] body = new char[contentLength];
         br.read(body);
 
+        String bodyString = String.valueOf(body);
+        if(headers.containsKey("Content-Type") && headers.get("Content-Type").equals("application/x-www-form-urlencoded")) {
+            try {
+                bodyString = URLDecoder.decode(bodyString, "UTF-8");
+            }
+            catch (Exception e) {
+                throw new IllegalArgumentException("인코딩 에러가 발생했습니다.");
+            }
+        }
+
         return HttpRequest.builder()
                 .method(method)
                 .path(path)
                 .version(version)
                 .headers(headers)
-                .body(String.valueOf(body))
+                .body(bodyString)
                 .build();
     }
 }

--- a/src/main/java/codesquad/processor/RegisterArgumentResolver.java
+++ b/src/main/java/codesquad/processor/RegisterArgumentResolver.java
@@ -3,6 +3,8 @@ package codesquad.processor;
 import codesquad.http.HttpRequest;
 import codesquad.web.user.RegisterRequest;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -29,16 +31,22 @@ public class RegisterArgumentResolver implements ArgumentResolver<RegisterReques
     }
 
     private Map<String, String> bodyParameters(String bodyString) {
-        return Arrays.stream(bodyString.split("&"))
-                .map(s -> {
-                    String[] split = s.split("=");
-                    String key = split[0];
-                    String value = split.length > 1 ? split[1] : ""; // If no value, use empty string
+        try {
+            String decodedBodyString = URLDecoder.decode(bodyString, "UTF-8");
+            return Arrays.stream(decodedBodyString.split("&"))
+                    .map(s -> {
+                        String[] split = s.split("=");
+                        String key = split[0];
+                        String value = split.length > 1 ? split[1] : ""; // If no value, use empty string
 
-                    return Map.entry(key, value);
-                })
+                        return Map.entry(key, value);
+                    })
 
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("인코딩 에러가 발생했습니다.");
+        }
     }
 
 }

--- a/src/main/java/codesquad/processor/RegisterArgumentResolver.java
+++ b/src/main/java/codesquad/processor/RegisterArgumentResolver.java
@@ -1,29 +1,44 @@
 package codesquad.processor;
 
 import codesquad.http.HttpRequest;
-import codesquad.http.Path;
 import codesquad.web.user.RegisterRequest;
 
+import java.util.Arrays;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class RegisterArgumentResolver implements ArgumentResolver<RegisterRequest> {
 
-        @Override
-        public RegisterRequest resolve(HttpRequest httpRequest) {
+    @Override
+    public RegisterRequest resolve(HttpRequest httpRequest) {
 
-            Path path = httpRequest.getPath();
-            //아직 PathVariable을 처리하는 방법은 생각하지 않았음
-            // 임시로 RegisterRequest를 만들기, TODO 필요에 따라 다양하게 만들 수 있게 수정
-            Map<String, String> queryParameters = path.getQueryParameters();
-            final String email = queryParameters.get("email");
-            final String userId = queryParameters.get("userId");
-            final String password = queryParameters.get("password");
-            final String name = queryParameters.get("name");
+        //아직 PathVariable을 처리하는 방법은 생각하지 않았음
+        // 임시로 RegisterRequest를 만들기, TODO 필요에 따라 다양하게 만들 수 있게 수정
+        Map<String, String> bodyParameters = bodyParameters(httpRequest.getBody());
 
-            if (userId == null || password == null || name == null || email == null) {
-                throw new IllegalArgumentException("필수 파라미터가 누락되었습니다.");
-            }
+        final String email = bodyParameters.get("email");
+        final String userId = bodyParameters.get("userId");
+        final String password = bodyParameters.get("password");
+        final String name = bodyParameters.get("name");
 
-            return new RegisterRequest(email, userId, password, name);
+        if (userId == null || password == null || name == null || email == null) {
+            throw new IllegalArgumentException("필수 파라미터가 누락되었습니다.");
         }
+
+        return new RegisterRequest(email, userId, password, name);
+    }
+
+    private Map<String, String> bodyParameters(String bodyString) {
+        return Arrays.stream(bodyString.split("&"))
+                .map(s -> {
+                    String[] split = s.split("=");
+                    String key = split[0];
+                    String value = split.length > 1 ? split[1] : ""; // If no value, use empty string
+
+                    return Map.entry(key, value);
+                })
+
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
 }

--- a/src/main/java/codesquad/processor/RegisterArgumentResolver.java
+++ b/src/main/java/codesquad/processor/RegisterArgumentResolver.java
@@ -3,8 +3,6 @@ package codesquad.processor;
 import codesquad.http.HttpRequest;
 import codesquad.web.user.RegisterRequest;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -31,22 +29,17 @@ public class RegisterArgumentResolver implements ArgumentResolver<RegisterReques
     }
 
     private Map<String, String> bodyParameters(String bodyString) {
-        try {
-            String decodedBodyString = URLDecoder.decode(bodyString, "UTF-8");
-            return Arrays.stream(decodedBodyString.split("&"))
-                    .map(s -> {
-                        String[] split = s.split("=");
-                        String key = split[0];
-                        String value = split.length > 1 ? split[1] : "";
+        return Arrays.stream(bodyString.split("&"))
+                .map(s -> {
+                    String[] split = s.split("=");
+                    String key = split[0];
+                    String value = split.length > 1 ? split[1] : "";
 
-                        return Map.entry(key, value);
-                    })
+                    return Map.entry(key, value);
+                })
 
-                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        }
-        catch (UnsupportedEncodingException e) {
-            throw new IllegalArgumentException("인코딩 에러가 발생했습니다.");
-        }
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
     }
 
 }

--- a/src/main/java/codesquad/processor/RegisterArgumentResolver.java
+++ b/src/main/java/codesquad/processor/RegisterArgumentResolver.java
@@ -37,7 +37,7 @@ public class RegisterArgumentResolver implements ArgumentResolver<RegisterReques
                     .map(s -> {
                         String[] split = s.split("=");
                         String key = split[0];
-                        String value = split.length > 1 ? split[1] : ""; // If no value, use empty string
+                        String value = split.length > 1 ? split[1] : "";
 
                         return Map.entry(key, value);
                     })

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -22,7 +22,7 @@
   </header>
   <div class="page">
     <h2 class="page-title">회원가입</h2>
-    <form class="form" method="GET" action="/create">
+    <form class="form" method="POST" action="/users/create">
       <div class="textfield textfield_size_s">
         <p class="title_textfield">이메일</p>
         <input

--- a/src/test/java/codesquad/processor/HttpRequestBuilderTest.java
+++ b/src/test/java/codesquad/processor/HttpRequestBuilderTest.java
@@ -1,0 +1,64 @@
+package codesquad.processor;
+
+import codesquad.http.HttpRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HttpRequestBuilderTest {
+
+    @DisplayName("urlencoded된 요청이 오는 경우에는 decode된 body를 HttpRequest에 저장한다.")
+    @Test
+    void urlencoded() throws IOException {
+        // given
+        HttpRequestBuilder httpRequestBuilder = new HttpRequestBuilder();
+        String request = """
+                POST /user/create HTTP/1.1
+                Host: localhost:8080
+                Connection: keep-alive
+                Content-Length: 93
+                Content-Type: application/x-www-form-urlencoded
+                
+                userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net
+                """;
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(request.getBytes());
+
+        // when
+        HttpRequest httpRequest = httpRequestBuilder.parseRequest(byteArrayInputStream);
+
+        // then
+        assertThat(httpRequest.getBody())
+                .isEqualTo("userId=javajigi&password=password&name=박재성&email=javajigi@slipp.net");
+    }
+
+    @DisplayName("urlencoded되어있지 않을 경우 decode하지 않은 body를 HttpRequest에 저장한다.")
+    @Test
+    void urlencode되어있지_않은_경우() throws IOException {
+        // given
+        HttpRequestBuilder httpRequestBuilder = new HttpRequestBuilder();
+        String request = """
+                POST /user/create HTTP/1.1
+                Host: localhost:8080
+                Connection: keep-alive
+                Content-Length: 93
+                Content-Type: application/json
+                
+                userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net
+                """;
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(request.getBytes());
+
+
+        // when
+        HttpRequest httpRequest = httpRequestBuilder.parseRequest(byteArrayInputStream);
+
+        // then
+        assertThat(httpRequest.getBody())
+                .isEqualTo("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net");
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
- registration의 `index.html`을 변경하여 HttpMethod를 POST로, url을 "users/create"로 변경한다.
- HandlerMapping의 Method와 url을 POST와 "users/create"로 변경한다.
- `RegisterArgumentResolver`의 파싱 로직을 Request Parameter가 아니라 Body에서 읽어서 반환하도록 하도록 변경한다.
- redirection location을 "/login"에서 "/"로 변경한다.
- urlencoding된 body String 값을 URLDecoder를 이용하여 decoding하여 사용할 수 있도록 수정한다.
- urlencoded인 경우 body를 decode해서 HttpRequest에 저장하는 것을 확인하는 테스트코드 작성
- URI Mapping 시 사용되는 정규표현식은 `HandlerRegistry`가 아니라 `HandlerMapping`이 가지고 있도록 하여 응집성을 강화하고자 함.

## 고민 사항
- request가 다양한 body stream 타입 (ex, 파일, json, urlencoded)을 가져야할 수도 있는데, 필요시 decoding하는 로직을 매번 추가하는 건 비효율적일 것 같은데, 일단은 요구사항이 간단하니 메서드 내에서 디코딩하고, 어떻게 레이어를 추가하든지 해야할 것 같다.
- 레이어를 추가하기보다도 HttpRequest만들 때 Content-Type을 확인하여 urlencoded면 Body를 저장할 때 decoding한 결과를 저장하는 방식으로 해결했다.

## 기타
