### PR TITLE
[강승훈] step-5 쿠키를 이용한 로그인

### DIFF
--- a/src/main/java/codesquad/command/CommandManager.java
+++ b/src/main/java/codesquad/command/CommandManager.java
@@ -86,15 +86,19 @@ public class CommandManager {
 			try {
 				var className = method.getDeclaringClass().getName();
 				var instance = findInstance(className);
+				System.out.println("instance = "+instance);
 
 				var userInputData = parsingQueryParameterResources(resources);
-				var parameters = makeParameterArgs(method,userInputData);
+				var cookie = new HashMap<String, String>();
+				var parameters = makeParameterArgs(method,userInputData,cookie);
 
+				System.out.println("parameters = "+ Arrays.toString(parameters));
 				var responseBody = method.invoke(instance, parameters);
+				System.out.println("responseBody = "+responseBody);
 
 				var returnType = method.getReturnType();
 				var headers = new HashMap<String,String>();
-				var cookie = new HashMap<String, String>();
+				System.out.println("cookie = "+cookie);
 				HttpStatus httpStatus = null;
 
 				if (instance == null) {
@@ -143,9 +147,8 @@ public class CommandManager {
 	 * @param resources
 	 * @return
 	 */
-	private Object[] makeParameterArgs(Method method, Map<String,String> resources) {
+	private Object[] makeParameterArgs(Method method, Map<String,String> resources, Map<String,String> cookie) {
 		var parameters = method.getParameters();
-		System.out.println("parameters = "+ Arrays.toString(parameters));
 
 		// 파라미터의 수가 더 작아야 한다. HttpClientResponse 객체가 넘어갈 수 있기 때문
 		if (parameters.length < resources.size()) {
@@ -163,7 +166,7 @@ public class CommandManager {
 			}
 
 			if (Objects.equals(parameterType, HttpClientResponse.class)) {
-				result[idx++] = new HttpClientResponse();
+				result[idx++] = new HttpClientResponse(cookie);
 			} else if (!Objects.isNull(resources.get(requestParamAnnotation.name()))) {
 				setParameterArgs(result, idx++, parameterType, resources.get(requestParamAnnotation.name()));
 			} else {

--- a/src/main/java/codesquad/command/annotation/RequestParam.java
+++ b/src/main/java/codesquad/command/annotation/RequestParam.java
@@ -1,0 +1,12 @@
+package codesquad.command.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestParam {
+    String name();
+}

--- a/src/main/java/codesquad/command/domain/UserDomain.java
+++ b/src/main/java/codesquad/command/domain/UserDomain.java
@@ -1,11 +1,16 @@
 package codesquad.command.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import codesquad.command.annotation.RequestParam;
 import codesquad.command.annotation.method.Command;
+import codesquad.command.annotation.method.GetMapping;
 import codesquad.command.annotation.method.PostMapping;
 import codesquad.command.annotation.redirect.Redirect;
+import codesquad.command.domainResponse.HttpClientRequest;
 import codesquad.command.domainResponse.HttpClientResponse;
 import codesquad.command.model.User;
 import codesquad.command.model.UserInfo;
@@ -36,7 +41,7 @@ public class UserDomain {
 		return User.getInstance().getUserInfo(userId);
 	}
 
-	@Redirect(redirection = "/index.html")
+	@Redirect(redirection = "/main/index.html")
 	@PostMapping(httpStatus = HttpStatus.FOUND, path = "/user/login")
 	public void login(@RequestParam(name = "userId") String userId, @RequestParam(name = "password") String password, HttpClientResponse response) {
 		System.out.println("userId = " + userId);
@@ -57,5 +62,13 @@ public class UserDomain {
 
 	}
 
+	@Redirect(redirection = "/index.html")
+	@PostMapping(httpStatus = HttpStatus.FOUND, path = "/user/logout")
+	public void logout(HttpClientRequest request, HttpClientResponse response) {
+		var cookie = request.getCookie("sessionKey");
+		User.getInstance().deleteUserInfo(cookie.key());
+		response.setCookie("sessionKey", "");
+		response.setMaxAge(cookie.key(), 0);
+	}
 
 }

--- a/src/main/java/codesquad/command/domain/UserDomain.java
+++ b/src/main/java/codesquad/command/domain/UserDomain.java
@@ -8,9 +8,11 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
+import codesquad.command.annotation.RequestParam;
 import codesquad.command.annotation.method.Command;
 import codesquad.command.annotation.method.PostMapping;
 import codesquad.command.annotation.redirect.Redirect;
+import codesquad.command.domainResponse.HttpClientResponse;
 import codesquad.command.model.User;
 import codesquad.command.model.UserInfo;
 import codesquad.exception.CustomException;
@@ -29,54 +31,17 @@ public class UserDomain {
 	}
 
 	@Redirect(redirection = "/index.html")
-	@PostMapping(httpStatus = HttpStatus.CONFLICT, path = "/user/create")
-	public UserInfo createUser(String queryParameter) {
-		var parsingUserInfo = parsingResources(queryParameter);
-
-		RecordComponent[] recordComponents = UserInfo.class.getRecordComponents();
-		if (parsingUserInfo.size() != recordComponents.length) {
-			throw ClientErrorCode.PARAMETER_FORMAT_EXCEPTION.exception();
-		}
-
-
-		int idx = 0;
-		for (List info : parsingUserInfo) {
-			if (!Objects.equals(info.get(0), recordComponents[idx++].getName())) {
-				throw ClientErrorCode.PARAMETER_FORMAT_EXCEPTION.exception();
-			}
-		}
-
-
-		var userId = parsingUserInfo.get(0).get(1);
-		var password = parsingUserInfo.get(1).get(1);
-		var name = parsingUserInfo.get(2).get(1);
-		var email = parsingUserInfo.get(3).get(1);
+	@PostMapping(httpStatus = HttpStatus.FOUND, path = "/user/create")
+	public UserInfo createUser(@RequestParam(name = "userId") String userId, @RequestParam(name = "password")String password, @RequestParam(name = "name")String name, @RequestParam(name = "email")String email) {
 		var userInfo = new UserInfo(userId, password, name, email);
-
 		User.getInstance().addUserInfo(userInfo);
 
 		return User.getInstance().getUserInfo(userId);
 	}
 
-	public List<List<String>> parsingResources(String resources) {
-		var userData = resources.split(QUERY_PARAMETER_SEPARATOR);
-		var parsingUserInfo = new ArrayList<List<String>>();
-
-
-		try {
-			for (String data : userData) {
-				var info = data.split(EQUAL_SEPARATOR);
-				if (info.length != 2) {
-					throw ClientErrorCode.PARAMETER_FORMAT_EXCEPTION.exception();
-				}
-				parsingUserInfo.add(List.of(info[0], URLDecoder.decode(info[1], "UTF-8")));
-			}
-		}catch (CustomException exception){
-			throw exception;
-		} catch (UnsupportedEncodingException exception) {
-			throw new RuntimeException(exception);
-		}
-
-		return parsingUserInfo;
+	@PostMapping(httpStatus = HttpStatus.OK, path = "/user/login")
+	public void login(@RequestParam(name = "userId") String userId, @RequestParam(name = "password") String password, HttpClientResponse response) {
+		
 	}
+
 }

--- a/src/main/java/codesquad/command/domainResponse/DomainResponse.java
+++ b/src/main/java/codesquad/command/domainResponse/DomainResponse.java
@@ -2,12 +2,14 @@ package codesquad.command.domainResponse;
 
 import codesquad.http.HttpStatus;
 
+import java.util.List;
 import java.util.Map;
 
 public record DomainResponse(
 	HttpStatus httpStatus,
 	Map<String,String> headers,
 	Map<String,String> cookie,
+	Map<String, List<String>> cookieOptions,
 	boolean hasBody,
 	Class<?> classType,
 	Object returnValue

--- a/src/main/java/codesquad/command/domainResponse/DomainResponse.java
+++ b/src/main/java/codesquad/command/domainResponse/DomainResponse.java
@@ -7,8 +7,13 @@ import java.util.Map;
 public record DomainResponse(
 	HttpStatus httpStatus,
 	Map<String,String> headers,
+	Map<String,String> cookie,
 	boolean hasBody,
 	Class<?> classType,
 	Object returnValue
 ) {
+
+	public void setCookie(String key, String returnValue) {
+		cookie.put(key, returnValue);
+	}
 }

--- a/src/main/java/codesquad/command/domainResponse/HttpClientRequest.java
+++ b/src/main/java/codesquad/command/domainResponse/HttpClientRequest.java
@@ -1,0 +1,20 @@
+package codesquad.command.domainResponse;
+
+import codesquad.http.request.format.HttpRequest;
+import codesquad.session.Cookie;
+
+import java.util.Map;
+
+public class HttpClientRequest {
+    Map<String,String> headers;
+    Map<String, Cookie> cookies;
+
+    public HttpClientRequest(HttpRequest httpRequest) {
+        this.headers = httpRequest.headers();
+        this.cookies = httpRequest.cookie();
+    }
+
+    public Cookie getCookie(String cookieName) {
+        return cookies.get(cookieName);
+    }
+}

--- a/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
+++ b/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
@@ -1,16 +1,32 @@
 package codesquad.command.domainResponse;
 
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
 public class HttpClientResponse {
     private Map<String,String> cookie;
 
-    public HttpClientResponse() {
-        this.cookie = new HashMap<>();
+    public HttpClientResponse(Map<String,String> cookie) {
+        this.cookie = cookie;
     }
 
     public void setCookie(String key, String value) {
+        encrypt(value);
         this.cookie.put(key, value);
+    }
+
+    public byte[] encrypt(String value) {
+        try{
+            MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
+            messageDigest.update(value.getBytes());
+            byte[] digest = messageDigest.digest();
+            System.out.println("digest = "+ Arrays.toString(digest));
+            return digest;
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
+++ b/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
@@ -1,0 +1,16 @@
+package codesquad.command.domainResponse;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpClientResponse {
+    private Map<String,String> cookie;
+
+    public HttpClientResponse() {
+        this.cookie = new HashMap<>();
+    }
+
+    public void setCookie(String key, String value) {
+        this.cookie.put(key, value);
+    }
+}

--- a/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
+++ b/src/main/java/codesquad/command/domainResponse/HttpClientResponse.java
@@ -2,20 +2,45 @@ package codesquad.command.domainResponse;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 public class HttpClientResponse {
+    private Map<String,String> headers;
     private Map<String,String> cookie;
+    private Map<String, List<String>> cookieOptions;
 
-    public HttpClientResponse(Map<String,String> cookie) {
-        this.cookie = cookie;
+    public HttpClientResponse() {
+        this.headers = new HashMap<>();
+        this.cookie = new HashMap<>();
+        this.cookieOptions = new HashMap<>();
     }
 
+    public Map<String, String> getHeaders() {
+        return this.headers;
+    }
+
+    public void setHeader(String key, String value) {
+        this.headers.put(key, value);
+    }
+
+    public Map<String, String> getCookie() {
+        return this.cookie;
+    }
     public void setCookie(String key, String value) {
         encrypt(value);
         this.cookie.put(key, value);
+    }
+
+    public void setMaxAge(String key, int value) {
+        if (cookieOptions.containsKey(key)) {
+            cookieOptions.get(key).add("Max-Age="+value);
+        } else {
+            cookieOptions.put(key, new ArrayList<>(List.of("Max-Age="+value)));
+        }
+    }
+
+    public Map<String, List<String>> getCookieOptions() {
+        return this.cookieOptions;
     }
 
     public byte[] encrypt(String value) {

--- a/src/main/java/codesquad/command/model/User.java
+++ b/src/main/java/codesquad/command/model/User.java
@@ -29,4 +29,5 @@ public class User {
 	public UserInfo getUserInfo(String userId) {
 		return userData.get(userId);
 	}
+
 }

--- a/src/main/java/codesquad/command/model/User.java
+++ b/src/main/java/codesquad/command/model/User.java
@@ -30,4 +30,8 @@ public class User {
 		return userData.get(userId);
 	}
 
+	public void deleteUserInfo(String userId) {
+		userData.remove(userId);
+	}
+
 }

--- a/src/main/java/codesquad/command/model/User.java
+++ b/src/main/java/codesquad/command/model/User.java
@@ -17,12 +17,13 @@ public class User {
 	}
 
 	public void addUserInfo(UserInfo userInfo) {
-		if (!Objects.isNull(userData.get(userInfo.userId()))) {
+		UserInfo value = userData.putIfAbsent(userInfo.userId(), userInfo);
+
+		// null이 아니면 기존에 값이 있다는 것을 의미
+		if (!Objects.isNull(value)) {
 			throw ClientErrorCode.USERID_ALREADY_EXISTS.exception();
 		}
 
-		userData.compute(userInfo.userId(), (k, v) -> v == null ? userInfo : v); // null일 때만 userInfo를 넣어준다.
-		userData.put(userInfo.userId(), userInfo);
 	}
 
 	public UserInfo getUserInfo(String userId) {

--- a/src/main/java/codesquad/exception/client/ClientErrorCode.java
+++ b/src/main/java/codesquad/exception/client/ClientErrorCode.java
@@ -7,8 +7,10 @@ public enum ClientErrorCode {
     URI_TOO_LONG(HttpStatus.URI_TOO_LONG,"네트워크에 문제가 발생했습니다."),
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "올바른 HTTP 메소드가 아닙니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "유효하지 않은 요청입니다. 요청 경로를 확인해 주세요."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 사용자입니다. 회원가입을 해주세요"),
     USERID_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
-    PARAMETER_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "입력 데이터 형식이 일치하지 않습니다. 입력값을 다시 확인해 주세요.");
+    PARAMETER_FORMAT_EXCEPTION(HttpStatus.BAD_REQUEST, "입력 데이터 형식이 일치하지 않습니다. 입력값을 다시 확인해 주세요."),
+    ;
 
     private HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/codesquad/exception/server/ServerErrorCode.java
+++ b/src/main/java/codesquad/exception/server/ServerErrorCode.java
@@ -5,7 +5,8 @@ import codesquad.http.HttpStatus;
 
 public enum ServerErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"서버에 문제가 발생했습니다."),
-    SOCKET_CLOSED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"네트워크에 문제가 발생했습니다.");
+    SOCKET_CLOSED_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,"네트워크에 문제가 발생했습니다."),
+    CANNOT_CREATE_SESSION(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 생겨 로그인을 할 수 없습니다. 잠시 후에 다시 시도해 주세요.");
 
     private HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/codesquad/http/parser/HttpRequestParser.java
+++ b/src/main/java/codesquad/http/parser/HttpRequestParser.java
@@ -92,7 +92,10 @@ public class HttpRequestParser extends Thread{
     public String getBody(String[] lines, int bodyIdx) {
         StringBuilder sb = new StringBuilder();
         for (; bodyIdx < lines.length; bodyIdx++) {
-            sb.append(lines[bodyIdx]).append("\n");
+            sb.append(lines[bodyIdx]);
+            if (bodyIdx != lines.length-1) {
+                sb.append("\n");
+            }
         }
 
         return sb.toString();

--- a/src/main/java/codesquad/http/request/dynamichandler/DynamicHandleResult.java
+++ b/src/main/java/codesquad/http/request/dynamichandler/DynamicHandleResult.java
@@ -25,6 +25,10 @@ public record DynamicHandleResult(
 			fileExtension = FileExtension.HTML;
 		}
 
+		for (Map.Entry<String, String> entry : domainResponse.cookie().entrySet()) {
+			domainResponse.headers().put("Set-Cookie", entry.getKey()+"="+entry.getValue()+ "; Path=/");
+		}
+
 		return new DynamicHandleResult(httpStatus, domainResponse.headers(), hasBody, fileExtension, body);
 	}
 }

--- a/src/main/java/codesquad/http/request/dynamichandler/DynamicHandleResult.java
+++ b/src/main/java/codesquad/http/request/dynamichandler/DynamicHandleResult.java
@@ -7,6 +7,9 @@ import java.util.Objects;
 import codesquad.command.domainResponse.DomainResponse;
 import codesquad.http.HttpStatus;
 import codesquad.util.FileExtension;
+import codesquad.util.StringSeparator;
+
+import static codesquad.util.StringSeparator.*;
 
 public record DynamicHandleResult(
 	HttpStatus httpStatus,
@@ -25,8 +28,20 @@ public record DynamicHandleResult(
 			fileExtension = FileExtension.HTML;
 		}
 
+		var cookieOptions = domainResponse.cookieOptions();
 		for (Map.Entry<String, String> entry : domainResponse.cookie().entrySet()) {
-			domainResponse.headers().put("Set-Cookie", entry.getKey()+"="+entry.getValue()+ "; Path=/");
+			var key = entry.getKey();
+			var value =entry.getValue();
+			var cookieValue = new StringBuilder(key).append(EQUAL_SEPARATOR).append(value).append(";");
+			var options = cookieOptions.get(key);
+			if (!Objects.isNull(options)) {
+				for (String option : options) {
+					cookieValue.append(SPACE_SEPARATOR).append(option).append(";");
+				}
+			}
+
+			cookieValue.append(" Path=/");
+			domainResponse.headers().put("Set-Cookie", cookieValue.toString());
 		}
 
 		return new DynamicHandleResult(httpStatus, domainResponse.headers(), hasBody, fileExtension, body);

--- a/src/main/java/codesquad/http/request/dynamichandler/DynamicResourceHandler.java
+++ b/src/main/java/codesquad/http/request/dynamichandler/DynamicResourceHandler.java
@@ -24,6 +24,8 @@ public class DynamicResourceHandler {
 			default -> throw ClientErrorCode.METHOD_NOT_ALLOWED.exception();
 		}
 
+		System.out.println("dynamicHandlerResult = "+dynamicHandleResult);
+
 		return dynamicHandleResult;
 	}
 }

--- a/src/main/java/codesquad/http/request/dynamichandler/methodhandler/GetHandler.java
+++ b/src/main/java/codesquad/http/request/dynamichandler/methodhandler/GetHandler.java
@@ -23,9 +23,8 @@ public class GetHandler {
 			var pathAndData = httpRequest.uri().split("\\?");
 			var path = pathAndData[0];
 			var resources = pathAndData[1];
-			DomainResponse domainResponse = CommandManager.getInstance().execute(httpRequest.method(), path, resources);
+			DomainResponse domainResponse = CommandManager.getInstance().execute(httpRequest);
 			dynamicHandleResult = DynamicHandleResult.of(domainResponse);
-
 		}
 
 		return dynamicHandleResult;

--- a/src/main/java/codesquad/http/request/dynamichandler/methodhandler/PostHandler.java
+++ b/src/main/java/codesquad/http/request/dynamichandler/methodhandler/PostHandler.java
@@ -15,7 +15,7 @@ public class PostHandler {
     }
 
     public DynamicHandleResult doPost(HttpRequest httpRequest) {
-        DomainResponse domainResponse = CommandManager.getInstance().execute(httpRequest.method(), httpRequest.uri(), httpRequest.body());
+        DomainResponse domainResponse = CommandManager.getInstance().execute(httpRequest);
         return DynamicHandleResult.of(domainResponse);
     }
 }

--- a/src/main/java/codesquad/http/request/format/HttpRequest.java
+++ b/src/main/java/codesquad/http/request/format/HttpRequest.java
@@ -2,6 +2,7 @@ package codesquad.http.request.format;
 
 import java.util.Map;
 
+import codesquad.session.Cookie;
 import codesquad.util.FileExtension;
 
 public record HttpRequest(
@@ -10,6 +11,7 @@ public record HttpRequest(
 	FileExtension fileExtension,
     String httpVersion,
     Map<String, String> headers,
+	Map<String, Cookie> cookie,
     String body
 
 ) {

--- a/src/main/java/codesquad/http/response/format/HttpResponse.java
+++ b/src/main/java/codesquad/http/response/format/HttpResponse.java
@@ -25,6 +25,7 @@ public record HttpResponse(
         var responseHeaders = new HashMap<String, String>();
         responseHeaders.put("Content-Type", fileExtension.getContentType());
         responseHeaders.put("Content-Length", String.valueOf(body.length));
+        responseHeaders.put("Set-Cookie", "test=zzz");
 
         return new HttpResponse(httpStatus, "HTTP/1.1", responseHeaders, body);
     }

--- a/src/main/java/codesquad/session/Cookie.java
+++ b/src/main/java/codesquad/session/Cookie.java
@@ -1,0 +1,8 @@
+package codesquad.session;
+
+public record Cookie(
+        String key,
+        String value
+) {
+
+}

--- a/src/main/java/codesquad/session/Session.java
+++ b/src/main/java/codesquad/session/Session.java
@@ -1,0 +1,27 @@
+package codesquad.session;
+
+import java.net.CookieManager;
+import java.net.HttpCookie;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class Session {
+    private static final Session session = new Session();
+    private static final Map<Integer, SessionUserInfo> sessionInfo = new ConcurrentHashMap<>();
+
+    private Session() {
+
+    }
+
+    public static Session getInstance() {
+        return session;
+    }
+    public void setSession() {
+
+    }
+
+    public void setCookie(String key, String value) {
+
+    }
+
+}

--- a/src/main/java/codesquad/session/Session.java
+++ b/src/main/java/codesquad/session/Session.java
@@ -1,13 +1,15 @@
 package codesquad.session;
 
-import java.net.CookieManager;
-import java.net.HttpCookie;
+import codesquad.exception.server.ServerErrorCode;
+
 import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class Session {
     private static final Session session = new Session();
-    private static final Map<Integer, SessionUserInfo> sessionInfo = new ConcurrentHashMap<>();
+    private static final Map<String, SessionUserInfo> sessionInfo = new ConcurrentHashMap<>();
 
     private Session() {
 
@@ -16,12 +18,27 @@ public class Session {
     public static Session getInstance() {
         return session;
     }
-    public void setSession() {
+    public String setSession(SessionUserInfo sessionUserInfo) {
+        System.out.println("session");
+        String sessionKey = UUID.randomUUID().toString();
+        int range = 5;
+        boolean isSuccess = false;
 
+        while (range-- > 0) {
+            // null이 아니면 기존에 값이 있다는 것
+            if (!Objects.isNull(sessionInfo.putIfAbsent(sessionKey, sessionUserInfo))) {
+                isSuccess = true;
+                break;
+            }
+        }
+
+        // 5번만에 성공 못하면 예외 발생
+        if (!isSuccess) {
+            throw ServerErrorCode.CANNOT_CREATE_SESSION.exception();
+        }
+
+        return sessionKey;
     }
 
-    public void setCookie(String key, String value) {
-
-    }
 
 }

--- a/src/main/java/codesquad/session/SessionUserInfo.java
+++ b/src/main/java/codesquad/session/SessionUserInfo.java
@@ -1,0 +1,8 @@
+package codesquad.session;
+
+public record SessionUserInfo(
+        String userId,
+        String userName
+) {
+
+}

--- a/src/main/java/codesquad/util/StringSeparator.java
+++ b/src/main/java/codesquad/util/StringSeparator.java
@@ -10,4 +10,5 @@ public class StringSeparator {
     public static final String COMMA_DELIMITER = ",";
     public static final String CR = "\r";
     public static final String QUERY_PARAMETER_SEPARATOR = "&";
+    public static final String SEMICOLON_SEPARATOR = ";";
 }

--- a/src/main/java/codesquad/webserver/ConnectionHandler.java
+++ b/src/main/java/codesquad/webserver/ConnectionHandler.java
@@ -113,6 +113,7 @@ public class ConnectionHandler {
                 } else {
                     try {
                         Exception exception = (Exception)throwable.getCause();
+                        exception.printStackTrace();
                         var errorResponse = HttpResponse.getErrorResponse(exception);
                         doResponse(clientSocket, errorResponse);
                     } catch (Exception e) {

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -13,7 +13,7 @@
         <a href="/"><img src="./img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            <a class="btn btn_contained btn_size_s" href="/login/index.html">로그인</a>
           </li>
           <li class="header__menu__item">
             <a class="btn btn_ghost btn_size_s" href="/registration/index.html">

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -12,10 +12,10 @@
         <a href="/"><img src="../img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            <a class="btn btn_contained btn_size_s" href="/login/index.html">로그인</a>
           </li>
           <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
+            <a class="btn btn_ghost btn_size_s" href="/registration/index.html">
               회원 가입
             </a>
           </li>
@@ -23,13 +23,14 @@
       </header>
       <div class="page">
         <h2 class="page-title">로그인</h2>
-        <form class="form">
+        <form class="form" method="post" action="/user/login">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">아이디</p>
             <input
               class="input_textfield"
               placeholder="아이디를 입력해주세요"
               autocomplete="username"
+              name="userId"
             />
           </div>
           <div class="textfield textfield_size_s">
@@ -39,13 +40,14 @@
               type="password"
               placeholder="비밀번호를 입력해주세요"
               autocomplete="current-password"
+              name="password"
             />
           </div>
           <button
             id="login-btn"
             class="btn btn_contained btn_size_m"
             style="margin-top: 24px"
-            type="button"
+            type="submit"
           >
             로그인
           </button>

--- a/src/main/resources/static/main/index.html
+++ b/src/main/resources/static/main/index.html
@@ -10,15 +10,18 @@
   <body>
     <div class="container">
       <header class="header">
-        <a href="/main"><img src="../img/signiture.svg" /></a>
+        <a href="/main/index.html"><img src="../img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
             <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
           </li>
           <li class="header__menu__item">
-            <button id="logout-btn" class="btn btn_ghost btn_size_s">
-              로그아웃
-            </button>
+            <form action="/user/logout" method="POST" class="form" enctype="application/x-www-form-urlencoded">
+
+              <button id="logout-btn" class="btn btn_ghost btn_size_s" type = "submit">
+                로그아웃
+              </button>
+            </form>
           </li>
         </ul>
       </header>

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -12,10 +12,10 @@
         <a href="/"><img src="../img/signiture.svg" /></a>
         <ul class="header__menu">
           <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            <a class="btn btn_contained btn_size_s" href="/login/index.html">로그인</a>
           </li>
           <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
+            <a class="btn btn_ghost btn_size_s" href="/registration/index.html">
               회원 가입
             </a>
           </li>

--- a/src/test/java/command/model/UserTest.java
+++ b/src/test/java/command/model/UserTest.java
@@ -1,0 +1,110 @@
+package command.model;
+
+import codesquad.command.model.User;
+import codesquad.command.model.UserInfo;
+import codesquad.exception.CustomException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+
+    String userId = "testId";
+    String userPass = "testPass";
+    String userName = "testName";
+    String userEmail = "testEmail@naver.com";
+    int corePoolSize = 10;
+    int maxPoolSize = 50;
+    int keepAliveTime = 10;
+    int queueCapacity = 10;
+
+    @Nested
+    @DisplayName("유저 클래스 동시성 테스트")
+    class concurrency_test {
+
+        @Test
+        @DisplayName("같은 아이디의 사용자가 있으면, 회원 가입 시에 예외를 반환한다.")
+        void request_with_already_existed_userId() throws InterruptedException {
+            // given
+            User user = User.getInstance();
+            UserInfo userInfo = new UserInfo(userId, userPass, userName, userEmail);
+            user.addUserInfo(userInfo);
+            ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueCapacity));
+            CountDownLatch countDownLatch = new CountDownLatch(queueCapacity);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+            AtomicInteger otherExceptionCount = new AtomicInteger(0);
+
+
+            // when
+            for (int i = 0; i < queueCapacity; i++) {
+                threadPoolExecutor.execute(() -> {
+                    try {
+                        user.addUserInfo(new UserInfo(userId, userPass, userName, userEmail));
+
+                    } catch (CustomException exception) {
+                        exceptionCount.getAndIncrement();
+                    } catch (Exception exception) {
+                        otherExceptionCount.getAndIncrement();
+                    } finally {
+                        countDownLatch.countDown();
+                    }
+                });
+            }
+
+            countDownLatch.await();
+
+            // then
+            assertEquals(exceptionCount.get(), queueCapacity);
+            assertEquals(otherExceptionCount.get(), 0);
+            assertEquals(user.getUserInfo(userId), userInfo);
+        }
+
+        @Test
+        @DisplayName("다른 아이디로 회원가입 하면 정상적으로 사용자 정보가 저장된다.")
+        void request_with_different_user_id() throws InterruptedException {
+            // given
+            User user = User.getInstance();
+            ThreadPoolExecutor threadPoolExecutor = new ThreadPoolExecutor(corePoolSize, maxPoolSize, keepAliveTime, TimeUnit.SECONDS, new LinkedBlockingQueue<>(queueCapacity));
+            CountDownLatch countDownLatch = new CountDownLatch(queueCapacity);
+            AtomicInteger exceptionCount = new AtomicInteger(0);
+            AtomicInteger otherExceptionCount = new AtomicInteger(0);
+            AtomicInteger successCount = new AtomicInteger(0);
+
+
+            // when
+            for (int i = 0; i < queueCapacity; i++) {
+                int idx = i;
+                threadPoolExecutor.execute(() -> {
+                    try {
+                        user.addUserInfo(new UserInfo(userId+idx, userPass, userName, userEmail));
+
+                    } catch (CustomException exception) {
+                        exceptionCount.getAndIncrement();
+                    } catch (Exception exception) {
+                        otherExceptionCount.getAndIncrement();
+                    } finally {
+                        countDownLatch.countDown();
+                        successCount.getAndIncrement();
+                    }
+                });
+            }
+
+            countDownLatch.await();
+
+            // then
+            assertEquals(exceptionCount.get(), 0);
+            assertEquals(otherExceptionCount.get(), 0);
+            assertEquals(successCount.get(), queueCapacity);
+        }
+    }
+}

--- a/src/test/java/command/model/UserTest.java
+++ b/src/test/java/command/model/UserTest.java
@@ -12,6 +12,9 @@ import java.net.CookieManager;
 import java.net.CookieStore;
 import java.net.HttpCookie;
 import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -114,11 +117,11 @@ class UserTest {
 
     @Test
     void test() {
-        HttpCookie httpCookie = new HttpCookie("test", "value");
-        System.out.println(httpCookie);
-        CookieManager cookieManager = new CookieManager();
-        CookieStore cookieStore = cookieManager.getCookieStore();
-        cookieStore.add(URI.create("test"), httpCookie);
-        System.out.println(cookieStore.get(URI.create("test")));
+        List<Map> list = new ArrayList<>();
+        list.add(Map.of(1, 2));
+        list.add(Map.of(3, 4));
+
+        list.stream()
+                .forEach(System.out::println);
     }
 }

--- a/src/test/java/command/model/UserTest.java
+++ b/src/test/java/command/model/UserTest.java
@@ -8,6 +8,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.net.CookieManager;
+import java.net.CookieStore;
+import java.net.HttpCookie;
+import java.net.URI;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -106,5 +110,15 @@ class UserTest {
             assertEquals(otherExceptionCount.get(), 0);
             assertEquals(successCount.get(), queueCapacity);
         }
+    }
+
+    @Test
+    void test() {
+        HttpCookie httpCookie = new HttpCookie("test", "value");
+        System.out.println(httpCookie);
+        CookieManager cookieManager = new CookieManager();
+        CookieStore cookieStore = cookieManager.getCookieStore();
+        cookieStore.add(URI.create("test"), httpCookie);
+        System.out.println(cookieStore.get(URI.create("test")));
     }
 }


### PR DESCRIPTION
## 구현 내용
- ConcurrentHashMap을 사용했을 때 미쳐 발견하지 못한 동시성 이슈가 있어서 수정했습니다.
   - 기존에는 containsKey()로 확인 후 compute()로 값을 갱신했지만, containsKey()를 동시에 실행할 수 있어서 문제가 발생할 수 있습니다.
   - putIfAbsent() 메소드의 리턴 값을 활용하여 해당 아이디로 처음 생성한 사용자의 정보만 저장할 수 있도록 했습니다.
- 사용자 정보를 파싱하는 메소드를 사용했지만, 새로운 요구사항에 따라 해당 기능이 여러 곳에서 중복된다고 생각했고, 이를 파싱하고 파라미터에 매핑까지 해주는 어노테이션을 만들어서 공통으로 처리하도록 했습니다.
- 쿠키 값을 헤더에 저장해서 활용했는데, 별도의 클래스로 분리하여 관리하도록 했습니다.  
- 세션의 UUID도 중복될 가능성이 있기 때문에 일정 횟수를 반복하여 재시도하고 실패하면 예외를 던지도록 했습니다.

## 고민 사항
- 비즈니스 로직에 접근하기 전 리플렉션을 활용하여 메소드를 찾고, 요청 정보에 따라 파라미터에 값을 넣어주고, 요청 데이터에 문제가 없는지 확인하고 있습니다. 기능이 추가됨에 따라 해당 클래스의 기능이 많아지는데 어떻게 구분하면 좋을지 고민입니다.
- 현재 리플렉션을 사용하지 않다가 추가하여 불필요한 계층이 많아 보이는데, 이것도 조금 줄이면 좋을 것 같습니다.

## 기타
- 테스트를 한 번에 몰아서 작성할 것 같습니다.
