### PR TITLE
[지찬우] step-4 POST로 회원 가입

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@
 
 #### 3-1단계
 
-- [ ] 회원가입 요청을 HTTP POST 메서드로 변경
-    - [ ] GET으로 요청이 오면 405 Method Not Allowed 응답
+- [x] 회원가입 요청을 HTTP POST 메서드로 변경
+    - [ ] GET으로 요청이 오면 405 Method Not Allowed 응답(나중에 구현하기)
 - [ ] HTTP redirection 기능을 사용해 회원가입 후 메인 페이지로 이동

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### 구현 목록
 
-#### 1단계
+#### 2-1단계
 
 - [x] http://localhost:8080/index.html로 요청이 오면 `resources/static/index.html` 파일을 읽어 응답
     - [x] 만약 존재하지 않은 파일을 요청하면 `404 Not Found`로 응답
@@ -12,7 +12,7 @@
     - [x] HTTP request를 logger를 사용해 debug 레벨로 출력
 - [x] `ExecutorService`(`ThreadPoolExecutor`)를 사용해 10개의 스레드로 사용자 요청 멀티 스레드 처리
 
-#### 2단계
+#### 2-2단계
 
 - [x] 여러 컨텐츠 타입 지원하기
     - html
@@ -22,8 +22,14 @@
     - png
     - jpg
 
-#### 3단계
+#### 2-3단계
 
 - [x] 정적 리소스 요청의 경로가 디렉토리인 경우, 해당 디렉토리 내의 `index.html`을 찾아 반환
 - [x] 요청 URI를 통해 처리 가능한 핸들러를 통해 처리
 - [x] 회원가입 요청이 오면 query string에 담긴 정보로 `model.User` 객체를 생성해 저장
+
+#### 3-1단계
+
+- [ ] 회원가입 요청을 HTTP POST 메서드로 변경
+    - [ ] GET으로 요청이 오면 405 Method Not Allowed 응답
+- [ ] HTTP redirection 기능을 사용해 회원가입 후 메인 페이지로 이동

--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@
 
 - [x] 회원가입 요청을 HTTP POST 메서드로 변경
     - [ ] GET으로 요청이 오면 405 Method Not Allowed 응답(나중에 구현하기)
-- [ ] HTTP redirection 기능을 사용해 회원가입 후 메인 페이지로 이동
+- [x] HTTP redirection 기능을 사용해 회원가입 후 메인 페이지로 이동

--- a/src/main/java/codesquad/Main.java
+++ b/src/main/java/codesquad/Main.java
@@ -1,6 +1,7 @@
 package codesquad;
 
 import codesquad.handler.HandlersMapper;
+import codesquad.http.HttpRequestReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,10 +19,11 @@ public class Main {
     public static void main(String[] args) throws IOException {
         ExecutorService executorService = Executors.newFixedThreadPool(MAXIMUM_THREAD_POOL_SIZE);
         HandlersMapper handlersMapper = new HandlersMapper();
+        HttpRequestReader requestReader = new HttpRequestReader();
         try (ServerSocket serverSocket = new ServerSocket(8080)) {
             log.debug("Listening for connection on port 8080 ....");
             while (true) {
-                executorService.execute(new HttpRequestProcessor(serverSocket.accept(), handlersMapper));
+                executorService.execute(new HttpRequestProcessor(serverSocket.accept(), requestReader, handlersMapper));
             }
         }
     }

--- a/src/main/java/codesquad/handler/HandlersMapper.java
+++ b/src/main/java/codesquad/handler/HandlersMapper.java
@@ -10,8 +10,8 @@ public class HandlersMapper {
     private final Map<String, RequestHandler> requestHandlers = new HashMap<>();
 
     {
-        requestHandlers.put("/user/create", new UserRegistrationHandler());
-        requestHandlers.put("/", new StaticResourceHandler());
+        requestHandlers.put("/user/create", UserRegistrationHandler.getInstance());
+        requestHandlers.put("/", StaticResourceHandler.getInstance());
     }
 
     public RequestHandler getRequestHandler(HttpRequest httpRequest) {

--- a/src/main/java/codesquad/handler/StaticResourceHandler.java
+++ b/src/main/java/codesquad/handler/StaticResourceHandler.java
@@ -5,14 +5,22 @@ import codesquad.http.HttpResponse;
 import codesquad.http.MediaType;
 import codesquad.resource.Resource;
 import codesquad.resource.ResourcesReader;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
-public class StaticResourceHandler extends RequestHandler {
+public final class StaticResourceHandler extends RequestHandler {
 
-    private final Logger log = LoggerFactory.getLogger(StaticResourceHandler.class);
+    private static StaticResourceHandler INSTANCE = new StaticResourceHandler();
+
+    private StaticResourceHandler() {
+    }
+
+    public static StaticResourceHandler getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new StaticResourceHandler();
+        }
+        return INSTANCE;
+    }
 
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {

--- a/src/main/java/codesquad/handler/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/handler/UserRegistrationHandler.java
@@ -5,9 +5,21 @@ import codesquad.http.HttpResponse;
 import codesquad.model.User;
 import codesquad.model.UserRepository;
 
-public class UserRegistrationHandler extends RequestHandler {
+public final class UserRegistrationHandler extends RequestHandler {
+
+    private static UserRegistrationHandler INSTANCE = new UserRegistrationHandler();
 
     private final UserRepository userRepository = new UserRepository();
+
+    private UserRegistrationHandler() {
+    }
+
+    public static UserRegistrationHandler getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new UserRegistrationHandler();
+        }
+        return INSTANCE;
+    }
 
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {

--- a/src/main/java/codesquad/handler/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/handler/UserRegistrationHandler.java
@@ -1,15 +1,24 @@
 package codesquad.handler;
 
+import codesquad.http.HttpHeaders;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
+import codesquad.http.QueryParameters;
+import codesquad.http.parser.ParsersFactory;
+import codesquad.http.parser.QueryParametersParser;
 import codesquad.model.User;
 import codesquad.model.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class UserRegistrationHandler extends RequestHandler {
 
     private static UserRegistrationHandler INSTANCE = new UserRegistrationHandler();
 
+    private final Logger log = LoggerFactory.getLogger(UserRegistrationHandler.class);
+
     private final UserRepository userRepository = new UserRepository();
+    private final QueryParametersParser queryParametersParser = ParsersFactory.getQueryParametersParser();
 
     private UserRegistrationHandler() {
     }
@@ -23,11 +32,27 @@ public final class UserRegistrationHandler extends RequestHandler {
 
     @Override
     public HttpResponse handle(HttpRequest httpRequest) {
-        String userId = httpRequest.firstParameterValue("userId")
+        if (!httpRequest.method().equals("POST")) {
+            // TODO 405 Method Not Allowed 적용
+            throw new IllegalArgumentException("[ERROR] 회원가입 요청은 POST 메서드여야 합니다.");
+        }
+
+        String contentType = httpRequest.firstHeaderValue(HttpHeaders.CONTENT_TYPE)
+                .orElse("");
+        if (!contentType.equals("application/x-www-form-urlencoded")) {
+            // TODO 400 Bad Request 적용
+            throw new IllegalArgumentException("[ERROR] request body 타입이 올바르지 않습니다.");
+        }
+
+        String body = httpRequest.body()
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] request body가 없습니다."));
+        QueryParameters parameters = queryParametersParser.parse(body);
+
+        String userId = parameters.getFirstValue("userId")
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원가입 아이디가 비어있습니다."));
-        String nickname = httpRequest.firstParameterValue("nickname")
+        String nickname = parameters.getFirstValue("nickname")
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원가입 닉네임이 비어있습니다."));
-        String password = httpRequest.firstParameterValue("password")
+        String password = parameters.getFirstValue("password")
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 회원가입 비밀번호가 비어있습니다."));
 
         User user = new User(userId, nickname, password);

--- a/src/main/java/codesquad/handler/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/handler/UserRegistrationHandler.java
@@ -58,7 +58,7 @@ public final class UserRegistrationHandler extends RequestHandler {
         User user = new User(userId, nickname, password);
         boolean success = userRepository.save(user);
         if (success) {
-            return responseGenerator.sendRedirect(httpRequest, "/login");
+            return responseGenerator.sendRedirect(httpRequest, "/");
         }
         return responseGenerator.sendBadRequest(httpRequest);
     }

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -32,10 +33,6 @@ public class HttpHeaders {
                 .add(value);
     }
 
-    public void addValues(String name, Iterable<String> values) {
-        values.forEach(value -> addValue(name, value));
-    }
-
     public List<String> getValues(String name) {
         if (name == null) {
             return Collections.emptyList();
@@ -43,6 +40,11 @@ public class HttpHeaders {
 
         List<String> values = this.headers.getOrDefault(name, Collections.emptyList());
         return Collections.unmodifiableList(values);
+    }
+
+    public Optional<String> getFirstValue(String name) {
+        return getValues(name).stream()
+                .findFirst();
     }
 
     public String toText() {

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -11,7 +11,7 @@ public class HttpRequest {
     private final String httpVersion;
     private final QueryParameters parameters;
     private final HttpHeaders headers;
-    private final String body;
+    private String body;
 
     public HttpRequest(String uri, String method, String httpVersion, QueryParameters parameters, HttpHeaders headers, String body) {
         this.uri = uri;
@@ -43,12 +43,19 @@ public class HttpRequest {
     }
 
     public Optional<String> body() {
-        return this.body == null || this.body.isEmpty() ? Optional.empty()
-                : Optional.of(this.body);
+        return this.body == null || this.body.isEmpty() ? Optional.empty() : Optional.of(this.body);
     }
 
     public Optional<String> firstParameterValue(String parameterName) {
         return parameters.getFirstValue(parameterName);
+    }
+
+    public Optional<String> firstHeaderValue(String headerName) {
+        return headers.getFirstValue(headerName);
+    }
+
+    public void setBody(String body) {
+        this.body = body;
     }
 
     @Override

--- a/src/main/java/codesquad/http/HttpRequestReader.java
+++ b/src/main/java/codesquad/http/HttpRequestReader.java
@@ -1,0 +1,28 @@
+package codesquad.http;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+
+public class HttpRequestReader {
+
+    public String read(BufferedReader reader) throws IOException {
+        StringBuilder request = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null && !line.isEmpty()) {
+            request.append(line)
+                    .append("\r\n");
+        }
+        return request.toString();
+    }
+
+    public String readBody(BufferedReader reader, int contentLength) throws IOException {
+        StringBuilder requestBody = new StringBuilder();
+        if (contentLength > 0) {
+            char[] body = new char[contentLength];
+            reader.read(body);
+            requestBody.append(new String(body));
+        }
+        return requestBody.toString();
+    }
+
+}

--- a/src/main/java/codesquad/http/parser/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/parser/HttpRequestParser.java
@@ -35,9 +35,12 @@ public class HttpRequestParser implements Parser<HttpRequest> {
                 .skip(1)
                 .collect(Collectors.joining("\r\n"));
         HttpHeaders httpHeaders = headersParser.parse(headers);
-        QueryParameters queryParameters = queryParametersParser.parse(uri);
-        if (queryParameters.isExists()) {
-            uri = uri.split("\\?")[0];
+
+        QueryParameters queryParameters = null;
+        if (uri.contains("?")) {
+            String[] uriQueryString = uri.split("\\?");
+            queryParameters = queryParametersParser.parse(uriQueryString[1]);
+            uri = uriQueryString[0];
         }
         return new HttpRequest(uri, method, httpVersion, queryParameters, httpHeaders, null);
     }

--- a/src/main/java/codesquad/http/parser/ParsersFactory.java
+++ b/src/main/java/codesquad/http/parser/ParsersFactory.java
@@ -10,4 +10,8 @@ public class ParsersFactory {
         return httpRequestParser;
     }
 
+    public static QueryParametersParser getQueryParametersParser() {
+        return queryParametersParser;
+    }
+
 }

--- a/src/main/java/codesquad/http/parser/QueryParametersParser.java
+++ b/src/main/java/codesquad/http/parser/QueryParametersParser.java
@@ -14,16 +14,10 @@ public class QueryParametersParser implements Parser<QueryParameters> {
     private final Logger log = LoggerFactory.getLogger(QueryParametersParser.class);
 
     @Override
-    public QueryParameters parse(String uriText) {
-        if (uriText == null || uriText.isEmpty()) {
+    public QueryParameters parse(String queryString) {
+        if (queryString == null || queryString.isEmpty()) {
             return QueryParameters.empty();
         }
-
-        int queryIndex = uriText.indexOf("?");
-        if (queryIndex == -1) {
-            return QueryParameters.empty();
-        }
-        String queryString = uriText.substring(queryIndex + 1);
 
         QueryParameters queryParameters = new QueryParameters();
         Arrays.stream(queryString.split("&"))

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
   </header>
   <div class="page">
     <h2 class="page-title">회원가입</h2>
-    <form class="form" action="/user/create">
+    <form class="form" method="post" action="/user/create">
       <div class="textfield textfield_size_s">
         <p class="title_textfield">아이디</p>
         <input

--- a/src/test/java/codesquad/handler/UserRegistrationHandlerTest.java
+++ b/src/test/java/codesquad/handler/UserRegistrationHandlerTest.java
@@ -1,0 +1,55 @@
+package codesquad.handler;
+
+import codesquad.http.HttpHeaders;
+import codesquad.http.HttpRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class UserRegistrationHandlerTest {
+
+    UserRegistrationHandler userRegistrationHandler;
+
+    @BeforeEach
+    void setUp() {
+        userRegistrationHandler = UserRegistrationHandler.getInstance();
+    }
+
+    @Nested
+    class handle_메서드는 {
+
+        @ParameterizedTest
+        @ValueSource(strings = {"GET", "PUT", "DELETE"})
+        void POST_메서드_요청이_아니면_예외가_발생한다(String httpMethod) {
+            HttpRequest httpRequest = new HttpRequest(null, httpMethod, null, null, null, null);
+            assertThatThrownBy(() -> userRegistrationHandler.handle(httpRequest))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("[ERROR] 회원가입 요청은 POST 메서드여야 합니다.");
+        }
+
+        @Test
+        void content_type이_x_www_form_urlencoded가_아니면_예외가_발생한다() {
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.addValue(HttpHeaders.CONTENT_TYPE, "application/json");
+            HttpRequest httpRequest = new HttpRequest(null, "POST", null, null, httpHeaders, null);
+            assertThatThrownBy(() -> userRegistrationHandler.handle(httpRequest))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[ERROR] request body 타입이 올바르지 않습니다.");
+        }
+
+        @Test
+        void request_body가_없으면_예외가_발생한다() {
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.addValue(HttpHeaders.CONTENT_TYPE, "application/x-www-form-urlencoded");
+            HttpRequest httpRequest = new HttpRequest(null, "POST", null, null, httpHeaders, "");
+            assertThatThrownBy(() -> userRegistrationHandler.handle(httpRequest))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("[ERROR] request body가 없습니다.");
+        }
+    }
+
+}


### PR DESCRIPTION
## 구현 내용

- [x] 회원가입 요청을 HTTP POST 메서드로 변경
- [x] HTTP redirection 기능을 사용해 회원가입 후 메인 페이지로 이동

## 고민 사항

### 1. application/x-www-form-urlencoded 타입의 body 파싱하기

기존에 구현한 `QueryParametersParser`를 활용 가능

URI가 아닌 request body에 담겨 오는 것이 차이점 → `Content-Length` 헤더 활용하기

### 2. 만약 request가 POST인데 header에 Content-Length가 없으면 어떻게 처리할까?

> HTTP/1.1 표준에서는 요청 본문이 있는 POST 요청에 `Content-Length` 헤더가 필수적, 따라서 이 헤더가 없으면 서버는 요청을 잘못된 것으로 간주하고 `400 Bad Request` 응답을 반환할 수 있다.

HTTP status code 중 `411 Length Required` 응답도 있다!

[411 Length Required - HTTP | MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/411)

## 기타

리플렉션 재밌다!
