### PR TITLE
[이지표] step-4 POST로 회원 가입

### DIFF
--- a/src/main/java/codesquad/app/Application.java
+++ b/src/main/java/codesquad/app/Application.java
@@ -12,19 +12,9 @@ import java.io.IOException;
 
 public class Application {
     private static final int PORT = 8080;
-    private static final UserRepository userRepository = new UserRepository();
 
     public static void main(String[] args) throws IOException {
         Server server = new Server(PORT);
-        server.addRequestHandler(new HomeHandler());
-        server.addRequestHandler(new UserLoginHandler(getUserRepository()));
-        server.addRequestHandler(new UserRegistrationHandler());
-        server.addRequestHandler(new UserJoinHandler(getUserRepository()));
-        server.addRequestHandler(new ArticleHandler());
         server.start();
-    }
-
-    private static UserRepository getUserRepository() {
-        return userRepository;
     }
 }

--- a/src/main/java/codesquad/domain/article/ArticleHandler.java
+++ b/src/main/java/codesquad/domain/article/ArticleHandler.java
@@ -1,22 +1,16 @@
 package codesquad.domain.article;
 
 import codesquad.server.handler.CustomRequestHandler;
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 
+@Handler("/article")
 public class ArticleHandler extends CustomRequestHandler {
-    @Override
-    protected String getMethod() {
-        return "GET";
-    }
 
-    @Override
-    protected String getPath() {
-        return "/article";
-    }
-
-    @Override
-    public HttpResponse handle(HttpRequest request) {
+    @HttpMethod("GET")
+    public HttpResponse article(HttpRequest request) {
         return ok(readFileContent("/static/article/index.html")).build();
     }
 }

--- a/src/main/java/codesquad/domain/home/HomeHandler.java
+++ b/src/main/java/codesquad/domain/home/HomeHandler.java
@@ -1,21 +1,14 @@
 package codesquad.domain.home;
 
 import codesquad.server.handler.CustomRequestHandler;
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 
+@Handler("/")
 public class HomeHandler extends CustomRequestHandler {
-    @Override
-    protected String getMethod() {
-        return "GET";
-    }
-
-    @Override
-    protected String getPath() {
-        return "/";
-    }
-
-    @Override
+    @HttpMethod("GET")
     public HttpResponse handle(HttpRequest request) {
         return ok(readFileContent("/static/index.html")).build();
     }

--- a/src/main/java/codesquad/domain/user/UserJoinHandler.java
+++ b/src/main/java/codesquad/domain/user/UserJoinHandler.java
@@ -5,8 +5,11 @@ import codesquad.server.Server;
 import codesquad.server.handler.CustomRequestHandler;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
+import codesquad.server.http.parser.UrlEncodedBodyParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Map;
 
 public class UserJoinHandler extends CustomRequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(Server.class);
@@ -18,7 +21,7 @@ public class UserJoinHandler extends CustomRequestHandler {
 
     @Override
     protected String getMethod() {
-        return "GET";
+        return "POST";
     }
 
     @Override
@@ -28,10 +31,11 @@ public class UserJoinHandler extends CustomRequestHandler {
 
     @Override
     public HttpResponse handle(HttpRequest request) {
-        String name = request.getQueryParam("name");
-        String password = request.getQueryParam("password");
-        String userId = request.getQueryParam("userId");
-        String email = request.getQueryParam("email");
+        Map<String, String> params = UrlEncodedBodyParser.parse(request.getBody());
+        String name = params.get("name");
+        String email = params.get("email");
+        String password = params.get("password");
+        String userId = params.get("userId");
         User user = new User(name, password, userId, email);
         long id = userRepository.join(user);
         logger.debug("User id: {} joined, User info: {}", id, user);

--- a/src/main/java/codesquad/domain/user/UserJoinHandler.java
+++ b/src/main/java/codesquad/domain/user/UserJoinHandler.java
@@ -3,34 +3,26 @@ package codesquad.domain.user;
 import codesquad.domain.user.model.User;
 import codesquad.server.Server;
 import codesquad.server.handler.CustomRequestHandler;
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 import codesquad.server.http.parser.UrlEncodedBodyParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.util.Map;
 
+@Handler("/user/create")
 public class UserJoinHandler extends CustomRequestHandler {
     private static final Logger logger = LoggerFactory.getLogger(Server.class);
     private final UserRepository userRepository;
 
-    public UserJoinHandler(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public UserJoinHandler() {
+        this.userRepository = UserRepository.INSTANCE;
     }
 
-    @Override
-    protected String getMethod() {
-        return "POST";
-    }
-
-    @Override
-    protected String getPath() {
-        return "/user/create";
-    }
-
-    @Override
-    public HttpResponse handle(HttpRequest request) {
+    @HttpMethod("POST")
+    public HttpResponse createUser(HttpRequest request) {
         Map<String, String> params = UrlEncodedBodyParser.parse(request.getBody());
         String name = params.get("name");
         String email = params.get("email");

--- a/src/main/java/codesquad/domain/user/UserJoinHandler.java
+++ b/src/main/java/codesquad/domain/user/UserJoinHandler.java
@@ -39,6 +39,6 @@ public class UserJoinHandler extends CustomRequestHandler {
         User user = new User(name, password, userId, email);
         long id = userRepository.join(user);
         logger.debug("User id: {} joined, User info: {}", id, user);
-        return ok(readFileContent("/static/registration/success.html")).build();
+        return redirect("/index.html").build();
     }
 }

--- a/src/main/java/codesquad/domain/user/UserLoginHandler.java
+++ b/src/main/java/codesquad/domain/user/UserLoginHandler.java
@@ -1,28 +1,21 @@
 package codesquad.domain.user;
 
 import codesquad.server.handler.CustomRequestHandler;
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 
+@Handler("/login")
 public class UserLoginHandler extends CustomRequestHandler {
     private final UserRepository userRepository;
 
-    public UserLoginHandler(UserRepository userRepository) {
-        this.userRepository = userRepository;
+    public UserLoginHandler() {
+        this.userRepository = UserRepository.INSTANCE;
     }
 
-    @Override
-    protected String getMethod() {
-        return "GET";
-    }
-
-    @Override
-    protected String getPath() {
-        return "/login";
-    }
-
-    @Override
-    public HttpResponse handle(HttpRequest request) {
+    @HttpMethod("GET")
+    public HttpResponse login(HttpRequest request) {
         return ok(readFileContent("/static/login/index.html")).build();
     }
 }

--- a/src/main/java/codesquad/domain/user/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/domain/user/UserRegistrationHandler.java
@@ -1,30 +1,16 @@
 package codesquad.domain.user;
 
 import codesquad.server.handler.CustomRequestHandler;
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 
+@Handler("/registration")
 public class UserRegistrationHandler extends CustomRequestHandler {
-    @Override
-    protected String getMethod() {
-        return "GET";
-    }
-
-    @Override
-    protected String getPath() {
-        return "/registration";
-    }
-
-    @Override
-    public HttpResponse handle(HttpRequest request) {
-        return ok(readFileContent("/static/registration/index.html")).build();
-    }
-
-    @Override
-    public boolean canHandle(HttpRequest request) {
-        if (getMethod().equals(request.getMethod()) && "/register.html".equals(request.getPath())) {
-            return true;
-        }
-        return super.canHandle(request);
+    @HttpMethod("GET")
+    public HttpResponse registration(HttpRequest request) {
+        return ok(readFileContent("/static/registration/index.html"))
+                .build();
     }
 }

--- a/src/main/java/codesquad/domain/user/UserRepository.java
+++ b/src/main/java/codesquad/domain/user/UserRepository.java
@@ -6,10 +6,11 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserRepository {
+    public static final UserRepository INSTANCE = new UserRepository();
     private long id;
     private final Map<Long, User> users;
 
-    public UserRepository() {
+    private  UserRepository() {
         users = new ConcurrentHashMap<>();
     }
 

--- a/src/main/java/codesquad/server/HttpConnectionProcessor.java
+++ b/src/main/java/codesquad/server/HttpConnectionProcessor.java
@@ -1,6 +1,6 @@
 package codesquad.server;
 
-import codesquad.server.http.Http11Parser;
+import codesquad.server.http.parser.Http11Parser;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 import org.slf4j.Logger;

--- a/src/main/java/codesquad/server/RequestDispatcher.java
+++ b/src/main/java/codesquad/server/RequestDispatcher.java
@@ -2,12 +2,21 @@ package codesquad.server;
 
 import codesquad.server.handler.RequestHandler;
 import codesquad.server.handler.StaticFileHandler;
+import codesquad.server.handler.annotation.Handler;
 import codesquad.server.http.HttpRequest;
 import codesquad.server.http.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 public class RequestDispatcher {
     private static final Logger logger = LoggerFactory.getLogger(Server.class);
@@ -18,6 +27,8 @@ public class RequestDispatcher {
     private RequestDispatcher() {
         requestHandlers = new CopyOnWriteArrayList<>();
         staticFileHandler = new StaticFileHandler();
+        registerRequestHandlers();
+        logger.debug("requestHandlers: {}", requestHandlers);
     }
 
     public static synchronized RequestDispatcher getInstance() {
@@ -25,6 +36,89 @@ public class RequestDispatcher {
             instance = new RequestDispatcher();
         }
         return instance;
+    }
+
+    private void registerRequestHandlers() {
+        try {
+            String packageName = "codesquad"; // 최상위 패키지로 변경
+            String packagePath = packageName.replace(".", "/");
+            logger.debug("Searching for handlers in package and subpackages: {}", packageName);
+
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+            if (classLoader == null) {
+                classLoader = RequestDispatcher.class.getClassLoader();
+            }
+
+            Enumeration<URL> resources = classLoader.getResources(packagePath);
+            if (!resources.hasMoreElements()) {
+                logger.warn("No resources found for package: {}", packageName);
+            }
+
+            while (resources.hasMoreElements()) {
+                URL resource = resources.nextElement();
+                logger.debug("Found resource: {}", resource);
+
+                if ("file".equals(resource.getProtocol())) {
+                    handleFileProtocol(resource, packageName);
+                } else if ("jar".equals(resource.getProtocol())) {
+                    handleJarProtocol(resource, packageName);
+                } else {
+                    logger.warn("Unsupported protocol: {}", resource.getProtocol());
+                }
+            }
+        } catch (Exception e) {
+            logger.error("Failed to register request handlers", e);
+        }
+    }
+
+    private void handleFileProtocol(URL resource, String packageName) throws ReflectiveOperationException, URISyntaxException {
+        File dir = new File(resource.toURI());
+        logger.debug("Scanning directory: {}", dir.getAbsolutePath());
+        scanDirectory(dir, packageName);
+    }
+
+    private void scanDirectory(File dir, String packageName) throws ReflectiveOperationException {
+        File[] files = dir.listFiles();
+        if (files == null) {
+            logger.warn("No files found in directory: {}", dir.getAbsolutePath());
+            return;
+        }
+        for (File file : files) {
+            if (file.isDirectory()) {
+                scanDirectory(file, packageName + "." + file.getName());
+            } else if (file.getName().endsWith(".class")) {
+                String className = packageName + "." + file.getName().substring(0, file.getName().length() - 6);
+                logger.debug("Processing class: {}", className);
+                processClass(className);
+            }
+        }
+    }
+
+    private void handleJarProtocol(URL resource, String packageName) throws IOException, URISyntaxException, ReflectiveOperationException {
+        String jarPath = resource.toURI().getSchemeSpecificPart().split("!")[0];
+        logger.debug("Scanning JAR file: {}", jarPath);
+        try (JarFile jarFile = new JarFile(new File(new URI(jarPath)))) {
+            Enumeration<JarEntry> entries = jarFile.entries();
+            while (entries.hasMoreElements()) {
+                JarEntry entry = entries.nextElement();
+                String entryName = entry.getName();
+                if (entryName.endsWith(".class")) {
+                    String className = entryName.substring(0, entryName.length() - 6).replace("/", ".");
+                    if (className.startsWith(packageName)) {
+                        logger.debug("Processing class from JAR: {}", className);
+                        processClass(className);
+                    }
+                }
+            }
+        }
+    }
+
+    private void processClass(String className) throws ReflectiveOperationException {
+        Class<?> clazz = Class.forName(className);
+        if (RequestHandler.class.isAssignableFrom(clazz) && !clazz.isInterface() && clazz.isAnnotationPresent(Handler.class)) {
+            RequestHandler requestHandler = (RequestHandler) clazz.getDeclaredConstructor().newInstance();
+            addRequestHandler(requestHandler);
+        }
     }
 
     public void addRequestHandler(RequestHandler requestHandler) {

--- a/src/main/java/codesquad/server/handler/AbstractRequestHandler.java
+++ b/src/main/java/codesquad/server/handler/AbstractRequestHandler.java
@@ -15,6 +15,13 @@ public abstract class AbstractRequestHandler implements RequestHandler {
                 .body(body);
     }
 
+    protected HttpResponse.Builder redirect(String url) {
+        return HttpResponse.builder()
+                .statusCode(302)
+                .statusText("Found")
+                .addHeader("Location", url);
+    }
+
     protected HttpResponse.Builder notFound() {
         byte[] errorContent = readErrorPage(404);
         return HttpResponse.builder()

--- a/src/main/java/codesquad/server/handler/CustomRequestHandler.java
+++ b/src/main/java/codesquad/server/handler/CustomRequestHandler.java
@@ -1,14 +1,43 @@
 package codesquad.server.handler;
 
+import codesquad.server.handler.annotation.Handler;
+import codesquad.server.handler.annotation.HttpMethod;
 import codesquad.server.http.HttpRequest;
+import codesquad.server.http.HttpResponse;
+import java.lang.reflect.Method;
 
 public abstract class CustomRequestHandler extends AbstractRequestHandler {
-    protected abstract String getMethod();
-
-    protected abstract String getPath();
+    @Override
+    public HttpResponse handle(HttpRequest request) {
+        String httpMethod = request.getMethod();
+        for (Method method : this.getClass().getDeclaredMethods()) {
+            HttpMethod httpMethodAnnotation = method.getAnnotation(HttpMethod.class);
+            if (httpMethodAnnotation != null && httpMethodAnnotation.value().equalsIgnoreCase(httpMethod)) {
+                try {
+                    return (HttpResponse) method.invoke(this, request);
+                } catch (Exception e) {
+                    return internalServerError().build();
+                }
+            }
+        }
+        return notFound().build();
+    }
 
     @Override
     public boolean canHandle(HttpRequest request) {
-        return request.getMethod().equalsIgnoreCase(getMethod()) && request.getPath().equals(getPath());
+        Handler handlerAnnotation = this.getClass().getAnnotation(Handler.class);
+        if (handlerAnnotation != null) {
+            String path = handlerAnnotation.value();
+            if (path.isEmpty() || !request.getPath().equals(path)) {
+                return false;
+            }
+        }
+        for (Method method : this.getClass().getDeclaredMethods()) {
+            HttpMethod httpMethodAnnotation = method.getAnnotation(HttpMethod.class);
+            if (httpMethodAnnotation != null && httpMethodAnnotation.value().equalsIgnoreCase(request.getMethod())) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/codesquad/server/handler/annotation/Handler.java
+++ b/src/main/java/codesquad/server/handler/annotation/Handler.java
@@ -1,0 +1,12 @@
+package codesquad.server.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface Handler {
+    String value();
+}

--- a/src/main/java/codesquad/server/handler/annotation/HttpMethod.java
+++ b/src/main/java/codesquad/server/handler/annotation/HttpMethod.java
@@ -1,0 +1,12 @@
+package codesquad.server.handler.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface HttpMethod {
+    String value() default "GET";
+}

--- a/src/main/java/codesquad/server/http/ContentType.java
+++ b/src/main/java/codesquad/server/http/ContentType.java
@@ -10,6 +10,7 @@ public enum ContentType {
     PNG("png", "image/png"),
     JPEG("jpeg", "image/jpeg"),
     SVG("svg", "image/svg+xml"),
+    FORM_URLENCODED("", "application/x-www-form-urlencoded; charset=UTF-8"),
     TXT("txt", "text/plain; charset=UTF-8");
 
     private final String extension;
@@ -43,6 +44,6 @@ public enum ContentType {
     }
 
     public boolean isTextBased() {
-        return this == HTML || this == CSS || this == JS || this == TXT;
+        return this == HTML || this == CSS || this == JS || this == FORM_URLENCODED || this == TXT;
     }
 }

--- a/src/main/java/codesquad/server/http/parser/Http11Parser.java
+++ b/src/main/java/codesquad/server/http/parser/Http11Parser.java
@@ -1,8 +1,7 @@
-package codesquad.server.http;
+package codesquad.server.http.parser;
 
+import codesquad.server.http.HttpRequest;
 import java.io.*;
-import java.util.HashMap;
-import java.util.Map;
 
 public class Http11Parser {
     private Http11Parser() {

--- a/src/main/java/codesquad/server/http/parser/UrlEncodedBodyParser.java
+++ b/src/main/java/codesquad/server/http/parser/UrlEncodedBodyParser.java
@@ -1,0 +1,30 @@
+package codesquad.server.http.parser;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.util.HashMap;
+import java.util.Map;
+
+public class UrlEncodedBodyParser {
+    private UrlEncodedBodyParser() {
+    }
+
+    public static Map<String, String> parse(String body) {
+        Map<String, String> parameters = new HashMap<>();
+        if (body != null && !body.isEmpty()) {
+            String[] pairs = body.split("&");
+            for (String pair : pairs) {
+                int idx = pair.indexOf("=");
+                if (idx != -1) {
+                    try {
+                        String key = URLDecoder.decode(pair.substring(0, idx), "UTF-8");
+                        String value = URLDecoder.decode(pair.substring(idx + 1), "UTF-8");
+                        parameters.put(key, value);
+                    } catch (UnsupportedEncodingException e) {
+                    }
+                }
+            }
+        }
+        return parameters;
+    }
+}

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
   </header>
   <div class="page">
     <h2 class="page-title">회원가입</h2>
-    <form class="form" action="/user/create" method="get">
+    <form class="form" action="/user/create" method="post">
       <div class="textfield textfield_size_s">
         <p class="title_textfield">아이디</p>
         <input

--- a/src/test/java/codesquad/domain/article/ArticleHandlerTest.java
+++ b/src/test/java/codesquad/domain/article/ArticleHandlerTest.java
@@ -1,0 +1,62 @@
+package codesquad.domain.article;
+
+import codesquad.domain.user.UserJoinHandler;
+import codesquad.server.http.HttpRequest;
+import codesquad.server.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ArticleHandlerTest {
+    private ArticleHandler articleHandler;
+
+    @BeforeEach
+    void 초기화() {
+        articleHandler = new ArticleHandler();
+    }
+
+    @Test
+    void 요청_처리_확인() {
+        HttpRequest request = HttpRequest.builder()
+                .method("GET")
+                .path("/article")
+                .build();
+
+        HttpResponse response = articleHandler.handle(request);
+
+        assertNotNull(response);
+        assertTrue(new String(response.getBody()).contains("<html>"));
+        assertEquals(200, response.getStatusCode());
+    }
+
+    @Test
+    void 처리_가능_여부_확인() {
+        HttpRequest request = HttpRequest.builder()
+                .method("GET")
+                .path("/article")
+                .build();
+
+        assertTrue(articleHandler.canHandle(request));
+    }
+
+    @Test
+    void 처리_불가능_여부_확인_잘못된_메서드() {
+        HttpRequest request = HttpRequest.builder()
+                .method("POST")
+                .path("/article")
+                .build();
+
+        assertFalse(articleHandler.canHandle(request));
+    }
+
+    @Test
+    void 처리_불가능_여부_확인_잘못된_경로() {
+        HttpRequest request = HttpRequest.builder()
+                .method("GET")
+                .path("/wrong-path")
+                .build();
+
+        assertFalse(articleHandler.canHandle(request));
+    }
+}

--- a/src/test/java/codesquad/domain/home/HomeHandlerTest.java
+++ b/src/test/java/codesquad/domain/home/HomeHandlerTest.java
@@ -16,16 +16,6 @@ class HomeHandlerTest {
     }
 
     @Test
-    void GET_메서드_확인() {
-        assertEquals("GET", homeHandler.getMethod());
-    }
-
-    @Test
-    void 경로_확인() {
-        assertEquals("/", homeHandler.getPath());
-    }
-
-    @Test
     void 요청_처리_확인() {
         HttpRequest request = HttpRequest.builder()
                 .method("GET")

--- a/src/test/java/codesquad/domain/user/UserJoinHandlerTest.java
+++ b/src/test/java/codesquad/domain/user/UserJoinHandlerTest.java
@@ -1,0 +1,61 @@
+package codesquad.domain.user;
+
+import codesquad.server.http.HttpRequest;
+import codesquad.server.http.HttpResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserJoinHandlerTest {
+    private UserJoinHandler userJoinHandler;
+
+    @BeforeEach
+    void 초기화() {
+        userJoinHandler = new UserJoinHandler();
+    }
+
+    @Test
+    void 요청_처리_확인() {
+        HttpRequest request = HttpRequest.builder()
+                .method("POST")
+                .path("/user/create")
+                .body("userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net")
+                .build();
+
+        HttpResponse response = userJoinHandler.handle(request);
+
+        assertNotNull(response);
+        assertEquals(302, response.getStatusCode());
+    }
+
+    @Test
+    void 처리_가능_여부_확인() {
+        HttpRequest request = HttpRequest.builder()
+                .method("POST")
+                .path("/user/create")
+                .build();
+
+        assertTrue(userJoinHandler.canHandle(request));
+    }
+
+    @Test
+    void 처리_불가능_여부_확인_잘못된_메서드() {
+        HttpRequest request = HttpRequest.builder()
+                .method("GET")
+                .path("/user/create")
+                .build();
+
+        assertFalse(userJoinHandler.canHandle(request));
+    }
+
+    @Test
+    void 처리_불가능_여부_확인_잘못된_경로() {
+        HttpRequest request = HttpRequest.builder()
+                .method("POST")
+                .path("/wrong-path")
+                .build();
+
+        assertFalse(userJoinHandler.canHandle(request));
+    }
+}

--- a/src/test/java/codesquad/domain/user/UserLoginHandlerTest.java
+++ b/src/test/java/codesquad/domain/user/UserLoginHandlerTest.java
@@ -9,22 +9,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 class UserLoginHandlerTest {
     private UserLoginHandler userLoginHandler;
-    private UserRepository userRepository;
 
     @BeforeEach
     void 초기화() {
-        userRepository = new UserRepository();
-        userLoginHandler = new UserLoginHandler(userRepository);
-    }
-
-    @Test
-    void GET_메서드_확인() {
-        assertEquals("GET", userLoginHandler.getMethod());
-    }
-
-    @Test
-    void 경로_확인() {
-        assertEquals("/login", userLoginHandler.getPath());
+        userLoginHandler = new UserLoginHandler();
     }
 
     @Test

--- a/src/test/java/codesquad/domain/user/UserRegistrationHandlerTest.java
+++ b/src/test/java/codesquad/domain/user/UserRegistrationHandlerTest.java
@@ -15,16 +15,6 @@ class UserRegistrationHandlerTest {
     }
 
     @Test
-    void GET_메서드_확인() {
-        assertEquals("GET", userRegistrationHandler.getMethod());
-    }
-
-    @Test
-    void 경로_확인() {
-        assertEquals("/registration", userRegistrationHandler.getPath());
-    }
-
-    @Test
     void 요청_처리_확인() {
         HttpRequest request = HttpRequest.builder()
                 .method("GET")
@@ -43,16 +33,6 @@ class UserRegistrationHandlerTest {
         HttpRequest request = HttpRequest.builder()
                 .method("GET")
                 .path("/registration")
-                .build();
-
-        assertTrue(userRegistrationHandler.canHandle(request));
-    }
-
-    @Test
-    void 처리_가능_여부_확인_register_html_경로() {
-        HttpRequest request = HttpRequest.builder()
-                .method("GET")
-                .path("/register.html")
                 .build();
 
         assertTrue(userRegistrationHandler.canHandle(request));

--- a/src/test/java/codesquad/server/http/HttpRequestTest.java
+++ b/src/test/java/codesquad/server/http/HttpRequestTest.java
@@ -1,5 +1,6 @@
 package codesquad.server.http;
 
+import codesquad.server.http.parser.Http11Parser;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;


### PR DESCRIPTION
## 구현 내용
- 회원가입 html 파일의 form태그 내 method를 get에서 post로 수정한다.
- 나머지 회원가입 기능이 정상적으로 동작한다.
- 가입 후 페이지 이동을 위해 HTTP redirection 기능을 한다.

## 고민 사항
- 이전 코드는 url과 method에 따라 계속 새로운 클래스를 생성해야 했습니다.
-> 같은 url이면, 메서드 HttpMethod어노테이션에 따라 동작하도록 했습니다.
- 사용자가 만든 CustomHandler의 경우도 직접 미들웨어에서 등록하는 방식으로 했습니다.
-> 이를 리플랙션기능을 활용하여 해당 어노테이션을 가지고 있으면 자동으로 Handler를 등록해줍니다.

## 기타
WAS-2-step-1 테크 스펙
https://docs.google.com/document/d/1cgcQsHFtTQgKEim3CimjveSx2E8w0QXvameZUDRzyHc/edit?usp=sharing