### PR TITLE
[이경민] step-4 POST로 회원 가입

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" project-jdk-name="liberica-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="liberica-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/src/main/java/codesquad/handler/EndPointHandler.java
+++ b/src/main/java/codesquad/handler/EndPointHandler.java
@@ -6,10 +6,11 @@ public interface EndPointHandler {
 
     static void handleAllHandler() {
         List<EndPointHandler> handlers = List.of(StaticFileEndPointHandler.getInstance(),
-            GetEndPointHandler.getInstance());
+            GetEndPointHandler.getInstance(),
+            PostEndPointHandler.getInstance());
         handlers.forEach(EndPointHandler::provideAll);
     }
-    
+
     void provideAll();
 
 }

--- a/src/main/java/codesquad/handler/GetEndPointHandler.java
+++ b/src/main/java/codesquad/handler/GetEndPointHandler.java
@@ -1,15 +1,8 @@
 package codesquad.handler;
 
-import codesquad.exception.BadRequestException;
 import codesquad.http.enums.HttpMethod;
-import codesquad.http.enums.StatusCode;
-import codesquad.model.User;
 import codesquad.register.EndPoint;
 import codesquad.register.EndPointRegister;
-import codesquad.register.UserRegister;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Function;
 
 public class GetEndPointHandler implements EndPointHandler {
 
@@ -29,7 +22,6 @@ public class GetEndPointHandler implements EndPointHandler {
     public void provideAll() {
         home();
         registration();
-        create();
     }
 
     public void home() {
@@ -46,27 +38,6 @@ public class GetEndPointHandler implements EndPointHandler {
         endPointRegister.addEndpoint(HttpMethod.GET,
             new EndPoint("/registration", staticEndPoint.getFunction(),
                 staticEndPoint.getContentType()));
-    }
-
-    public void create() {
-        EndPoint staticEndPoint = endPointRegister.getEndpoint(HttpMethod.GET,
-            "/index.html");
-        Function<String, byte[]> function = query -> {
-            Map<String, String> queryMap = new HashMap<>();
-            String[] values = query.split("&");
-            for (String value : values) {
-                String[] split = value.split("=");
-                if (split.length != 2) {
-                    throw new BadRequestException("요청 값을 찾을 수 없습니다: " + split[0]);
-                }
-                queryMap.put(split[0], split[1]);
-            }
-            UserRegister.getInstance().save(User.from(queryMap));
-            return staticEndPoint.getFunction().apply(query);
-        };
-        EndPoint endPoint = new EndPoint("/create", function, null, StatusCode.FOUND);
-        endPoint.setRedirectUri("/");
-        endPointRegister.addEndpoint(HttpMethod.GET, endPoint);
     }
 
 }

--- a/src/main/java/codesquad/handler/GetEndPointHandler.java
+++ b/src/main/java/codesquad/handler/GetEndPointHandler.java
@@ -64,7 +64,7 @@ public class GetEndPointHandler implements EndPointHandler {
             UserRegister.getInstance().save(User.from(queryMap));
             return staticEndPoint.getFunction().apply(query);
         };
-        EndPoint endPoint = new EndPoint("/create", function, null, StatusCode.MOVED_PERMANENTLY);
+        EndPoint endPoint = new EndPoint("/create", function, null, StatusCode.FOUND);
         endPoint.setRedirectUri("/");
         endPointRegister.addEndpoint(HttpMethod.GET, endPoint);
     }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -25,20 +25,28 @@ public class HttpRequestHandler {
         try {
             // Parse request to HttpRequest
             HttpRequest request = new HttpRequest(is);
-            // Find endpoint with request
-            EndPoint endPoint = endpointRegister.getEndpoint(request.getHttpMethod(),
-                request.getRequestUri().getPath());
             // Get response from endpoint
-            return new HttpResponse(endPoint, request.getRequestQuery());
+            return generateResponse(request);
         } catch (BadRequestException be) {
             log.error("400: {}", be.getMessage());
             return new HttpResponse(StatusCode.BAD_REQUEST);
         } catch (NotFoundException ne) {
-            log.info("404: {}", ne.getMessage());
+            log.error("404: {}", ne.getMessage());
             return new HttpResponse(StatusCode.NOT_FOUND);
         } catch (Exception e) {
-            log.error(e.getMessage());
+            log.error("500: {}", e.getMessage());
             return new HttpResponse(StatusCode.INTERNAL_SERVER_ERROR);
         }
+    }
+
+    private HttpResponse generateResponse(HttpRequest httpRequest) {
+        // Find endpoint with request
+        EndPoint endPoint = endpointRegister.getEndpoint(httpRequest.getHttpMethod(),
+            httpRequest.getRequestUri().getPath());
+        return switch (httpRequest.getHttpMethod()) {
+            case GET -> new HttpResponse(endPoint, httpRequest.getRequestQuery());
+            case POST -> new HttpResponse(StatusCode.NOT_IMPLEMENTED);
+            default -> new HttpResponse(StatusCode.NOT_IMPLEMENTED);
+        };
     }
 }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -29,13 +29,13 @@ public class HttpRequestHandler {
             return generateResponse(request);
         } catch (BadRequestException be) {
             log.error("400: {}", be.getMessage());
-            return new HttpResponse(StatusCode.BAD_REQUEST);
+            return HttpResponse.from(StatusCode.BAD_REQUEST);
         } catch (NotFoundException ne) {
             log.error("404: {}", ne.getMessage());
-            return new HttpResponse(StatusCode.NOT_FOUND);
+            return HttpResponse.from(StatusCode.NOT_FOUND);
         } catch (Exception e) {
             log.error("500: {}", e.getMessage());
-            return new HttpResponse(StatusCode.INTERNAL_SERVER_ERROR);
+            return HttpResponse.from(StatusCode.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -44,9 +44,9 @@ public class HttpRequestHandler {
         EndPoint endPoint = endpointRegister.getEndpoint(httpRequest.getHttpMethod(),
             httpRequest.getRequestUri().getPath());
         return switch (httpRequest.getHttpMethod()) {
-            case GET -> new HttpResponse(endPoint, httpRequest.getRequestQuery());
-            case POST -> new HttpResponse(endPoint, httpRequest.getBody());
-            default -> new HttpResponse(StatusCode.NOT_IMPLEMENTED);
+            case GET -> HttpResponse.of(endPoint, httpRequest.getRequestQuery());
+            case POST -> HttpResponse.of(endPoint, httpRequest.getBody());
+            default -> HttpResponse.from(StatusCode.NOT_IMPLEMENTED);
         };
     }
 }

--- a/src/main/java/codesquad/handler/HttpRequestHandler.java
+++ b/src/main/java/codesquad/handler/HttpRequestHandler.java
@@ -45,7 +45,7 @@ public class HttpRequestHandler {
             httpRequest.getRequestUri().getPath());
         return switch (httpRequest.getHttpMethod()) {
             case GET -> new HttpResponse(endPoint, httpRequest.getRequestQuery());
-            case POST -> new HttpResponse(StatusCode.NOT_IMPLEMENTED);
+            case POST -> new HttpResponse(endPoint, httpRequest.getBody());
             default -> new HttpResponse(StatusCode.NOT_IMPLEMENTED);
         };
     }

--- a/src/main/java/codesquad/handler/PostEndPointHandler.java
+++ b/src/main/java/codesquad/handler/PostEndPointHandler.java
@@ -1,0 +1,51 @@
+package codesquad.handler;
+
+import codesquad.exception.BadRequestException;
+import codesquad.http.enums.HttpMethod;
+import codesquad.http.enums.StatusCode;
+import codesquad.model.User;
+import codesquad.register.EndPoint;
+import codesquad.register.EndPointRegister;
+import codesquad.register.UserRegister;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public class PostEndPointHandler implements EndPointHandler {
+
+    private static final PostEndPointHandler INSTANCE = new PostEndPointHandler();
+
+    private final EndPointRegister endPointRegister;
+
+    public PostEndPointHandler() {
+        this.endPointRegister = EndPointRegister.getInstance();
+    }
+
+    public static PostEndPointHandler getInstance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void provideAll() {
+        create();
+    }
+
+    void create() {
+        Function<String, byte[]> function = query -> {
+            Map<String, String> queryMap = new HashMap<>();
+            String[] values = query.split("&");
+            for (String value : values) {
+                String[] split = value.split("=");
+                if (split.length != 2) {
+                    throw new BadRequestException("요청 값을 찾을 수 없습니다: " + split[0]);
+                }
+                queryMap.put(split[0], split[1]);
+            }
+            UserRegister.getInstance().save(User.from(queryMap));
+            return new byte[0];
+        };
+        EndPoint endPoint = new EndPoint("/create", function, null, StatusCode.FOUND);
+        endPoint.setRedirectUri("/index.html");
+        endPointRegister.addEndpoint(HttpMethod.POST, endPoint);
+    }
+}

--- a/src/main/java/codesquad/handler/PostEndPointHandler.java
+++ b/src/main/java/codesquad/handler/PostEndPointHandler.java
@@ -41,7 +41,11 @@ public class PostEndPointHandler implements EndPointHandler {
                 }
                 queryMap.put(split[0], split[1]);
             }
-            UserRegister.getInstance().save(User.from(queryMap));
+            try {
+                UserRegister.getInstance().save(User.from(queryMap));
+            } catch (IllegalArgumentException e) {
+                throw new BadRequestException(e.getMessage());
+            }
             return new byte[0];
         };
         EndPoint endPoint = new EndPoint("/create", function, null, StatusCode.FOUND);

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -12,7 +12,6 @@ import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +79,7 @@ public class HttpRequest {
         }
     }
 
-    private void parseBody(BufferedReader br) throws IOException{
+    private void parseBody(BufferedReader br) throws IOException {
         int size = Integer.parseInt(headers.getOrDefault("Content-Length", "0"));
         if (size != 0) {
             char[] buffer = new char[size];

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URI;
+import java.net.URLDecoder;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -79,14 +80,12 @@ public class HttpRequest {
         }
     }
 
-    private void parseBody(BufferedReader br) {
+    private void parseBody(BufferedReader br) throws IOException{
         int size = Integer.parseInt(headers.getOrDefault("Content-Length", "0"));
         if (size != 0) {
-            String value = br.lines().collect(Collectors.joining("\n"));
-            if (value.length() != size) {
-                throw new BadRequestException("Content-Length와 Body의 길이가 일치하지 않습니다.");
-            }
-            this.body = value;
+            char[] buffer = new char[size];
+            br.read(buffer, 0, size);
+            body = URLDecoder.decode(new String(buffer), "UTF-8");
         }
     }
 

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -14,21 +14,25 @@ public class HttpResponse {
     private final Map<String, String> headers = new HashMap<>();
     private final byte[] body;
 
-    public HttpResponse(EndPoint endPoint, String query) {
+    private HttpResponse(EndPoint endPoint, String query) {
         this.statusCode = endPoint.getStatusCode();
         this.body = endPoint.getFunction().apply(query);
         addDefaultHeaders();
         manageHeaders(endPoint);
     }
 
-    public HttpResponse(StatusCode statusCode, byte[] body) {
+    private HttpResponse(StatusCode statusCode) {
         this.statusCode = statusCode;
-        this.body = body;
+        this.body = new byte[0];
         addDefaultHeaders();
     }
 
-    public HttpResponse(StatusCode statusCode) {
-        this(statusCode, new byte[0]);
+    public static HttpResponse from(StatusCode statusCode) {
+        return new HttpResponse(statusCode);
+    }
+
+    public static HttpResponse of(EndPoint endPoint, String query) {
+        return new HttpResponse(endPoint, query);
     }
 
     public void addHeader(String key, String value) {

--- a/src/main/java/codesquad/http/enums/StatusCode.java
+++ b/src/main/java/codesquad/http/enums/StatusCode.java
@@ -2,10 +2,11 @@ package codesquad.http.enums;
 
 public enum StatusCode {
     OK(200, "OK"),
-    MOVED_PERMANENTLY(301, "Moved Permanently"),
+    FOUND(302, "Found"),
     BAD_REQUEST(400, "Bad Request"),
     NOT_FOUND(404, "Not Found"),
-    INTERNAL_SERVER_ERROR(500, "Internal Server Error");
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    NOT_IMPLEMENTED(501, "Not Implemented");
 
     private final int code;
     private final String message;

--- a/src/main/java/codesquad/model/User.java
+++ b/src/main/java/codesquad/model/User.java
@@ -1,5 +1,6 @@
 package codesquad.model;
 
+import codesquad.model.values.Email;
 import java.util.Map;
 
 public class User {
@@ -7,13 +8,13 @@ public class User {
     private final String userId;
     private final String password;
     private final String name;
-    private final String email;
+    private final Email email;
 
     private User(String userId, String password, String name, String email) {
         this.userId = userId;
         this.password = password;
         this.name = name;
-        this.email = email;
+        this.email = Email.from(email);
     }
 
     public static User from(Map<String, String> queryMap) {
@@ -34,7 +35,7 @@ public class User {
     }
 
     public String getEmail() {
-        return email;
+        return email.getValue();
     }
 
     @Override
@@ -43,7 +44,7 @@ public class User {
             "userId='" + userId + '\'' +
             ", password='" + password + '\'' +
             ", name='" + name + '\'' +
-            ", email='" + email + '\'' +
+            ", email='" + email.getValue() + '\'' +
             '}';
     }
 }

--- a/src/main/java/codesquad/model/values/Email.java
+++ b/src/main/java/codesquad/model/values/Email.java
@@ -1,0 +1,26 @@
+package codesquad.model.values;
+
+import java.util.regex.Pattern;
+
+public class Email {
+
+    private static final Pattern PATTERN = Pattern.compile(
+        "[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?");
+
+    private final String value;
+
+    private Email(String value) {
+        if (!PATTERN.matcher(value).matches()) {
+            throw new IllegalArgumentException("이메일 형식이 올바르지 않습니다.");
+        }
+        this.value = value;
+    }
+
+    public static Email from(String value) {
+        return new Email(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/codesquad/register/UserRegister.java
+++ b/src/main/java/codesquad/register/UserRegister.java
@@ -21,6 +21,9 @@ public class UserRegister {
     }
 
     public User save(User user) {
+        if (userRepository.containsKey(user.getUserId())) {
+            throw new IllegalArgumentException("이미 존재하는 사용자입니다.");
+        }
         log.debug("User: {}", user);
         userRepository.put(user.getUserId(), user);
         return user;

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
   </header>
   <div class="page">
     <h2 class="page-title">회원가입</h2>
-    <form class="form" action="/create">
+    <form class="form" action="/create" method="post">
       <div class="textfield textfield_size_s">
         <p class="title_textfield">아이디</p>
         <input

--- a/src/test/java/codesquad/handler/GetEndPointHandlerTest.java
+++ b/src/test/java/codesquad/handler/GetEndPointHandlerTest.java
@@ -1,0 +1,28 @@
+package codesquad.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import codesquad.http.enums.HttpMethod;
+import codesquad.register.EndPointRegister;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GetEndPointHandlerTest {
+
+    @Test
+    @DisplayName("지정한 GET Endpoint들을 저장한다.")
+    void provideAll() {
+        // Arrange
+        EndPointRegister register = EndPointRegister.getInstance();
+        StaticFileEndPointHandler.getInstance().provideAll();
+        // Act
+        GetEndPointHandler.getInstance().provideAll();
+        // Assert
+        assertAll(
+            () -> assertThat(register.getEndpoint(HttpMethod.GET, "/")).isNotNull(),
+            () -> assertThat(register.getEndpoint(HttpMethod.GET, "/registration")).isNotNull()
+        );
+
+    }
+}

--- a/src/test/java/codesquad/handler/PostEndPointHandlerTest.java
+++ b/src/test/java/codesquad/handler/PostEndPointHandlerTest.java
@@ -1,0 +1,23 @@
+package codesquad.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import codesquad.http.enums.HttpMethod;
+import codesquad.register.EndPointRegister;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostEndPointHandlerTest {
+
+    @Test
+    @DisplayName("지정한 POST EndPoint를 저장한다.")
+    void provideAll() {
+        // Arrange
+        EndPointRegister register = EndPointRegister.getInstance();
+        // Act
+        PostEndPointHandler.getInstance().provideAll();
+        // Assert
+        assertThat(register.getEndpoint(HttpMethod.POST, "/create")).isNotNull();
+    }
+
+}

--- a/src/test/java/codesquad/http/HttpRequestTest.java
+++ b/src/test/java/codesquad/http/HttpRequestTest.java
@@ -98,22 +98,4 @@ class HttpRequestTest {
             .hasMessage("요청 라인이 올바르지 않습니다.");
     }
 
-    @Test
-    @DisplayName("Content-Length와 Body의 길이가 일치하지 않을 시 예외를 던진다.")
-    void createWhenContentLengthAndBodyLengthMismatch() {
-        // Arrange
-        var expectedInputStream = new ByteArrayInputStream("""
-            GET /index.html HTTP/1.1
-            Host: localhost:8080
-            Content-Length: 10
-                        
-            hello?
-            """.getBytes());
-
-        // Act & Assert
-        assertThatThrownBy(() -> new HttpRequest(expectedInputStream))
-            .isInstanceOf(BadRequestException.class)
-            .hasMessage("Content-Length와 Body의 길이가 일치하지 않습니다.");
-    }
-
 }

--- a/src/test/java/codesquad/http/HttpResponseTest.java
+++ b/src/test/java/codesquad/http/HttpResponseTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import codesquad.http.enums.StatusCode;
+import codesquad.register.EndPoint;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -15,13 +16,13 @@ class HttpResponseTest {
     void createHttpResponse() {
         // Arrange
         var statusCode = StatusCode.OK;
-        var body = new byte[0];
         // Act
-        var actualResult = new HttpResponse(statusCode, body);
+        var actualResult = HttpResponse.from(statusCode);
         // Assert
         assertAll(
             () -> assertNotNull(actualResult),
-            () -> assertThat(actualResult).isInstanceOf(HttpResponse.class)
+            () -> assertThat(actualResult).isInstanceOf(HttpResponse.class),
+            () -> assertThat(actualResult).extracting("statusCode").isEqualTo(statusCode)
         );
     }
 
@@ -29,9 +30,10 @@ class HttpResponseTest {
     @DisplayName("HttpResponse 객체를 생성한다.")
     void createHttpResponseWithoutBody() {
         // Arrange
-        var statusCode = StatusCode.OK;
+        var endPoint = new EndPoint("/index.html", query -> new byte[0]);
+        String query = null;
         // Act
-        var actualResult = new HttpResponse(statusCode);
+        var actualResult = HttpResponse.of(endPoint, query);
         // Assert
         assertAll(
             () -> assertNotNull(actualResult),
@@ -44,8 +46,7 @@ class HttpResponseTest {
     void addHeader() {
         // Arrange
         var statusCode = StatusCode.OK;
-        var body = new byte[0];
-        var httpResponse = new HttpResponse(statusCode, body);
+        var httpResponse = HttpResponse.from(statusCode);
         // Act
         httpResponse.addHeader("Content-Type", "text/html");
         // Assert
@@ -58,8 +59,7 @@ class HttpResponseTest {
     void convertToResponseBytes() {
         // Arrange
         var statusCode = StatusCode.OK;
-        var body = new byte[0];
-        var httpResponse = new HttpResponse(statusCode, body);
+        var httpResponse = HttpResponse.from(statusCode);
         // Act
         var actualResult = httpResponse.toResponseBytes();
         // Assert

--- a/src/test/java/codesquad/model/values/EmailTest.java
+++ b/src/test/java/codesquad/model/values/EmailTest.java
@@ -1,0 +1,43 @@
+package codesquad.model.values;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class EmailTest {
+
+    @Test
+    @DisplayName("이메일 형식이 올바르지 않은 경우 예외를 던진다.")
+    void createFail() {
+        // Arrange
+        String invalidEmail = "codesquad";
+        // Act & Assert
+        assertThatThrownBy(() -> Email.from(invalidEmail))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("이메일 형식이 올바르지 않습니다.");
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    @DisplayName("이메일 형식이 올바른 경우 Email 인스턴스를 생성한다.")
+    void create(String email) {
+        // Act
+        Email actualResult = Email.from(email);
+        // Assert
+        assertThat(email).isEqualTo(actualResult.getValue());
+    }
+
+    private static Stream<Arguments> create() {
+        return Stream.of(
+            Arguments.of("a@naver.com"),
+            Arguments.of("b@gmail.com"),
+            Arguments.of("hello@daum.net"));
+    }
+
+}

--- a/src/test/java/codesquad/register/EndPointTest.java
+++ b/src/test/java/codesquad/register/EndPointTest.java
@@ -48,7 +48,7 @@ class EndPointTest {
         Function<String, byte[]> expectedFunction = query -> new byte[0];
         String expectedRedirectUri = "/";
         EndPoint expectedEndPoint = new EndPoint(expectedPath, expectedFunction, null,
-            StatusCode.MOVED_PERMANENTLY);
+            StatusCode.FOUND);
         // Act
         expectedEndPoint.setRedirectUri(expectedRedirectUri);
         // Assert

--- a/src/test/java/codesquad/register/UserRegisterTest.java
+++ b/src/test/java/codesquad/register/UserRegisterTest.java
@@ -1,6 +1,7 @@
 package codesquad.register;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import codesquad.model.User;
@@ -20,7 +21,7 @@ class UserRegisterTest {
             "userId", "hello",
             "password", "password",
             "name", "hi",
-            "email", "hi@hi"
+            "email", "hello@gmail.com"
         );
         var exceptedUser = User.from(expectedQueryMap);
         // Act
@@ -32,5 +33,23 @@ class UserRegisterTest {
             () -> assertThat(actualResult.getName()).isEqualTo(exceptedUser.getName()),
             () -> assertThat(actualResult.getEmail()).isEqualTo(exceptedUser.getEmail())
         );
+    }
+
+    @Test
+    @DisplayName("UserRegister에 중복된 User를 저장하면 예외를 던진다.")
+    void saveFail() {
+        // Arrange
+        var queryMap = Map.of(
+            "userId", "hello2",
+            "password", "password",
+            "name", "hi",
+            "email", "hello@gmail.com");
+        var user = User.from(queryMap);
+        userRegister.save(user);
+        // Act & Assert
+        assertThatThrownBy(() -> userRegister.save(user))
+            .isInstanceOf(IllegalArgumentException.class)
+            .hasMessage("이미 존재하는 사용자입니다.");
+
     }
 }


### PR DESCRIPTION
## 구현 내용

- `POST`로 회원가입을 진행하도록 로직을 변경했습니다.
  - `PostEndPointHandler` 를 구현해 Post 요청에 대한 핸들링이 가능하도록 했습니다.
  - 기존 `GetEndPointHandler`에 존재하던 회원가입 로직을 삭제했습니다.

- HTTP 요청에 대해 Body를 파싱하는 방법을 변경했습니다
  - `Content-Length`에 맞게 데이터를 파싱하도록 변경했습니다.

- `User` 생성 과정에서 `Email` 검증과 중복 유저 검증을 진행하도록 로직을 추가했습니다.

- 구현 및 리팩토링에 따른 테스트를 추가 및 수정했습니다. 

## 고민 사항

- 추후 Request Body에 대한 JSON, XML 파싱을 어떻게 구현할지 고민하고 있습니다!

## 기타
