### PR TITLE
[박혜성] step-4 POST로 회원 가입

### DIFF
--- a/src/main/java/codesquad/ClientRequest.java
+++ b/src/main/java/codesquad/ClientRequest.java
@@ -3,8 +3,11 @@ package codesquad;
 import codesquad.handler.Handler;
 import codesquad.handler.HandlerMapper;
 import codesquad.handler.ModelAndView;
+import codesquad.message.HttpBody;
+import codesquad.message.HttpHeaders;
 import codesquad.message.HttpRequest;
 import codesquad.message.HttpResponse;
+import codesquad.message.HttpStartLine;
 import codesquad.message.HttpStatusCode;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,6 +15,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,23 +34,26 @@ public class ClientRequest implements Runnable {
 
     @Override
     public void run() {
-        try (OutputStream clientOutput = clientSocket.getOutputStream()) {
-            process(clientOutput);
+        try (
+                InputStream inputStream = clientSocket.getInputStream();
+                OutputStream clientOutput = clientSocket.getOutputStream()
+        ) {
+            process(inputStream, clientOutput);
         } catch (IOException e) {
             log.error("입출력 예외가 발생했습니다.", e);
         }
     }
 
-    private void process(OutputStream clientOutput) throws IOException {
+    private void process(InputStream inputStream, OutputStream clientOutput) throws IOException {
         try {
             log.debug("Client connected");
 
             // HTTP 요청을 파싱합니다.
-            HttpRequest requestMessage = getHttpRequest();
+            HttpRequest requestMessage = getHttpRequest(inputStream);
             log.debug("Http request message={}", requestMessage);
 
             // 요청을 처리할 핸들러를 조회합니다.
-            Handler handler = HandlerMapper.mapping(requestMessage.requestUrl());
+            Handler handler = HandlerMapper.mapping(requestMessage);
             ModelAndView modelAndView = handler.handle(requestMessage);
 
             // HTTP 응답을 생성합니다.
@@ -64,20 +72,31 @@ public class ClientRequest implements Runnable {
         }
     }
 
-    private HttpRequest getHttpRequest() throws IOException {
-        InputStream clientInput = clientSocket.getInputStream();
-        String rawHttpRequestMessage = readHttpRequestMessage(clientInput);
-        return HttpRequest.parse(rawHttpRequestMessage);
+    private HttpRequest getHttpRequest(InputStream inputStream) throws IOException {
+        return readHttpRequestMessage(inputStream);
     }
 
-    private String readHttpRequestMessage(InputStream clientInput) throws IOException {
+    private HttpRequest readHttpRequestMessage(InputStream clientInput) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(clientInput));
-        StringBuilder sb = new StringBuilder();
-        String readLine;
-        while (!(readLine = br.readLine()).isEmpty()) {
-            sb.append(readLine).append("\n");
+        HttpStartLine httpStartLine = HttpStartLine.parse(br.readLine());
+        Map<String, String> headers = new HashMap<>();
+        String header;
+        while (!(header = br.readLine()).isEmpty()) {
+            String[] keyValue = header.split(": ");
+            headers.put(keyValue[0], keyValue[1]);
         }
-        return sb.toString();
+        HttpHeaders httpHeaders = new HttpHeaders(headers);
+        HttpBody httpBody = new HttpBody(new HashMap<>());
+        String contentType = headers.get("Content-Type");
+        if(contentType != null && contentType.equals("application/x-www-form-urlencoded")) {
+            int contentLength = Integer.parseInt(headers.get("Content-Length"));
+            char[] buffer = new char[contentLength];
+            br.read(buffer);
+            String body = new String(buffer);
+            httpBody = HttpBody.parse(body);
+            log.debug("바디= {}", body);
+        }
+        return new HttpRequest(httpStartLine, httpHeaders, httpBody);
     }
 
     private String getContentType(String requestUrl) {

--- a/src/main/java/codesquad/ClientRequest.java
+++ b/src/main/java/codesquad/ClientRequest.java
@@ -92,7 +92,7 @@ public class ClientRequest implements Runnable {
     private void writeHttpResponse(OutputStream clientOutput, HttpResponse httpResponse) throws IOException {
         clientOutput.write(httpResponse.getHttpMessageStartLine());
         clientOutput.write(httpResponse.getHttpMessageHeaders());
-        clientOutput.write("\r\n".getBytes());
+        clientOutput.write("\n".getBytes());
         clientOutput.write(httpResponse.getHttpMessageBody());
     }
 

--- a/src/main/java/codesquad/ContentTypes.java
+++ b/src/main/java/codesquad/ContentTypes.java
@@ -14,7 +14,7 @@ public final class ContentTypes {
         MIME_TYPES.put("js", "text/javascript");
         MIME_TYPES.put("jpg", "image/jpeg");
         MIME_TYPES.put("png", "image/png");
-        MIME_TYPES.put("ico", "image/vnd.microsoft.icon");
+        MIME_TYPES.put("ico", "image/x-icon");
         MIME_TYPES.put("svg", "image/svg+xml");
     }
 

--- a/src/main/java/codesquad/handler/CreateUserHandler.java
+++ b/src/main/java/codesquad/handler/CreateUserHandler.java
@@ -1,6 +1,7 @@
 package codesquad.handler;
 
 import codesquad.message.HttpRequest;
+import codesquad.message.HttpStatusCode;
 import codesquad.model.User;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -19,7 +20,8 @@ public class CreateUserHandler implements Handler {
         User user = User.create(data.userId, data.password, data.name, data.password);
         log.debug("새로운 유저가 생성되었습니다. userId={}", user.getUserId());
 
-        ModelAndView modelAndView = new ModelAndView();
+        ModelAndView modelAndView = new ModelAndView(HttpStatusCode.FOUND);
+        modelAndView.addHeader("Location", "/");
         modelAndView.add("userId", user.getUserId());
         return modelAndView;
     }

--- a/src/main/java/codesquad/handler/CreateUserHandler.java
+++ b/src/main/java/codesquad/handler/CreateUserHandler.java
@@ -27,7 +27,7 @@ public class CreateUserHandler implements Handler {
     }
 
     private Data queriesToData(HttpRequest httpRequest) {
-        Map<String, String> queries = httpRequest.queries();
+        Map<String, String> queries = httpRequest.bodyData();
         String userId = queries.get("userId");
         String password = queries.get("password");
         String name = queries.get("name");

--- a/src/main/java/codesquad/handler/HandlerMapper.java
+++ b/src/main/java/codesquad/handler/HandlerMapper.java
@@ -1,19 +1,28 @@
 package codesquad.handler;
 
+import codesquad.message.HttpRequest;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 
 public final class HandlerMapper {
 
     private static final Map<String, Handler> HANDLERS = new HashMap<>();
+    private static final Map<String, Handler> POST_HANDLERS = new HashMap<>();
 
     static {
-        HANDLERS.put("/user/create", new CreateUserHandler());
+        POST_HANDLERS.put("/user/create", new CreateUserHandler());
     }
 
-    public static Handler mapping(String url) {
-        return Optional.ofNullable(HANDLERS.get(url))
-                .orElse(new StaticResourceHandler());
+    public static Handler mapping(HttpRequest httpRequest) {
+        if(httpRequest.method().equals("GET")) {
+            return Optional.ofNullable(HANDLERS.get(httpRequest.requestUrl()))
+                    .orElse(new StaticResourceHandler());
+        } else {
+            return Optional.ofNullable(POST_HANDLERS.get(httpRequest.requestUrl()))
+                    .orElseThrow(
+                            () -> new NoSuchElementException("리소스가 존재하지 않습니다. requestUrl=" + httpRequest.requestUrl()));
+        }
     }
 }

--- a/src/main/java/codesquad/handler/ModelAndView.java
+++ b/src/main/java/codesquad/handler/ModelAndView.java
@@ -19,6 +19,10 @@ public class ModelAndView {
         this(view, HttpStatusCode.OK);
     }
 
+    public ModelAndView(HttpStatusCode statusCode) {
+        this(new byte[]{}, statusCode);
+    }
+
     public ModelAndView(byte[] view, HttpStatusCode statusCode) {
         this.view = view;
         this.statusCode = statusCode;

--- a/src/main/java/codesquad/handler/ModelAndView.java
+++ b/src/main/java/codesquad/handler/ModelAndView.java
@@ -8,18 +8,18 @@ public class ModelAndView {
 
     private final Map<String, String> headers = new HashMap<>();
     private final Map<String, String> model = new HashMap<>();
-    private final String view;
+    private final byte[] view;
     private final HttpStatusCode statusCode;
 
     public ModelAndView() {
-        this("");
+        this(new byte[]{});
     }
 
-    public ModelAndView(String view) {
+    public ModelAndView(byte[] view) {
         this(view, HttpStatusCode.OK);
     }
 
-    public ModelAndView(String view, HttpStatusCode statusCode) {
+    public ModelAndView(byte[] view, HttpStatusCode statusCode) {
         this.view = view;
         this.statusCode = statusCode;
     }
@@ -32,7 +32,7 @@ public class ModelAndView {
         return model.get(key);
     }
 
-    public String getView() {
+    public byte[] getView() {
         return view;
     }
 
@@ -42,5 +42,9 @@ public class ModelAndView {
 
     public Map<String, String> getHeaders() {
         return headers;
+    }
+
+    public void addHeader(String key, String value) {
+        headers.put(key, value);
     }
 }

--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -12,8 +12,10 @@ public class StaticResourceHandler implements Handler {
     @Override
     public ModelAndView handle(HttpRequest httpRequest) {
         String viewPath = addIndexPath(httpRequest.requestUrl());
-        String view = getStaticFile(viewPath);
-        return new ModelAndView(view);
+        byte[] view = getStaticFile(viewPath);
+        ModelAndView modelAndView = new ModelAndView(view);
+        modelAndView.addHeader("Content-Length", String.valueOf(view.length));
+        return modelAndView;
     }
 
     private String addIndexPath(String requestUrl) {
@@ -26,10 +28,10 @@ public class StaticResourceHandler implements Handler {
         return requestUrl + "/index.html";
     }
 
-    private String getStaticFile(String resourcePath) {
+    private byte[] getStaticFile(String resourcePath) {
         try {
             InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream("static" + resourcePath);
-            return new String(resourceAsStream.readAllBytes());
+            return resourceAsStream.readAllBytes();
         } catch (NullPointerException e) {
             throw new IllegalArgumentException("유효하지 않은 경로입니다. path=" + resourcePath);
         } catch (IOException e) {

--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -3,6 +3,7 @@ package codesquad.handler;
 import codesquad.message.HttpRequest;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.NoSuchElementException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class StaticResourceHandler implements Handler {
             InputStream resourceAsStream = getClass().getClassLoader().getResourceAsStream("static" + resourcePath);
             return resourceAsStream.readAllBytes();
         } catch (NullPointerException e) {
-            throw new IllegalArgumentException("유효하지 않은 경로입니다. path=" + resourcePath);
+            throw new NoSuchElementException("유효하지 않은 경로입니다. path=" + resourcePath);
         } catch (IOException e) {
             throw new RuntimeException("입출력 예외가 발생했습니다.", e);
         }

--- a/src/main/java/codesquad/message/HttpBody.java
+++ b/src/main/java/codesquad/message/HttpBody.java
@@ -1,0 +1,17 @@
+package codesquad.message;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public record HttpBody(Map<String, String> data) {
+
+    public static HttpBody parse(String rawMessageBody) {
+        Map<String, String> bodies = new HashMap<>();
+        String[] splitBody = rawMessageBody.split("&");
+        for (String rawKeyValue : splitBody) {
+            String[] keyValue = rawKeyValue.split("=");
+            bodies.put(keyValue[0], keyValue[1]);
+        }
+        return new HttpBody(bodies);
+    }
+}

--- a/src/main/java/codesquad/message/HttpHeaders.java
+++ b/src/main/java/codesquad/message/HttpHeaders.java
@@ -1,0 +1,42 @@
+package codesquad.message;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public record HttpHeaders(Map<String, String> headers) {
+
+    private static final String LINE_SEPARATOR = "\n";
+
+    public static HttpHeaders parse(String rawHeaders) {
+        Map<String, String> headers = new HashMap<>();
+        String[] splitHeaders = rawHeaders.split(LINE_SEPARATOR);
+        for (String header : splitHeaders) {
+            String[] keyValue = header.split(": ");
+            validateHeader(keyValue);
+            headers.put(keyValue[0], keyValue[1]);
+        }
+        return new HttpHeaders(headers);
+    }
+
+    private static void validateHeader(String[] keyValue) {
+        if(checkKeyValue(keyValue)) {
+            return;
+        }
+        throw new IllegalArgumentException("헤더 형식이 올바르지 않습니다. header=" + Arrays.toString(keyValue));
+    }
+
+    private static boolean checkKeyValue(String[] keyValue) {
+        if(keyValue.length != 2) {
+            return false;
+        }
+        if(keyValue[0].isBlank() || keyValue[1].isBlank()) {
+            return false;
+        }
+        return true;
+    }
+
+    public String get(String key) {
+        return headers.get(key);
+    }
+}

--- a/src/main/java/codesquad/message/HttpRequest.java
+++ b/src/main/java/codesquad/message/HttpRequest.java
@@ -1,13 +1,18 @@
 package codesquad.message;
 
+import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public record HttpRequest(
         HttpStartLine httpStartLine,
         HttpHeaders httpHeaders,
-        String body) {
+        HttpBody httpBody) {
 
     private static final String LINE_SEPARATOR = "\n";
+    private static final Logger log = LoggerFactory.getLogger(HttpRequest.class);
+
 
     public static HttpRequest parse(String rawHttpMessage) {
         String[] headAndBody = rawHttpMessage.split(LINE_SEPARATOR + LINE_SEPARATOR);
@@ -21,11 +26,12 @@ public record HttpRequest(
         HttpHeaders httpHeaders = HttpHeaders.parse(rawHttpHeaders);
 
         if(headAndBody.length >= 2) {
-            String httpBody = headAndBody[1];
-
+            String rawHttpBody = headAndBody[1];
+            HttpBody httpBody = HttpBody.parse(rawHttpBody);
+            return new HttpRequest(httpStartLine, httpHeaders, httpBody);
         }
 
-        return new HttpRequest(httpStartLine, httpHeaders, "");
+        return new HttpRequest(httpStartLine, httpHeaders, new HttpBody(new HashMap<>()));
     }
 
     public String method() {
@@ -46,5 +52,9 @@ public record HttpRequest(
 
     public Map<String, String> queries() {
         return httpStartLine.queries();
+    }
+
+    public Map<String, String> bodyData() {
+        return httpBody.data();
     }
 }

--- a/src/main/java/codesquad/message/HttpResponse.java
+++ b/src/main/java/codesquad/message/HttpResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public final class HttpResponse {
 
-    public static final String CRLF = "\r\n";
+    public static final String CRLF = "\n";
 
     private final String version;
     private final HttpStatusCode statusCode;

--- a/src/main/java/codesquad/message/HttpResponse.java
+++ b/src/main/java/codesquad/message/HttpResponse.java
@@ -4,32 +4,52 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class HttpResponse {
+
+    public static final String CRLF = "\r\n";
+
     private final String version;
     private final HttpStatusCode statusCode;
     private final Map<String, String> headers = new HashMap<>();
-    private final String body;
+    private final byte[] body;
 
     public HttpResponse(
             String version,
             HttpStatusCode statusCode,
-            String body) {
+            byte[] body) {
         this.version = version;
         this.statusCode = statusCode;
         this.body = body;
     }
 
-    public String toHttpMessage() {
+    public HttpResponse(
+            String version,
+            HttpStatusCode statusCode,
+            String body) {
+        this(version, statusCode, body.getBytes());
+    }
+
+    public byte[] getHttpMessageStartLine() {
+        String sb = version + " " + statusCode.getStatusCode() + " " + statusCode.getStatusText() + CRLF;
+        return sb.getBytes();
+    }
+
+    public byte[] getHttpMessageHeaders() {
         StringBuilder sb = new StringBuilder();
-        sb.append(version).append(" ")
-                .append(statusCode.getStatusCode()).append(" ")
-                .append(statusCode.getStatusText()).append("\n");
-        headers.forEach((key, value) -> sb.append(key).append(": ").append(value).append("\n"));
-        sb.append("\n");
-        sb.append(body);
-        return sb.toString();
+        headers.forEach((key, value) -> {
+            sb.append(key).append(": ").append(value).append(CRLF);
+        });
+        return sb.toString().getBytes();
+    }
+
+    public byte[] getHttpMessageBody() {
+        return body;
     }
 
     public void addHeader(String key, String contentType) {
         headers.put(key, contentType);
+    }
+
+    public void addHeaders(Map<String, String> headers) {
+        this.headers.putAll(headers);
     }
 }

--- a/src/main/java/codesquad/message/HttpStartLine.java
+++ b/src/main/java/codesquad/message/HttpStartLine.java
@@ -1,0 +1,62 @@
+package codesquad.message;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public record HttpStartLine(String method, String path, Map<String, String> queries, String version) {
+
+    public static HttpStartLine parse(String rawStartLine) {
+        String[] splitLine = rawStartLine.split(" ");
+        checkFormat(splitLine);
+
+        String method = splitLine[0];
+        String pathWithQueries = splitLine[1];
+        String version = splitLine[2];
+
+        URI uri = URI.create(pathWithQueries);
+        String path = uri.getPath();
+        String queryString = uri.getQuery();
+        Map<String, String> queries = parseQueries(queryString);
+        return new HttpStartLine(method, path, queries, version);
+    }
+
+    private static void checkFormat(String[] splitLine) {
+        if(splitLine.length == 3) {
+            return;
+        }
+        throw new IllegalArgumentException("HTTP 요청 개행 형식에 맞지 않습니다. startLine=" + Arrays.toString(splitLine));
+    }
+
+    private static Map<String, String> parseQueries(String queryString) {
+        Map<String, String> queries = new HashMap<>();
+        if(queryString == null || queryString.isBlank()) {
+            return queries;
+        }
+        String[] splitQueries = queryString.split("&");
+        for (String query : splitQueries) {
+            String[] keyValue = query.split("=");
+            checkQuery(keyValue);
+            queries.put(decode(keyValue[0]), decode(keyValue[1]));
+        }
+        return queries;
+    }
+
+    private static void checkQuery(String[] keyValue) {
+        if(keyValue.length == 2) {
+            return;
+        }
+        throw new IllegalArgumentException("쿼리 파라미터가 형식에 맞지 안습니다. keyValue=" + Arrays.toString(keyValue));
+    }
+
+    private static String decode(String rawValue) {
+        try {
+            return URLDecoder.decode(rawValue, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            throw new IllegalArgumentException("문자 인코딩 타입이 잘못되었습니다.");
+        }
+    }
+}

--- a/src/main/java/codesquad/message/HttpStatusCode.java
+++ b/src/main/java/codesquad/message/HttpStatusCode.java
@@ -1,8 +1,10 @@
 package codesquad.message;
 
 public enum HttpStatusCode {
-    OK(200, "OK"), FOUND(302, "Found"), BAD_REQUEST(400, "Bad Request"), NOT_FOUND(404, "Not Found"),
-    INTERNAL_SERVER_ERROR(500, "Internal Server Error");
+    OK(200, "OK"), MOVED_PERMANENTLY(301, "Moved Permanently"), FOUND(302, "Found"), BAD_REQUEST(400,
+            "Bad Request"), NOT_FOUND(404, "Not Found"),
+    INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
+    ;
 
     private final int statusCode;
     private final String statusText;

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/user/create" method="get" id="registration-form">
+        <form class="form" action="/user/create" method="post" id="registration-form">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input
@@ -58,7 +58,7 @@
                     id="registration-btn"
                     class="btn btn_contained btn_size_m"
                     style="margin-top: 24px"
-                    type="button"
+                    type="submit"
             >
                 회원가입
             </button>
@@ -67,13 +67,3 @@
 </div>
 </body>
 </html>
-
-<script>
-    document.getElementById('registration-btn').addEventListener('click', function() {
-        const form = document.getElementById('registration-form');
-        const formData = new FormData(form);
-        const queryString = new URLSearchParams(formData).toString();
-        const actionUrl = form.getAttribute('action');
-        const url = `${actionUrl}?${queryString}`;
-        window.location.href = url;
-    });</script>

--- a/src/test/java/codesquad/ContentTypesTest.java
+++ b/src/test/java/codesquad/ContentTypesTest.java
@@ -22,7 +22,7 @@ class ContentTypesTest {
                 "js, text/javascript",
                 "jpg, image/jpeg",
                 "png, image/png",
-                "ico, image/vnd.microsoft.icon",
+                "ico, image/x-icon",
                 "svg, image/svg+xml"
         })
         @DisplayName("컨텐츠 타입을 반환한다.")

--- a/src/test/java/codesquad/handler/CreateUserHandlerTest.java
+++ b/src/test/java/codesquad/handler/CreateUserHandlerTest.java
@@ -22,10 +22,12 @@ class CreateUserHandlerTest {
         void setUp() {
             createUserHandler = new CreateUserHandler();
             rawHttpMessage = """
-                    POST /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1
+                    POST /create HTTP/1.1
                     Host: localhost:8080
                     Connection: keep-alive
-                    Cache-Control: max-age=0""";
+                    Cache-Control: max-age=0
+                    
+                    userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net""";
         }
 
         @Test

--- a/src/test/java/codesquad/handler/CreateUserHandlerTest.java
+++ b/src/test/java/codesquad/handler/CreateUserHandlerTest.java
@@ -3,6 +3,7 @@ package codesquad.handler;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import codesquad.message.HttpRequest;
+import codesquad.message.HttpStatusCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -15,21 +16,22 @@ class CreateUserHandlerTest {
     class Handle {
 
         private CreateUserHandler createUserHandler;
+        private String rawHttpMessage;
 
         @BeforeEach
         void setUp() {
             createUserHandler = new CreateUserHandler();
+            rawHttpMessage = """
+                    POST /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0""";
         }
 
         @Test
         @DisplayName("사용자가 생성된다.")
         void userCreate() {
             //given
-            String rawHttpMessage = """
-                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
-                    Cache-Control: max-age=0""";
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
 
             //when
@@ -37,6 +39,21 @@ class CreateUserHandlerTest {
 
             //then
             assertThat(mav.getModelValue("userId")).isNotNull().isEqualTo("javajigi");
+
+        }
+
+        @Test
+        @DisplayName("/index.html 페이지로 리다이렉트한다.")
+        void redirectToIndexPage() {
+            //given
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
+            //when
+            ModelAndView mav = createUserHandler.handle(httpRequest);
+
+            //then
+            assertThat(mav.getHeaders().get("Location")).isNotNull().isEqualTo("/");
+            assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
         }
     }
 }

--- a/src/test/java/codesquad/handler/CreateUserHandlerTest.java
+++ b/src/test/java/codesquad/handler/CreateUserHandlerTest.java
@@ -26,9 +26,9 @@ class CreateUserHandlerTest {
         void userCreate() {
             //given
             String rawHttpMessage = """
-                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1
-                    Host: localhost:8080
-                    Connection: keep-alive
+                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
                     Cache-Control: max-age=0""";
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
 

--- a/src/test/java/codesquad/handler/HandlerMapperTest.java
+++ b/src/test/java/codesquad/handler/HandlerMapperTest.java
@@ -1,10 +1,14 @@
 package codesquad.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
+import codesquad.message.HttpRequest;
+import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -12,16 +16,53 @@ import org.junit.jupiter.params.provider.MethodSource;
 class HandlerMapperTest {
 
     @Nested
-    @DisplayName("find 메서드 호출 시")
-    class FindTest {
+    @DisplayName("mapping 메서드 호출 시")
+    class MappingTest {
+
+        @Test
+        @DisplayName("예외(NoSuchElement): POST 요청에 매핑되는 핸들러가 없으면 ")
+        void noSuchElement_WhenNotMatchPostRequest() {
+            //given
+            String rawHttpMessage = """
+                    POST /user HTTP/1.1
+                    Accept: application/json""";
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
+            //when
+            Exception exception = catchException(() -> HandlerMapper.mapping(httpRequest));
+
+            //then
+            assertThat(exception).isInstanceOf(NoSuchElementException.class);
+        }
+
+        @Test
+        @DisplayName("GET 요청에 매핑되는 핸들러가 없으면 정적 리소스 핸들러를 반환한다.")
+        void test() {
+            //given
+            String rawHttpMessage = """
+                    GET /user HTTP/1.1
+                    Accept: application/json""";
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
+            //when
+            Handler handler = HandlerMapper.mapping(httpRequest);
+
+            //then
+            assertThat(handler).isInstanceOf(StaticResourceHandler.class);
+        }
 
         @ParameterizedTest
         @MethodSource("findHandler")
         @DisplayName("URL 경로에 매핑된 핸들러를 조회한다.")
         void findHandler(String url, Handler expected) {
             //given
+            String rawHttpMessage = """
+                    POST /user/create HTTP/1.1
+                    Accept: application/json""";
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
             //when
-            Handler handler = HandlerMapper.mapping(url);
+            Handler handler = HandlerMapper.mapping(httpRequest);
 
             //then
             assertThat(handler).isInstanceOf(expected.getClass());

--- a/src/test/java/codesquad/message/HttpHeadersTest.java
+++ b/src/test/java/codesquad/message/HttpHeadersTest.java
@@ -1,0 +1,62 @@
+package codesquad.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class HttpHeadersTest {
+
+    @Nested
+    @DisplayName("parse 호출 시")
+    class ParseTest {
+
+        @Test
+        @DisplayName("파싱한 객체를 반환한다.")
+        void parseRawHttpHeaders() {
+            //given
+            String rawHeaders = """
+                    Accept: application/json\r
+                    Authorization: Bearer accessToken\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Accept-Language: en-US,en;q=0.5\r
+                    Accept-Encoding: gzip, deflate""";
+
+            //when
+            HttpHeaders httpHeaders = HttpHeaders.parse(rawHeaders);
+
+            //then
+            assertThat(httpHeaders.headers()).satisfies(headers -> {
+                assertThat(headers).hasSize(6);
+                assertThat(headers.get("Authorization")).isNotNull().isEqualTo("Bearer accessToken");
+                assertThat(headers.get("Accept")).isNotNull().isEqualTo("application/json");
+                assertThat(headers.get("Host")).isNotNull().isEqualTo("localhost:8080");
+                assertThat(headers.get("Connection")).isNotNull().isEqualTo("keep-alive");
+                assertThat(headers.get("Accept-Language")).isNotNull().isEqualTo("en-US,en;q=0.5");
+                assertThat(headers.get("Accept-Encoding")).isNotNull().isEqualTo("gzip, deflate");
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "Host: ",
+                "Key:value",
+                ": value"
+        })
+        @DisplayName("예외(IllegalArgument): 형식이 올바르지 않으면")
+        void illegalArgument_WhenInvalidFormat(String rawHeaders) {
+            //given
+            //when
+            Exception exception = catchException(() -> HttpHeaders.parse(rawHeaders));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+}

--- a/src/test/java/codesquad/message/HttpHeadersTest.java
+++ b/src/test/java/codesquad/message/HttpHeadersTest.java
@@ -20,11 +20,11 @@ class HttpHeadersTest {
         void parseRawHttpHeaders() {
             //given
             String rawHeaders = """
-                    Accept: application/json\r
-                    Authorization: Bearer accessToken\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
-                    Accept-Language: en-US,en;q=0.5\r
+                    Accept: application/json
+                    Authorization: Bearer accessToken
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Accept-Language: en-US,en;q=0.5
                     Accept-Encoding: gzip, deflate""";
 
             //when

--- a/src/test/java/codesquad/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/message/HttpRequestTest.java
@@ -1,6 +1,7 @@
 package codesquad.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
 
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -60,6 +61,45 @@ class HttpRequestTest {
             assertThat(queries.get("password")).isNotNull().isEqualTo("password");
             assertThat(queries.get("name")).isNotNull().isEqualTo("박재성");
             assertThat(queries.get("email")).isNotNull().isEqualTo("javajigi@slipp.net");
+        }
+
+        @Test
+        @DisplayName("?만 들어오면 무시한다.")
+        void asdf() {
+            //given
+            String rawHttpMessage = """
+                    GET /create? HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0""";
+
+            //when
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
+            //then
+            assertThat(httpRequest.method()).isEqualTo("GET");
+            assertThat(httpRequest.requestUrl()).isEqualTo("/create");
+            assertThat(httpRequest.httpVersion()).isEqualTo("HTTP/1.1");
+            assertThat(httpRequest.header().get("Host")).isEqualTo("localhost:8080");
+            assertThat(httpRequest.header().get("Connection")).isEqualTo("keep-alive");
+            assertThat(httpRequest.header().get("Cache-Control")).isEqualTo("max-age=0");
+        }
+
+        @Test
+        @DisplayName("예외(IllegalArgument): 쿼리 파라미터에 =가 없으면")
+        void illegalArgument_WhenQueryDoesNotHaveEqual() {
+            //given
+            String rawHttpMessage = """
+                    GET /create?key HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0""";
+
+            //when
+            Exception exception = catchException(() -> HttpRequest.parse(rawHttpMessage));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
         }
     }
 }

--- a/src/test/java/codesquad/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/message/HttpRequestTest.java
@@ -19,10 +19,11 @@ class HttpRequestTest {
         void parseInputMessage() {
             //given
             String rawHttpMessage = """
-                    GET /index.html HTTP/1.1
-                    Host: localhost:8080
-                    Connection: keep-alive
-                    Cache-Control: max-age=0""";
+                    GET /index.html HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Cache-Control: max-age=0\r
+                    """;
 
             //when
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
@@ -41,10 +42,11 @@ class HttpRequestTest {
         void parseQueryString() {
             //given
             String rawHttpMessage = """
-                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1
-                    Host: localhost:8080
-                    Connection: keep-alive
-                    Cache-Control: max-age=0""";
+                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Cache-Control: max-age=0\r
+                    """;
 
             //when
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
@@ -68,10 +70,11 @@ class HttpRequestTest {
         void asdf() {
             //given
             String rawHttpMessage = """
-                    GET /create? HTTP/1.1
-                    Host: localhost:8080
-                    Connection: keep-alive
-                    Cache-Control: max-age=0""";
+                    GET /create? HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Cache-Control: max-age=0\r
+                    """;
 
             //when
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
@@ -90,10 +93,11 @@ class HttpRequestTest {
         void illegalArgument_WhenQueryDoesNotHaveEqual() {
             //given
             String rawHttpMessage = """
-                    GET /create?key HTTP/1.1
-                    Host: localhost:8080
-                    Connection: keep-alive
-                    Cache-Control: max-age=0""";
+                    GET /create?key HTTP/1.1\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Cache-Control: max-age=0\r
+                    """;
 
             //when
             Exception exception = catchException(() -> HttpRequest.parse(rawHttpMessage));

--- a/src/test/java/codesquad/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/message/HttpRequestTest.java
@@ -66,7 +66,7 @@ class HttpRequestTest {
 
         @Test
         @DisplayName("?만 들어오면 무시한다.")
-        void asdf() {
+        void ignorePathHasQuestionMark() {
             //given
             String rawHttpMessage = """
                     GET /create? HTTP/1.1
@@ -103,6 +103,27 @@ class HttpRequestTest {
 
             //then
             assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+
+        @Test
+        @DisplayName("입력으로 주어진 HTTP POST 메시지를 파싱한다.")
+        void parsePostMessage() {
+            //given
+            String rawHttpMessage = """
+                    POST /user/create HTTP/1.1
+                    Host: localhost:8080
+                                        
+                    userId=userId&nickname=nickname""";
+
+            //when
+            HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);
+
+            //then
+            assertThat(httpRequest.httpBody().data()).satisfies(data -> {
+                assertThat(data).hasSize(2);
+                assertThat(data.get("userId")).isNotNull().isEqualTo("userId");
+                assertThat(data.get("nickname")).isNotNull().isEqualTo("nickname");
+            });
         }
     }
 }

--- a/src/test/java/codesquad/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/message/HttpRequestTest.java
@@ -22,8 +22,7 @@ class HttpRequestTest {
                     GET /index.html HTTP/1.1\r
                     Host: localhost:8080\r
                     Connection: keep-alive\r
-                    Cache-Control: max-age=0\r
-                    """;
+                    Cache-Control: max-age=0""";
 
             //when
             HttpRequest httpRequest = HttpRequest.parse(rawHttpMessage);

--- a/src/test/java/codesquad/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/message/HttpRequestTest.java
@@ -19,9 +19,9 @@ class HttpRequestTest {
         void parseInputMessage() {
             //given
             String rawHttpMessage = """
-                    GET /index.html HTTP/1.1\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
+                    GET /index.html HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
                     Cache-Control: max-age=0""";
 
             //when
@@ -41,10 +41,10 @@ class HttpRequestTest {
         void parseQueryString() {
             //given
             String rawHttpMessage = """
-                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
-                    Cache-Control: max-age=0\r
+                    GET /create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0
                     """;
 
             //when
@@ -69,10 +69,10 @@ class HttpRequestTest {
         void asdf() {
             //given
             String rawHttpMessage = """
-                    GET /create? HTTP/1.1\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
-                    Cache-Control: max-age=0\r
+                    GET /create? HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0
                     """;
 
             //when
@@ -92,10 +92,10 @@ class HttpRequestTest {
         void illegalArgument_WhenQueryDoesNotHaveEqual() {
             //given
             String rawHttpMessage = """
-                    GET /create?key HTTP/1.1\r
-                    Host: localhost:8080\r
-                    Connection: keep-alive\r
-                    Cache-Control: max-age=0\r
+                    GET /create?key HTTP/1.1
+                    Host: localhost:8080
+                    Connection: keep-alive
+                    Cache-Control: max-age=0
                     """;
 
             //when

--- a/src/test/java/codesquad/message/HttpResponseTest.java
+++ b/src/test/java/codesquad/message/HttpResponseTest.java
@@ -45,8 +45,8 @@ class HttpResponseTest {
             //then
             assertThat(httpMessageHeaders).asString()
                     .isEqualTo("""
-                            Content-Length: 10\r
-                            Content-Type: text/html\r
+                            Content-Length: 10
+                            Content-Type: text/html
                             """);
         }
     }
@@ -66,7 +66,7 @@ class HttpResponseTest {
 
             //then
             assertThat(httpMessageStartLine).asString()
-                    .isEqualTo("HTTP/1.1 200 OK" + "\r\n");
+                    .isEqualTo("HTTP/1.1 200 OK" + "\n");
         }
     }
 }

--- a/src/test/java/codesquad/message/HttpResponseTest.java
+++ b/src/test/java/codesquad/message/HttpResponseTest.java
@@ -9,25 +9,64 @@ import org.junit.jupiter.api.Test;
 class HttpResponseTest {
 
     @Nested
-    @DisplayName("toHttpMessage 호출 시")
-    class ToHttpMessage {
+    @DisplayName("getHttpMessageBody 호출 시")
+    class GetHttpMessageBody {
 
         @Test
-        @DisplayName("HTTP 메시지로 변환된다.")
-        void test() {
+        @DisplayName("HTTP 메시지 바디가 반환된다.")
+        void getBody() {
             //given
-            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", HttpStatusCode.OK, "body");
+            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", HttpStatusCode.OK, "바디 내용");
             httpResponse.addHeader("Content-Type", "text/html");
 
             //when
-            String result = httpResponse.toHttpMessage();
+            byte[] httpMessageBody = httpResponse.getHttpMessageBody();
 
             //then
-            assertThat(result).isEqualTo("""
-                    HTTP/1.1 200 OK
-                    Content-Type: text/html
-                                        
-                    body""");
+            assertThat(new String(httpMessageBody)).isEqualTo("바디 내용");
+        }
+    }
+
+    @Nested
+    @DisplayName("getHttpMessageHeaders 호출 시")
+    class GetHttpMessageHeaders {
+
+        @Test
+        @DisplayName("HTTP 메시지 헤더가 반환된다.")
+        void getHeaders() {
+            //given
+            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", HttpStatusCode.OK, "바디 내용");
+            httpResponse.addHeader("Content-Type", "text/html");
+            httpResponse.addHeader("Content-Length", "10");
+
+            //when
+            byte[] httpMessageHeaders = httpResponse.getHttpMessageHeaders();
+
+            //then
+            assertThat(httpMessageHeaders).asString()
+                    .isEqualTo("""
+                            Content-Length: 10\r
+                            Content-Type: text/html\r
+                            """);
+        }
+    }
+
+    @Nested
+    @DisplayName("getHttpMessageStartLine 호출 시")
+    class GetHttpMessageStartLine {
+
+        @Test
+        @DisplayName("HTTP 메시지 개행이 반환된다.")
+        void getStartLine() {
+            //given
+            HttpResponse httpResponse = new HttpResponse("HTTP/1.1", HttpStatusCode.OK, "바디 내용");
+
+            //when
+            byte[] httpMessageStartLine = httpResponse.getHttpMessageStartLine();
+
+            //then
+            assertThat(httpMessageStartLine).asString()
+                    .isEqualTo("HTTP/1.1 200 OK" + "\r\n");
         }
     }
 }

--- a/src/test/java/codesquad/message/HttpStartLineTest.java
+++ b/src/test/java/codesquad/message/HttpStartLineTest.java
@@ -1,0 +1,52 @@
+package codesquad.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class HttpStartLineTest {
+
+    @Nested
+    @DisplayName("parse 호출 시")
+    class ParseTest {
+
+        @Test
+        @DisplayName("파싱한 객체를 반환한다.")
+        void parseRawHttpStartLine() {
+            //given
+            String rawHttpStartLine = "GET /user/create?key=value&key2=value2 HTTP/1.1";
+
+            //when
+            HttpStartLine result = HttpStartLine.parse(rawHttpStartLine);
+
+            //then
+            assertThat(result.method()).isEqualTo("GET");
+            assertThat(result.path()).isEqualTo("/user/create");
+            assertThat(result.version()).isEqualTo("HTTP/1.1");
+            assertThat(result.queries()).satisfies(query -> {
+                assertThat(query.get("key")).isNotNull().isEqualTo("value");
+                assertThat(query.get("key2")).isNotNull().isEqualTo("value2");
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "GET /user/create?key HTTP/1.1",
+                "GET /user&key=value"
+        })
+        @DisplayName("예외(IllegalArgument): 형식에 맞지 않으면")
+        void illegalArgument_WhenNotSuitable(String rawHttpStartLine) {
+            //given
+            //when
+            Exception exception = catchException(() -> HttpStartLine.parse(rawHttpStartLine));
+
+            //then
+            assertThat(exception).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 회원 가입 후 리다이렉트를 구현하였습니다.
  - http 응답 상태 코드로 302를 반환하고, 응답 헤더에 `Location`을 추가하여 `/index.html`로 리다이렉트하도록 작업하였습니다.
- 회원 가입 요청의 HTTP 메서드가 POST인 경우 동작하도록 수정하였습니다.
  - 메서드가 GET, POST 인 경우로 나누어 분기 처리를 수행해 POST 핸들러 목록, GET 핸들러 목록 둘 중 하나에서 요청을 처리하기 위한 핸들러를 조회합니다.
  - http 요청 메시지 바디를 파싱할 수 있도록 로직을 추가 및 수정하였습니다. 

## 고민 사항
- 기능 구현을 우선적으로 처리하고 추후 리팩토링을 수행합니다.

## 기타
- 파비콘이 정상적으로 출력되지 않던 문제를 수정하였습니다.
- 기존 HTTP 요청 메시지를 `HttpRequest` 하나에서 책임지던 것에서 개행, 헤더, 바디 각각 책임지도록 클래스를 분리하였습니다.
- 헤더의 값에 띄어쓰기가 들어가는 경우 요청 메시지 파싱이 정상적으로 이루어지지 않던 문제를 수정하였습니다.
- 정적 리소스 핸들러가 리소스를 찾지 못할 경우 던지는 예외를 IllegalArgumentException에서 NoSuchElementException으로 변경하였습니다. 후자가 의미상 더 적절하다고 판단하였습니다.
