### PR TITLE
[이호석] step-4 POST로 회원 가입

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,12 +5,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestParametersTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/HeaderType.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/HeaderType.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -85,7 +80,7 @@
     "Gradle.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다.executor": "Run",
     "Gradle.Tests in 'codesquad'.executor": "Run",
     "Gradle.Tests in 'codesquad.http'.executor": "Run",
-    "Gradle.Tests in 'java-was.test'.executor": "Coverage",
+    "Gradle.Tests in 'java-was.test'.executor": "Run",
     "Gradle.java-was [:Main.main()].executor": "Run",
     "Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -60,42 +60,43 @@
   <component name="ProjectViewState">
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Gradle.HeadersTest.getHeader_헤더목록에_있는_헤더_값을_찾을_수_있다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.HttpRequestTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.HttpResponse_객체를_생성하면.HttpResponse_메시지를_만들_수_있다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.MessageBodyTest.httpRequest의_요청_바디를_읽을_수_있다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.MessageBodyTest.httpRequest의_요청바디가_비어있다면_바디는_비어있다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.MimeTypeTest.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.MimeTypeTest.알_수_없는_mimeType이라면_octet_stream이_반환된다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.MimeTypeTest.일치하는_확장자의_mimeType이_없으면_예외가_발생한다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.RawTest.test.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.RequestLineTest.httpRequestLine을_받으면_각_메소드를_파싱하여_RequestLine을_생성한다.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.Tests in 'codesquad'.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.Tests in 'codesquad.http'.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.Tests in 'java-was.test'.executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.java-was [:Main.main()].executor&quot;: &quot;Run&quot;,
-    &quot;Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary&quot;: &quot;JUnit5&quot;,
-    &quot;com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5&quot;: &quot;&quot;,
-    &quot;create.test.in.the.same.root&quot;: &quot;true&quot;,
-    &quot;git-widget-placeholder&quot;: &quot;was1-3&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;Project&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;reference.settingsdialog.project.gradle&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Gradle.HeadersTest.getHeader_헤더목록에_있는_헤더_값을_찾을_수_있다.executor": "Run",
+    "Gradle.HttpRequestTest.executor": "Run",
+    "Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다.executor": "Run",
+    "Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다.executor": "Run",
+    "Gradle.HttpResponse_객체를_생성하면.HttpResponse_메시지를_만들_수_있다.executor": "Run",
+    "Gradle.MessageBodyTest.httpRequest의_요청_바디를_읽을_수_있다.executor": "Run",
+    "Gradle.MessageBodyTest.httpRequest의_요청바디가_비어있다면_바디는_비어있다.executor": "Run",
+    "Gradle.MimeTypeTest.executor": "Run",
+    "Gradle.MimeTypeTest.알_수_없는_mimeType이라면_octet_stream이_반환된다.executor": "Run",
+    "Gradle.MimeTypeTest.일치하는_확장자의_mimeType이_없으면_예외가_발생한다.executor": "Run",
+    "Gradle.RawTest.test.executor": "Run",
+    "Gradle.RequestLineTest.httpRequestLine을_받으면_각_메소드를_파싱하여_RequestLine을_생성한다.executor": "Run",
+    "Gradle.Tests in 'codesquad'.executor": "Run",
+    "Gradle.Tests in 'codesquad.http'.executor": "Run",
+    "Gradle.Tests in 'java-was.test'.executor": "Run",
+    "Gradle.java-was [:Main.main()].executor": "Run",
+    "Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
+    "create.test.in.the.same.root": "true",
+    "git-widget-placeholder": "was2-1",
+    "kotlin-language-version-configured": "true",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "Project",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.2",
+    "settings.editor.selected.configurable": "reference.settingsdialog.project.gradle",
+    "vue.rearranger.settings.migration": "true"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="codesquad" />
@@ -148,6 +149,30 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
+    <configuration name="HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.was.http.HttpRequestTest$HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
     <configuration name="HttpRequest가_들어오면.httpRequest_객체를_생성한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -172,7 +197,7 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="HttpResponse_객체를_생성하면.HttpResponse_메시지를_만들_수_있다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+    <configuration name="Tests in 'java-was.test'" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
@@ -184,32 +209,6 @@
         <option name="taskNames">
           <list>
             <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.http.HttpResponseTest$HttpResponse_객체를_생성하면.HttpResponse_메시지를_만들_수_있다&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="잘못된_파일경로를_넘겨주면.예외가_발생한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.http.HttpResponseTest$forward_메소드는$잘못된_파일경로를_넘겨주면.예외가_발생한다&quot;" />
           </list>
         </option>
         <option name="vmOptions" />
@@ -222,11 +221,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다" />
+        <item itemvalue="Gradle.Tests in 'java-was.test'" />
         <item itemvalue="Gradle.HttpRequestTest" />
         <item itemvalue="Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다" />
         <item itemvalue="Application.Main" />
-        <item itemvalue="Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다" />
-        <item itemvalue="Gradle.HttpResponse_객체를_생성하면.HttpResponse_메시지를_만들_수_있다" />
       </list>
     </recent_temporary>
   </component>
@@ -294,6 +293,11 @@
           <url>jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/OutputStream.java</url>
           <line>47</line>
           <option name="timeStamp" value="6" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/test/java/codesquad/was/http/HttpRequestTest.java</url>
+          <line>105</line>
+          <option name="timeStamp" value="7" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -111,7 +111,7 @@
       <recent name="codesquad.http" />
     </key>
   </component>
-  <component name="RunManager" selected="Application.Main">
+  <component name="RunManager" selected="Gradle.Tests in 'java-was.test'">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="codesquad.Main" />
       <module name="java-was.main" />
@@ -221,8 +221,8 @@
     </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다" />
         <item itemvalue="Gradle.Tests in 'java-was.test'" />
+        <item itemvalue="Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다" />
         <item itemvalue="Gradle.HttpRequestTest" />
         <item itemvalue="Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다" />
         <item itemvalue="Application.Main" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,7 +5,12 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestParametersTest.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/README.md" beforeDir="false" afterPath="$PROJECT_DIR$/README.md" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/HeaderType.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/HeaderType.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -41,14 +46,17 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="Enum" />
-        <option value="JUnit5 Test Class" />
         <option value="Interface" />
         <option value="Class" />
+        <option value="JUnit5 Test Class" />
       </list>
     </option>
   </component>
   <component name="Git.Settings">
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="JvmLoggingSettingsStorage">
+    <option name="loggerId" value="Slf4j" />
   </component>
   <component name="ProjectColorInfo">{
   &quot;associatedIndex&quot;: 4
@@ -74,9 +82,10 @@
     "Gradle.MimeTypeTest.일치하는_확장자의_mimeType이_없으면_예외가_발생한다.executor": "Run",
     "Gradle.RawTest.test.executor": "Run",
     "Gradle.RequestLineTest.httpRequestLine을_받으면_각_메소드를_파싱하여_RequestLine을_생성한다.executor": "Run",
+    "Gradle.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다.executor": "Run",
     "Gradle.Tests in 'codesquad'.executor": "Run",
     "Gradle.Tests in 'codesquad.http'.executor": "Run",
-    "Gradle.Tests in 'java-was.test'.executor": "Run",
+    "Gradle.Tests in 'java-was.test'.executor": "Coverage",
     "Gradle.java-was [:Main.main()].executor": "Run",
     "Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다.executor": "Run",
     "RunOnceActivity.ShowReadmeOnStart": "true",
@@ -107,24 +116,13 @@
       <recent name="" />
     </key>
     <key name="CreateTestDialog.RecentsKey">
+      <recent name="codesquad.web" />
+      <recent name="codesquad.was.http" />
       <recent name="codesquad.http.type" />
       <recent name="codesquad.http" />
     </key>
   </component>
   <component name="RunManager" selected="Gradle.Tests in 'java-was.test'">
-    <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
-      <option name="MAIN_CLASS_NAME" value="codesquad.Main" />
-      <module name="java-was.main" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="codesquad.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
-    </configuration>
     <configuration name="HttpRequestTest" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -197,6 +195,30 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
+    <configuration name="SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.web.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
     <configuration name="Tests in 'java-was.test'" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -222,10 +244,10 @@
     <recent_temporary>
       <list>
         <item itemvalue="Gradle.Tests in 'java-was.test'" />
+        <item itemvalue="Gradle.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다" />
         <item itemvalue="Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다" />
         <item itemvalue="Gradle.HttpRequestTest" />
         <item itemvalue="Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다" />
-        <item itemvalue="Application.Main" />
       </list>
     </recent_temporary>
   </component>
@@ -301,5 +323,8 @@
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/java_was$Tests_in__java_was_test_.ic" NAME="Tests in 'java-was.test' Coverage Results" MODIFIED="1720437367689" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 2024 우아한 테크캠프 프로젝트 WAS
 
 - Java
-  - Temurin 17.0.11
-  - Gradle 8.5
+    - Temurin 17.0.11
+    - Gradle 8.5
 - 실행방법
-  - codesquad.Main.main() 실행
+    - codesquad.Main.main() 실행

--- a/src/main/java/codesquad/was/http/HttpRequest.java
+++ b/src/main/java/codesquad/was/http/HttpRequest.java
@@ -2,6 +2,7 @@ package codesquad.was.http;
 
 import codesquad.was.http.type.HeaderType;
 import codesquad.was.http.type.HttpMethod;
+import codesquad.was.http.type.MimeType;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,9 +10,9 @@ import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class HttpRequest {
@@ -40,6 +41,20 @@ public class HttpRequest {
         requestLine = createRequestLine(requestReader.readLine());
         headers = new Headers(requestReader);
         requestBody = new RequestMessageBody(requestReader, headers.getHeader(HeaderType.CONTENT_LENGTH));
+
+        if (isFormData()) {
+            String bodyData = requestBody.getBodyData();
+            requestParameters.putAll(parseQueryParams(bodyData));
+        }
+    }
+
+    private boolean isFormData() {
+        String contentType = headers.getHeader(HeaderType.CONTENT_TYPE);
+
+        if (Objects.isNull(contentType)) {
+            return false;
+        }
+        return contentType.contains(MimeType.APPLICATION_X_WWW_FORM_ENCODED.getValue());
     }
 
     private RequestLine createRequestLine(final String requestLine) throws UnsupportedEncodingException {
@@ -47,7 +62,9 @@ public class HttpRequest {
         HttpMethod method = HttpMethod.find(splitLines[METHOD_INDEX].toUpperCase());
         String[] pathWithQueryString = splitDecodedQueryString(splitLines[URI_INDEX]);
         String requestPath = pathWithQueryString[PATH_INDEX];
-        requestParameters.putAll(parseQueryParams(pathWithQueryString));
+        if (pathWithQueryString.length == 2) {
+            requestParameters.putAll(parseQueryParams(pathWithQueryString[QUERY_STRING_INDEX]));
+        }
         String httpVersion = splitLines[VERSION_INDEX];
 
         return new RequestLine(method, requestPath, httpVersion);
@@ -55,15 +72,12 @@ public class HttpRequest {
 
     private String[] splitDecodedQueryString(final String queryString) throws UnsupportedEncodingException {
         String decodedQueryString = URLDecoder.decode(queryString, "UTF-8");
+
         return decodedQueryString.split("\\?");
     }
 
-    private Map<String, String> parseQueryParams(final String[] pathWithQueryString) {
-        if (pathWithQueryString.length == 1) {
-            return Collections.emptyMap();
-        }
-
-        return Arrays.stream(pathWithQueryString[QUERY_STRING_INDEX].split("&"))
+    private Map<String, String> parseQueryParams(final String queryString) {
+        return Arrays.stream(queryString.split("&"))
                 .map(param -> param.split("="))
                 .filter(params -> params.length == KEY_VALUE_LENGTH)
                 .collect(Collectors.toMap(splitParams -> splitParams[0], splitParams -> splitParams[1]));

--- a/src/main/java/codesquad/was/http/HttpResponse.java
+++ b/src/main/java/codesquad/was/http/HttpResponse.java
@@ -16,7 +16,6 @@ public class HttpResponse {
     private static final String CRLF = "\r\n";
     private static final String ONE_SPACE = " ";
     private static final String DELIMITER = ": ";
-    private static final String HOST_URL = "http://localhost:8080";
 
     private final StatusLine statusLine;
     private final Headers headers = new Headers();
@@ -64,7 +63,7 @@ public class HttpResponse {
 
     public void sendRedirect(final String redirectPath) throws IOException {
         statusLine.setResponseStatus(StatusCodeType.FOUND);
-        headers.add(HeaderType.LOCATION, HOST_URL + redirectPath);
+        headers.add(HeaderType.LOCATION, redirectPath);
         sendResponse(new byte[0]);
     }
 }

--- a/src/main/java/codesquad/was/http/RequestMessageBody.java
+++ b/src/main/java/codesquad/was/http/RequestMessageBody.java
@@ -2,6 +2,7 @@ package codesquad.was.http;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.Objects;
 
 public class RequestMessageBody {
@@ -32,9 +33,7 @@ public class RequestMessageBody {
         if (result == NO_DATA || result == END_STREAM) {
             return EMPTY_DATA;
         }
-
-        return String.valueOf(buffer)
-                .trim();
+        return URLDecoder.decode(String.valueOf(buffer).trim(), "UTF-8");
     }
 
     public String getBodyData() {

--- a/src/main/java/codesquad/was/http/RequestParameters.java
+++ b/src/main/java/codesquad/was/http/RequestParameters.java
@@ -1,5 +1,7 @@
 package codesquad.was.http;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,8 +13,9 @@ public class RequestParameters {
 
     private final Map<String, String> requestParameters = new HashMap<>();
 
-    public void putParameters(final String bodyData) {
-        requestParameters.putAll(parseQueryParams(bodyData));
+    public void putParameters(final String bodyData) throws UnsupportedEncodingException {
+        String decodedBodyData = URLDecoder.decode(bodyData, "UTF-8");
+        requestParameters.putAll(parseQueryParams(decodedBodyData));
     }
 
     private Map<String, String> parseQueryParams(final String queryString) {

--- a/src/main/java/codesquad/was/http/RequestParameters.java
+++ b/src/main/java/codesquad/was/http/RequestParameters.java
@@ -1,0 +1,35 @@
+package codesquad.was.http;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class RequestParameters {
+
+    public static final int KEY_VALUE_LENGTH = 2;
+
+    private final Map<String, String> requestParameters = new HashMap<>();
+
+    public void putParameters(final String bodyData) {
+        requestParameters.putAll(parseQueryParams(bodyData));
+    }
+
+    private Map<String, String> parseQueryParams(final String queryString) {
+        return Arrays.stream(queryString.split("&"))
+                .map(param -> param.split("="))
+                .filter(params -> params.length == KEY_VALUE_LENGTH)
+                .collect(Collectors.toMap(splitParams -> splitParams[0], splitParams -> splitParams[1]));
+    }
+
+    public String get(final String name) {
+        return requestParameters.get(name);
+    }
+
+    @Override
+    public String toString() {
+        return "RequestParameters{" +
+                "requestParameters=" + requestParameters +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/was/http/type/HeaderType.java
+++ b/src/main/java/codesquad/was/http/type/HeaderType.java
@@ -2,7 +2,6 @@ package codesquad.was.http.type;
 
 import java.util.Arrays;
 
-// TODO 표준, 비표준 헤더에 대한 정리 필요, 인덴트라도
 public enum HeaderType {
 
     NONE("none"),

--- a/src/main/java/codesquad/was/http/type/MimeType.java
+++ b/src/main/java/codesquad/was/http/type/MimeType.java
@@ -12,6 +12,7 @@ public enum MimeType {
     PNG(Set.of("png"), "image/png"),
     JPG(Set.of("jpg", "jpeg"), "image/jpeg"),
     SVG(Set.of("svg"), "image/svg+xml"),
+    APPLICATION_X_WWW_FORM_ENCODED(Set.of("application/x-www-form-urlencoded"), "application/x-www-form-urlencoded"),
     APPLICATION_OCTET_STREAM(Set.of("application/octet-stream"), "application/octet-stream");
 
     private final Set<String> extensions;
@@ -28,5 +29,9 @@ public enum MimeType {
                 .map(type -> type.value)
                 .findAny()
                 .orElse(APPLICATION_OCTET_STREAM.value);
+    }
+
+    public String getValue() {
+        return value;
     }
 }

--- a/src/main/java/codesquad/web/HomeForwardHandler.java
+++ b/src/main/java/codesquad/web/HomeForwardHandler.java
@@ -4,7 +4,7 @@ import codesquad.was.http.HttpRequest;
 import codesquad.was.http.HttpResponse;
 import java.io.IOException;
 
-public class HomeForwardController implements RequestHandler {
+public class HomeForwardHandler implements RequestHandler {
 
     @Override
     public void process(final HttpRequest request, final HttpResponse response) throws IOException {

--- a/src/main/java/codesquad/web/RequestHandler.java
+++ b/src/main/java/codesquad/web/RequestHandler.java
@@ -21,7 +21,7 @@ public interface RequestHandler {
     default void handleGet(HttpRequest request, HttpResponse response) throws IOException {
     }
 
-    default void handlePost(HttpRequest request, HttpResponse response) {
+    default void handlePost(HttpRequest request, HttpResponse response) throws IOException {
     }
 
     default void handlePut(HttpRequest request, HttpResponse response) {

--- a/src/main/java/codesquad/web/RequestHandlerMapping.java
+++ b/src/main/java/codesquad/web/RequestHandlerMapping.java
@@ -11,7 +11,7 @@ public class RequestHandlerMapping {
             "static", new StaticResourceForwardHandler(),
             "/", new HomeForwardController(),
             "/registration", new RegistrationForwardHandler(),
-            "/signup", new SignUpRequestHandler(),
+            "/user/create", new SignUpRequestHandler(),
             "/main", new MainForwardHandler()
     );
 

--- a/src/main/java/codesquad/web/RequestHandlerMapping.java
+++ b/src/main/java/codesquad/web/RequestHandlerMapping.java
@@ -9,7 +9,7 @@ public class RequestHandlerMapping {
 
     private static final Map<String, RequestHandler> handlerMappings = Map.of(
             "static", new StaticResourceForwardHandler(),
-            "/", new HomeForwardController(),
+            "/", new HomeForwardHandler(),
             "/registration", new RegistrationForwardHandler(),
             "/user/create", new SignUpRequestHandler(),
             "/main", new MainForwardHandler()

--- a/src/main/java/codesquad/web/SignUpRequestHandler.java
+++ b/src/main/java/codesquad/web/SignUpRequestHandler.java
@@ -12,7 +12,7 @@ public class SignUpRequestHandler implements RequestHandler {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
-    public void handleGet(final HttpRequest request, final HttpResponse response) throws IOException {
+    public void handlePost(final HttpRequest request, final HttpResponse response) throws IOException {
         String userId = request.getParameter("userId");
         String nickname = request.getParameter("nickname");
         String password = request.getParameter("password");

--- a/src/main/java/codesquad/web/SignUpRequestHandler.java
+++ b/src/main/java/codesquad/web/SignUpRequestHandler.java
@@ -12,6 +12,11 @@ public class SignUpRequestHandler implements RequestHandler {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     @Override
+    public void handleGet(final HttpRequest request, final HttpResponse response) throws IOException {
+        throw new IllegalStateException("GET으로 회원가입할 수 없습니다.");
+    }
+
+    @Override
     public void handlePost(final HttpRequest request, final HttpResponse response) throws IOException {
         String userId = request.getParameter("userId");
         String nickname = request.getParameter("nickname");

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/signup">
+        <form class="form" method="post" action="/user/create">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input

--- a/src/test/java/codesquad/was/http/HttpRequestTest.java
+++ b/src/test/java/codesquad/was/http/HttpRequestTest.java
@@ -47,7 +47,7 @@ class HttpRequestTest {
                             + "Content-Type: application/x-www-form-urlencoded\r\n"
                             + "Content-Length: 13\r\n"
                             + "\r\n"
-                            + "name=JohnDoe";
+                            + "body=data";
             InputStream clientInput = new ByteArrayInputStream(httpRequestValue.getBytes("UTF-8"));
 
             // when
@@ -72,7 +72,7 @@ class HttpRequestTest {
                             + "Content-Type: application/x-www-form-urlencoded\r\n"
                             + "Content-Length: 13\r\n"
                             + "\r\n"
-                            + "name=JohnDoe";
+                            + "body=data";
             InputStream clientInput = new ByteArrayInputStream(httpRequestValue.getBytes("UTF-8"));
 
             // when
@@ -82,6 +82,33 @@ class HttpRequestTest {
             assertAll(
                     () -> assertThat(httpRequest.getParameter("userId")).isNull(),
                     () -> assertThat(httpRequest.getParameter("password")).isNull(),
+                    () -> assertThat(httpRequest.getParameter("name")).isEqualTo("박재성"),
+                    () -> assertThat(httpRequest.getParameter("email")).isEqualTo("javajigi@slipp.net")
+            );
+        }
+
+        @Test
+        void Request_Message_Body가_form_data_라면_파싱하여_저장한다() throws IOException {
+            // given
+            String httpRequestValue =
+                    "GET /create HTTP/1.1\r\n"
+                            + "Host: localhost\r\n"
+                            + "Connection: keep-alive\r\n"
+                            + "Content-Type: application/x-www-form-urlencoded\r\n"
+                            + "Content-Length: "
+                            + "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net".length()
+                            + "\r\n"
+                            + "\r\n"
+                            + "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
+            InputStream clientInput = new ByteArrayInputStream(httpRequestValue.getBytes("UTF-8"));
+
+            // when
+            HttpRequest httpRequest = new HttpRequest(clientInput);
+
+            // then
+            assertAll(
+                    () -> assertThat(httpRequest.getParameter("userId")).isEqualTo("javajigi"),
+                    () -> assertThat(httpRequest.getParameter("password")).isEqualTo("password"),
                     () -> assertThat(httpRequest.getParameter("name")).isEqualTo("박재성"),
                     () -> assertThat(httpRequest.getParameter("email")).isEqualTo("javajigi@slipp.net")
             );

--- a/src/test/java/codesquad/was/http/RequestParametersTest.java
+++ b/src/test/java/codesquad/was/http/RequestParametersTest.java
@@ -1,13 +1,28 @@
 package codesquad.was.http;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.io.UnsupportedEncodingException;
 import org.junit.jupiter.api.Test;
 
 class RequestParametersTest {
 
     @Test
-    void Query_String_형식의_파라미터를_저장할_수_있다() {
+    void Query_String_형식의_파라미터를_저장할_수_있다() throws UnsupportedEncodingException {
         // given
-//        String data = ""
-    }
+        RequestParameters requestParameters = new RequestParameters();
+        String data = "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
+        // when
+        requestParameters.putParameters(data);
+
+        // then
+        assertAll(
+                () -> assertThat(requestParameters.get("userId")).isEqualTo("javajigi"),
+                () -> assertThat(requestParameters.get("name")).isEqualTo("박재성"),
+                () -> assertThat(requestParameters.get("password")).isEqualTo("password"),
+                () -> assertThat(requestParameters.get("email")).isEqualTo("javajigi@slipp.net")
+        );
+    }
 }

--- a/src/test/java/codesquad/was/http/RequestParametersTest.java
+++ b/src/test/java/codesquad/was/http/RequestParametersTest.java
@@ -1,0 +1,13 @@
+package codesquad.was.http;
+
+import org.junit.jupiter.api.Test;
+
+class RequestParametersTest {
+
+    @Test
+    void Query_String_형식의_파라미터를_저장할_수_있다() {
+        // given
+//        String data = ""
+    }
+
+}

--- a/src/test/java/codesquad/web/SignUpRequestHandlerTest.java
+++ b/src/test/java/codesquad/web/SignUpRequestHandlerTest.java
@@ -1,0 +1,29 @@
+package codesquad.web;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import codesquad.was.http.Headers;
+import codesquad.was.http.HttpRequest;
+import codesquad.was.http.HttpResponse;
+import codesquad.was.http.RequestLine;
+import codesquad.was.http.RequestMessageBody;
+import codesquad.was.http.type.HttpMethod;
+import java.io.DataOutputStream;
+import org.junit.jupiter.api.Test;
+
+class SignUpRequestHandlerTest {
+
+    @Test
+    void GET으로_회원가입을_시도하면_예외가_발생한다() {
+        // given
+        SignUpRequestHandler signUpRequestHandler = new SignUpRequestHandler();
+
+        // expect
+        assertThatThrownBy(() -> signUpRequestHandler.handleGet(
+                new HttpRequest(new RequestLine(HttpMethod.GET, "/path", "HTTP/1.1"), new Headers(),
+                        new RequestMessageBody("data")),
+                new HttpResponse(new DataOutputStream(System.out), "HTTP/1.1")))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
- POST로 회원가입 하기 위한 준비
  -  Form 형식에서 POST로 전송하도록 변경
- 기존 `Query String`에서 분리하던 값을 형태만 유지해서 `Form Data`도 분리할 수 있도록 변경z
  - 이후 `RequestParameters`라는 별도의 클래스로 `Form Data`, `Query String`을 같이 관리할 수 있도록 분리
  - `Request Context-Type`을 통해 `x-www-form-urlencoded`일때 form data를 파싱하도록 분리 -> 추후 JSON 파싱도 추가할 수 있게 미리 구조 작성~

## 고민 사항
POST로 폼 데이터를 전송하면 Message Request Boby로 데이터가 전송되는데 이때 해당 데이터가 form 데이터인지, JSON 데이터인지 아니면 다른 데이터인지 어떻게 판단할 수 있을까?를 고민했었는데

요청에서 Content-Type을 구분하여 파싱 로직을 분기하도록 진행하려고 합니다!

## 기타
우테캠 7기 화이팅!! 벌써 3주차라니,,
