### PR TITLE
[김준기] step-5 쿠키를 이용한 로그인

### DIFF
--- a/src/main/java/codesquad/domain/model/User.java
+++ b/src/main/java/codesquad/domain/model/User.java
@@ -27,4 +27,9 @@ public class User {
     public String getUserId() {
         return userId;
     }
+
+    public String getPassword() {
+        return password;
+    }
+    
 }

--- a/src/main/java/codesquad/servlet/SessionStorage.java
+++ b/src/main/java/codesquad/servlet/SessionStorage.java
@@ -19,4 +19,8 @@ public class SessionStorage {
         return sessions.get(uuid);
     }
 
+    public void removeSessionValue(String uuid) {
+        sessions.remove(uuid);
+    }
+
 }

--- a/src/main/java/codesquad/servlet/SessionStorage.java
+++ b/src/main/java/codesquad/servlet/SessionStorage.java
@@ -1,0 +1,22 @@
+package codesquad.servlet;
+
+import codesquad.domain.model.User;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class SessionStorage {
+
+    private final Map<String, User> sessions = new ConcurrentHashMap<>();
+
+    public String createSession(User user) {
+        String uuid = UUID.randomUUID().toString();
+        sessions.put(uuid, user);
+        return uuid;
+    }
+
+    public User getSessionValue(String uuid) {
+        return sessions.get(uuid);
+    }
+
+}

--- a/src/main/java/codesquad/servlet/handler/HandlerMapper.java
+++ b/src/main/java/codesquad/servlet/handler/HandlerMapper.java
@@ -3,6 +3,7 @@ package codesquad.servlet.handler;
 import codesquad.domain.InMemoryUserStorage;
 import codesquad.servlet.SessionStorage;
 import codesquad.servlet.handler.api.UserLoginHandler;
+import codesquad.servlet.handler.api.UserLogoutHandler;
 import codesquad.servlet.handler.api.UserRegistrationHandler;
 import codesquad.webserver.http.HttpMethod;
 import java.util.HashMap;
@@ -21,7 +22,7 @@ public class HandlerMapper {
 
         InMemoryUserStorage inMemoryUserStorage = new InMemoryUserStorage();
         SessionStorage sessionStorage = new SessionStorage();
-        
+
         handlers.get(HttpMethod.POST)
                 .put("/user/create", new UserRegistrationHandler(
                         inMemoryUserStorage,
@@ -31,6 +32,9 @@ public class HandlerMapper {
                 .put("/user/login", new UserLoginHandler(
                         inMemoryUserStorage,
                         sessionStorage));
+
+        handlers.get(HttpMethod.POST)
+                .put("/user/logout", new UserLogoutHandler(sessionStorage));
     }
 
     public Optional<Handler> findBy(HttpMethod httpMethod, String path) {

--- a/src/main/java/codesquad/servlet/handler/HandlerMapper.java
+++ b/src/main/java/codesquad/servlet/handler/HandlerMapper.java
@@ -1,6 +1,7 @@
 package codesquad.servlet.handler;
 
 import codesquad.domain.InMemoryUserStorage;
+import codesquad.servlet.SessionStorage;
 import codesquad.servlet.handler.api.UserRegistrationHandler;
 import codesquad.webserver.http.HttpMethod;
 import java.util.HashMap;
@@ -16,7 +17,11 @@ public class HandlerMapper {
         for (HttpMethod httpMethod : HttpMethod.values()) {
             handlers.put(httpMethod, new HashMap<>());
         }
-        handlers.get(HttpMethod.POST).put("/create", new UserRegistrationHandler(new InMemoryUserStorage()));
+        handlers.get(HttpMethod.POST)
+                .put("/create", new UserRegistrationHandler(
+                        new InMemoryUserStorage(),
+                        new SessionStorage())
+                );
     }
 
     public Optional<Handler> findBy(HttpMethod httpMethod, String path) {

--- a/src/main/java/codesquad/servlet/handler/HandlerMapper.java
+++ b/src/main/java/codesquad/servlet/handler/HandlerMapper.java
@@ -2,6 +2,7 @@ package codesquad.servlet.handler;
 
 import codesquad.domain.InMemoryUserStorage;
 import codesquad.servlet.SessionStorage;
+import codesquad.servlet.handler.api.UserLoginHandler;
 import codesquad.servlet.handler.api.UserRegistrationHandler;
 import codesquad.webserver.http.HttpMethod;
 import java.util.HashMap;
@@ -17,11 +18,19 @@ public class HandlerMapper {
         for (HttpMethod httpMethod : HttpMethod.values()) {
             handlers.put(httpMethod, new HashMap<>());
         }
+
+        InMemoryUserStorage inMemoryUserStorage = new InMemoryUserStorage();
+        SessionStorage sessionStorage = new SessionStorage();
+        
         handlers.get(HttpMethod.POST)
-                .put("/create", new UserRegistrationHandler(
-                        new InMemoryUserStorage(),
-                        new SessionStorage())
-                );
+                .put("/user/create", new UserRegistrationHandler(
+                        inMemoryUserStorage,
+                        sessionStorage));
+
+        handlers.get(HttpMethod.POST)
+                .put("/user/login", new UserLoginHandler(
+                        inMemoryUserStorage,
+                        sessionStorage));
     }
 
     public Optional<Handler> findBy(HttpMethod httpMethod, String path) {

--- a/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
@@ -1,0 +1,50 @@
+package codesquad.servlet.handler.api;
+
+import codesquad.domain.InMemoryUserStorage;
+import codesquad.domain.model.User;
+import codesquad.servlet.SessionStorage;
+import codesquad.servlet.handler.Handler;
+import codesquad.webserver.http.Cookie;
+import codesquad.webserver.http.HttpRequest;
+import codesquad.webserver.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserLoginHandler implements Handler {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserRegistrationHandler.class);
+    private final InMemoryUserStorage inMemoryUserStorage;
+    private final SessionStorage sessionStorage;
+
+    public UserLoginHandler(InMemoryUserStorage inMemoryUserStorage, SessionStorage sessionStorage) {
+        this.inMemoryUserStorage = inMemoryUserStorage;
+        this.sessionStorage = sessionStorage;
+    }
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) {
+
+        String userId = request.getBodyParamValue("userId");
+        String password = request.getBodyParamValue("password");
+
+        logger.debug("userId = {}, password = {}", userId, password);
+        logger.debug("inMemoryUserStorage.getUsers = {}", inMemoryUserStorage.getUsers());
+
+        User findUser = inMemoryUserStorage.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));
+
+        if (!findUser.getPassword().equals(password)) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        String createdSessionId = sessionStorage.createSession(findUser);
+        logger.debug("created session id: {}", createdSessionId);
+
+        Cookie cookie = new Cookie("sid", createdSessionId);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+        logger.debug("crated cookie: {}", cookie);
+        response.sendRedirect("/index.html");
+    }
+
+}

--- a/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
@@ -28,7 +28,6 @@ public class UserLoginHandler implements Handler {
         String password = request.getBodyParamValue("password");
 
         logger.debug("userId = {}, password = {}", userId, password);
-        logger.debug("inMemoryUserStorage.getUsers = {}", inMemoryUserStorage.getUsers());
 
         User findUser = inMemoryUserStorage.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 아이디입니다."));

--- a/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserLoginHandler.java
@@ -43,7 +43,7 @@ public class UserLoginHandler implements Handler {
         cookie.setPath("/");
         response.addCookie(cookie);
         logger.debug("crated cookie: {}", cookie);
-        response.sendRedirect("/index.html");
+        response.sendRedirect("/main");
     }
 
 }

--- a/src/main/java/codesquad/servlet/handler/api/UserLogoutHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserLogoutHandler.java
@@ -1,0 +1,35 @@
+package codesquad.servlet.handler.api;
+
+import codesquad.servlet.SessionStorage;
+import codesquad.servlet.handler.Handler;
+import codesquad.webserver.http.Cookie;
+import codesquad.webserver.http.HttpRequest;
+import codesquad.webserver.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UserLogoutHandler implements Handler {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserRegistrationHandler.class);
+    private final SessionStorage sessionStorage;
+
+    public UserLogoutHandler(SessionStorage sessionStorage) {
+        this.sessionStorage = sessionStorage;
+    }
+
+    @Override
+    public void service(HttpRequest request, HttpResponse response) {
+        Cookie cookie = request.getCookie();
+        logger.debug("cookie: {}", cookie);
+        if (cookie == null || !cookie.getName().equals("sid")) {
+            response.unauthorized();
+            return;
+        }
+
+        sessionStorage.removeSessionValue(cookie.getValue());
+        cookie.expire();
+        logger.debug("cookie: {}", cookie);
+        response.addCookie(cookie);
+        response.sendRedirect("/index.html");
+    }
+}

--- a/src/main/java/codesquad/servlet/handler/api/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserRegistrationHandler.java
@@ -2,7 +2,9 @@ package codesquad.servlet.handler.api;
 
 import codesquad.domain.InMemoryUserStorage;
 import codesquad.domain.model.User;
+import codesquad.servlet.SessionStorage;
 import codesquad.servlet.handler.Handler;
+import codesquad.webserver.http.Cookie;
 import codesquad.webserver.http.HttpRequest;
 import codesquad.webserver.http.HttpResponse;
 import java.util.Optional;
@@ -13,9 +15,11 @@ public class UserRegistrationHandler implements Handler {
 
     private static final Logger logger = LoggerFactory.getLogger(UserRegistrationHandler.class);
     private final InMemoryUserStorage inMemoryUserStorage;
+    private final SessionStorage sessionStorage;
 
-    public UserRegistrationHandler(InMemoryUserStorage inMemoryUserStorage) {
+    public UserRegistrationHandler(InMemoryUserStorage inMemoryUserStorage, SessionStorage sessionStorage) {
         this.inMemoryUserStorage = inMemoryUserStorage;
+        this.sessionStorage = sessionStorage;
     }
 
     @Override
@@ -28,7 +32,15 @@ public class UserRegistrationHandler implements Handler {
         User user = new User(userId, password, name, email);
         inMemoryUserStorage.save(user);
         Optional<User> savedUser = inMemoryUserStorage.findById(user.getUserId());
-        logger.debug("User Registration Success = {}", savedUser);
+        logger.debug("saved user: {}", savedUser);
+
+        String createdSessionId = sessionStorage.createSession(user);
+        logger.debug("created session id: {}", createdSessionId);
+
+        Cookie cookie = new Cookie("sid", createdSessionId);
+        cookie.setPath("/");
+        response.addCookie(cookie);
+        logger.debug("crated cookie: {}", cookie);
         response.sendRedirect("/index.html");
     }
 

--- a/src/main/java/codesquad/servlet/handler/api/UserRegistrationHandler.java
+++ b/src/main/java/codesquad/servlet/handler/api/UserRegistrationHandler.java
@@ -4,7 +4,6 @@ import codesquad.domain.InMemoryUserStorage;
 import codesquad.domain.model.User;
 import codesquad.servlet.SessionStorage;
 import codesquad.servlet.handler.Handler;
-import codesquad.webserver.http.Cookie;
 import codesquad.webserver.http.HttpRequest;
 import codesquad.webserver.http.HttpResponse;
 import java.util.Optional;
@@ -33,14 +32,6 @@ public class UserRegistrationHandler implements Handler {
         inMemoryUserStorage.save(user);
         Optional<User> savedUser = inMemoryUserStorage.findById(user.getUserId());
         logger.debug("saved user: {}", savedUser);
-
-        String createdSessionId = sessionStorage.createSession(user);
-        logger.debug("created session id: {}", createdSessionId);
-
-        Cookie cookie = new Cookie("sid", createdSessionId);
-        cookie.setPath("/");
-        response.addCookie(cookie);
-        logger.debug("crated cookie: {}", cookie);
         response.sendRedirect("/index.html");
     }
 

--- a/src/main/java/codesquad/servlet/handler/resource/StaticResourceHandler.java
+++ b/src/main/java/codesquad/servlet/handler/resource/StaticResourceHandler.java
@@ -1,6 +1,5 @@
 package codesquad.servlet.handler.resource;
 
-import static codesquad.webserver.http.HttpStatus.NOT_FOUND;
 import static codesquad.webserver.http.HttpStatus.OK;
 
 import codesquad.servlet.handler.Handler;
@@ -47,10 +46,7 @@ public class StaticResourceHandler implements Handler {
             response.setBody(body);
 
         } catch (FileNotFoundException e) {
-            response.setHttpResponseLine(new HttpResponseLine(httpVersion, NOT_FOUND));
-            byte[] notFound = NOT_FOUND.getRepresentation()
-                    .getBytes(); // TODO: BODY X, 중복된 코드 -> HttpResponse 에서 한 번에 처리하면 되지 않을까?
-            response.setBody(notFound);
+            response.notFound();
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/codesquad/servlet/handler/resource/StaticResourceHandler.java
+++ b/src/main/java/codesquad/servlet/handler/resource/StaticResourceHandler.java
@@ -44,7 +44,6 @@ public class StaticResourceHandler implements Handler {
 
             response.setHttpResponseLine(new HttpResponseLine(httpVersion, OK));
             response.setContentType(httpMediaType);
-            response.setContentLength(body.length);
             response.setBody(body);
 
         } catch (FileNotFoundException e) {
@@ -52,7 +51,6 @@ public class StaticResourceHandler implements Handler {
             byte[] notFound = NOT_FOUND.getRepresentation()
                     .getBytes(); // TODO: BODY X, 중복된 코드 -> HttpResponse 에서 한 번에 처리하면 되지 않을까?
             response.setBody(notFound);
-            response.setContentLength(notFound.length);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/codesquad/webserver/http/Cookie.java
+++ b/src/main/java/codesquad/webserver/http/Cookie.java
@@ -1,0 +1,87 @@
+package codesquad.webserver.http;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+public class Cookie {
+
+    private static final String PATH = "Path";
+    private static final String DOMAIN = "Domain";
+    private static final String MAX_AGE = "Max-Age";
+    private static final String SECURE = "Secure";
+    private static final String HTTP_ONLY = "HttpOnly";
+
+    private String name;
+    private String value;
+
+    private Map<String, String> attributes = new HashMap<>();
+
+    public Cookie(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public Map<String, String> getAttributes() {
+        return Collections.unmodifiableMap(attributes);
+    }
+
+    public void setPath(String uri) {
+        attributes.put(PATH, uri);
+    }
+
+    public void setHttpOnly(boolean httpOnly) {
+        if (httpOnly) {
+            attributes.put(HTTP_ONLY, "");
+        }
+    }
+
+    public void setSecure(boolean secure) {
+        if (secure) {
+            attributes.put(SECURE, "");
+        }
+    }
+
+    public void setMaxAge(int maxAge) {
+        attributes.put(MAX_AGE, Integer.toString(maxAge));
+    }
+
+    public void setDomain(String domain) {
+        attributes.put(DOMAIN, domain);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Cookie cookie = (Cookie) o;
+        return Objects.equals(name, cookie.name) && Objects.equals(value, cookie.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return "Cookie{" +
+                "name='" + name + '\'' +
+                ", value='" + value + '\'' +
+                ", attributes=" + attributes +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/webserver/http/Cookie.java
+++ b/src/main/java/codesquad/webserver/http/Cookie.java
@@ -23,6 +23,12 @@ public class Cookie {
         this.value = value;
     }
 
+    public void expire() {
+        value = "";
+        setPath("/");
+        setMaxAge(0);
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/codesquad/webserver/http/HttpHeaders.java
+++ b/src/main/java/codesquad/webserver/http/HttpHeaders.java
@@ -66,9 +66,13 @@ public class HttpHeaders {
     }
 
     public enum HeaderName {
+        DATE("Date"),
+        SERVER("Server"),
+        CONNECTION("Connection"),
         CONTENT_TYPE("Content-Type"),
         CONTENT_LENGTH("Content-Length"),
-        LOCATION("Location");
+        LOCATION("Location"),
+        SET_COOKIE("Set-Cookie");
 
         private final String name;
 

--- a/src/main/java/codesquad/webserver/http/HttpRequest.java
+++ b/src/main/java/codesquad/webserver/http/HttpRequest.java
@@ -41,6 +41,18 @@ public class HttpRequest {
         return httpRequestBody.getParamValue(paramName);
     }
 
+    public Cookie getCookie() {
+        Optional<String> optCookieValues = getHeaderValue("Cookie");
+        if (optCookieValues.isEmpty()) {
+            return null;
+        }
+
+        String cookieValues = optCookieValues.get();
+        String[] cookieValueParts = cookieValues.split(";");
+        String[] nameAndValue = cookieValueParts[0].split("=");
+        return new Cookie(nameAndValue[0], nameAndValue[1]);
+    }
+
     @Override
     public String toString() {
         return httpRequestLine + "\n" + headers + "\n" + httpRequestBody;

--- a/src/main/java/codesquad/webserver/http/HttpResponse.java
+++ b/src/main/java/codesquad/webserver/http/HttpResponse.java
@@ -7,6 +7,7 @@ import static codesquad.webserver.http.HttpHeaders.HeaderName.LOCATION;
 import static codesquad.webserver.http.HttpHeaders.HeaderName.SERVER;
 import static codesquad.webserver.http.HttpHeaders.HeaderName.SET_COOKIE;
 import static codesquad.webserver.http.HttpStatus.NOT_FOUND;
+import static codesquad.webserver.http.HttpStatus.UNAUTHORIZED;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -46,6 +47,13 @@ public class HttpResponse {
         byte[] notFound = NOT_FOUND.getRepresentation().getBytes();
         setHttpResponseLine(httpResponseLine);
         setBody(notFound);
+    }
+
+    public void unauthorized() {
+        HttpResponseLine httpResponseLine = new HttpResponseLine(HttpVersion.HTTP1_1, HttpStatus.UNAUTHORIZED);
+        byte[] unauthorized = UNAUTHORIZED.getRepresentation().getBytes();
+        setHttpResponseLine(httpResponseLine);
+        setBody(unauthorized);
     }
 
     public void setHttpResponseLine(HttpResponseLine httpResponseLine) {

--- a/src/main/java/codesquad/webserver/http/HttpResponse.java
+++ b/src/main/java/codesquad/webserver/http/HttpResponse.java
@@ -1,10 +1,17 @@
 package codesquad.webserver.http;
 
 import static codesquad.utils.string.StringUtils.CRLF;
+import static codesquad.webserver.http.HttpHeaders.HeaderName.CONNECTION;
+import static codesquad.webserver.http.HttpHeaders.HeaderName.DATE;
+import static codesquad.webserver.http.HttpHeaders.HeaderName.LOCATION;
+import static codesquad.webserver.http.HttpHeaders.HeaderName.SERVER;
+import static codesquad.webserver.http.HttpHeaders.HeaderName.SET_COOKIE;
 
-import codesquad.webserver.http.HttpHeaders.HeaderName;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -13,12 +20,15 @@ public class HttpResponse {
     private HttpResponseLine httpResponseLine;
     private HttpHeaders headers;
     private byte[] body;
+    private List<Cookie> cookies = new ArrayList<>();
 
     public HttpResponse(HttpResponseLine httpResponseLine, HttpHeaders headers, byte[] body) {
         this.httpResponseLine = httpResponseLine;
         this.headers = headers;
         this.body = body;
     }
+
+    /*---------- static factory method ----------*/
 
     public static HttpResponse ok() {
         HttpResponseLine httpResponseLine = new HttpResponseLine(HttpVersion.HTTP1_1, HttpStatus.OK);
@@ -27,53 +37,84 @@ public class HttpResponse {
         return new HttpResponse(httpResponseLine, empty, bytes);
     }
 
+    /*---------- setter http response line ----------*/
+
     public void setHttpResponseLine(HttpResponseLine httpResponseLine) {
         this.httpResponseLine = httpResponseLine;
+    }
+
+    /*---------- setter headers ----------*/
+
+    public void setDefaultHeaders(ZonedDateTime zonedDateTime) {
+        setDate(zonedDateTime);
+        setServer();
+        setConnectionClose();
+    }
+
+    private void setDate(ZonedDateTime zonedDateTime) {
+        this.headers.setHeader(DATE.getName(), zonedDateTime.toString());
+    }
+
+    private void setServer() {
+        this.headers.setHeader(SERVER.getName(), "Woowah WAS Server/1.0");
+    }
+
+    private void setConnectionClose() {
+        this.headers.setHeader(CONNECTION.getName(), "close");
+    }
+
+    public void setBody(byte[] body) {
+        this.body = body;
+        setContentLength(body.length);
+    }
+
+    private void setContentLength(int contentLength) {
+        this.headers.setContentLength(contentLength);
     }
 
     public void setContentType(HttpMediaType httpMediaType) {
         this.headers.setContentType(httpMediaType);
     }
 
-    public void setContentLength(int contentLength) {
-        this.headers.setContentLength(contentLength);
+    public void addCookie(Cookie cookie) {
+        if (cookies.contains(cookie)) {
+            return;
+        }
+        cookies.add(cookie);
+        setCookie(cookie);
     }
 
-    public void setDate(ZonedDateTime zonedDateTime) {
-        this.headers.setHeader("Date", zonedDateTime.toString());
-    }
+    private void setCookie(Cookie cookie) {
+        StringBuilder sb = new StringBuilder();
 
-    public void setServer() {
-        this.headers.setHeader("Server", "Woowah WAS Server/1.0");
-    }
+        final String cookieName = cookie.getName();
+        final String cookieValue = cookie.getValue();
+        final Map<String, String> cookieAttributes = cookie.getAttributes();
 
-    public void setConnectionClose() {
-        this.headers.setHeader("Connection", "close");
-    }
+        final String cookieNameAndValue = cookieName + "=" + cookieValue;
+        sb.append(cookieNameAndValue);
 
-    public void setBadRequest() {
-        this.httpResponseLine = new HttpResponseLine(HttpVersion.HTTP1_1, HttpStatus.BAD_REQUEST);
-        this.headers = HttpHeaders.empty();
-        this.body = new byte[0];
-    }
+        for (String attributeName : cookieAttributes.keySet()) {
+            String attributeValue = cookieAttributes.get(attributeName);
+            sb.append("; ").append(attributeName);
 
-    public void setBody(byte[] body) {
-        this.body = body;
+            if (attributeValue.isEmpty()) {
+                continue;
+            }
+            sb.append("=").append(attributeValue);
+        }
+        headers.setHeader(SET_COOKIE.getName(), sb.toString());
     }
 
     public void sendRedirect(String redirectUrl) {
         httpResponseLine.setStatus(HttpStatus.FOUND);
-        headers.setHeader(HeaderName.LOCATION.getName(), redirectUrl);
+        headers.setHeader(LOCATION.getName(), redirectUrl);
     }
+
+    /*---------- getter ----------*/
 
     public Optional<String> getRedirect() {
-        return headers.getHeaderValue(HeaderName.LOCATION.getName());
-    }
-
-    public void setDefaultHeaders(ZonedDateTime zonedDateTime) {
-        setDate(zonedDateTime);
-        setServer();
-        setConnectionClose();
+        return headers.getHeaderValue(LOCATION.getName());
     }
 
     public String getResponseLine() {
@@ -100,6 +141,10 @@ public class HttpResponse {
             sb.append(headerName).append(delimiter).append(headers.get(headerName)).append(CRLF);
         }
         return sb.toString();
+    }
+
+    public List<Cookie> getCookies() {
+        return Collections.unmodifiableList(cookies);
     }
 
     public byte[] getBody() {

--- a/src/main/java/codesquad/webserver/http/HttpResponse.java
+++ b/src/main/java/codesquad/webserver/http/HttpResponse.java
@@ -6,6 +6,7 @@ import static codesquad.webserver.http.HttpHeaders.HeaderName.DATE;
 import static codesquad.webserver.http.HttpHeaders.HeaderName.LOCATION;
 import static codesquad.webserver.http.HttpHeaders.HeaderName.SERVER;
 import static codesquad.webserver.http.HttpHeaders.HeaderName.SET_COOKIE;
+import static codesquad.webserver.http.HttpStatus.NOT_FOUND;
 
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -37,7 +38,15 @@ public class HttpResponse {
         return new HttpResponse(httpResponseLine, empty, bytes);
     }
 
+
     /*---------- setter http response line ----------*/
+
+    public void notFound() {
+        HttpResponseLine httpResponseLine = new HttpResponseLine(HttpVersion.HTTP1_1, HttpStatus.NOT_FOUND);
+        byte[] notFound = NOT_FOUND.getRepresentation().getBytes();
+        setHttpResponseLine(httpResponseLine);
+        setBody(notFound);
+    }
 
     public void setHttpResponseLine(HttpResponseLine httpResponseLine) {
         this.httpResponseLine = httpResponseLine;

--- a/src/main/java/codesquad/webserver/http/HttpStatus.java
+++ b/src/main/java/codesquad/webserver/http/HttpStatus.java
@@ -6,6 +6,7 @@ public enum HttpStatus {
     FOUND(302, "Found"),
     SEE_OTHER(303, "See Other"),
     BAD_REQUEST(400, "Bad Request"),
+    UNAUTHORIZED(401, "Unauthorized"),
     NOT_FOUND(404, "Not Found");
 
     private final int code;

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -38,6 +38,7 @@
                 <p class="title_textfield">비밀번호</p>
                 <input
                         class="input_textfield"
+                        name="password"
                         type="password"
                         placeholder="비밀번호를 입력해주세요"
                         autocomplete="current-password"

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -1,56 +1,59 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/"><img src="../img/signiture.svg" /></a>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg"/></a>
         <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
-          </li>
-          <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
-              회원 가입
-            </a>
-          </li>
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            </li>
+            <li class="header__menu__item">
+                <a class="btn btn_ghost btn_size_s" href="/registration">
+                    회원 가입
+                </a>
+            </li>
         </ul>
-      </header>
-      <div class="page">
+    </header>
+    <div class="page">
         <h2 class="page-title">로그인</h2>
-        <form class="form">
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">아이디</p>
-            <input
-              class="input_textfield"
-              placeholder="아이디를 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">비밀번호</p>
-            <input
-              class="input_textfield"
-              type="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
-            />
-          </div>
-          <button
-            id="login-btn"
-            class="btn btn_contained btn_size_m"
-            style="margin-top: 24px"
-            type="button"
-          >
-            로그인
-          </button>
+        <form class="form" action="/user/login" method="post">
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">아이디</p>
+                <input
+                        class="input_textfield"
+                        name="userId"
+                        placeholder="아이디를 입력해주세요"
+                        autocomplete="userId"
+                        required
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">비밀번호</p>
+                <input
+                        class="input_textfield"
+                        type="password"
+                        placeholder="비밀번호를 입력해주세요"
+                        autocomplete="current-password"
+                        required
+                />
+            </div>
+            <button
+                    id="login-btn"
+                    class="btn btn_contained btn_size_m"
+                    style="margin-top: 24px"
+                    type="submit"
+            >
+                로그인
+            </button>
         </form>
-      </div>
     </div>
-  </body>
+</div>
+</body>
 </html>

--- a/src/main/resources/static/main/index.html
+++ b/src/main/resources/static/main/index.html
@@ -1,149 +1,149 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-    <link href="../main.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/main"><img src="../img/signiture.svg" /></a>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+    <link href="../main.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/main"><img src="../img/signiture.svg"/></a>
         <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
-          </li>
-          <li class="header__menu__item">
-            <button id="logout-btn" class="btn btn_ghost btn_size_s">
-              로그아웃
-            </button>
-          </li>
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
+            </li>
+            <li class="header__menu__item">
+                <form id="logout-form" action="/user/logout" method="post" style="display: inline;">
+                    <button type="submit" id="logout-btn" class="btn btn_ghost btn_size_s">로그아웃</button>
+                </form>
+            </li>
         </ul>
-      </header>
-      <div class="wrapper">
+    </header>
+    <div class="wrapper">
         <div class="post">
-          <div class="post__account">
-            <img class="post__account__img" />
-            <p class="post__account__nickname">account</p>
-          </div>
-          <img class="post__img" />
-          <div class="post__menu">
-            <ul class="post__menu__personal">
-              <li>
+            <div class="post__account">
+                <img class="post__account__img"/>
+                <p class="post__account__nickname">account</p>
+            </div>
+            <img class="post__img"/>
+            <div class="post__menu">
+                <ul class="post__menu__personal">
+                    <li>
+                        <button class="post__menu__btn">
+                            <img src="../img/like.svg"/>
+                        </button>
+                    </li>
+                    <li>
+                        <button class="post__menu__btn">
+                            <img src="../img/sendLink.svg"/>
+                        </button>
+                    </li>
+                </ul>
                 <button class="post__menu__btn">
-                  <img src="../img/like.svg" />
+                    <img src="../img/bookMark.svg"/>
                 </button>
-              </li>
-              <li>
-                <button class="post__menu__btn">
-                  <img src="../img/sendLink.svg" />
-                </button>
-              </li>
-            </ul>
-            <button class="post__menu__btn">
-              <img src="../img/bookMark.svg" />
-            </button>
-          </div>
-          <p class="post__article">
-            우리는 시스템 아키텍처에 대한 일관성 있는 접근이 필요하며, 필요한
-            모든 측면은 이미 개별적으로 인식되고 있다고 생각합니다. 즉, 응답이
-            잘 되고, 탄력적이며 유연하고 메시지 기반으로 동작하는 시스템 입니다.
-            우리는 이것을 리액티브 시스템(Reactive Systems)라고 부릅니다.
-            리액티브 시스템으로 구축된 시스템은 보다 유연하고, 느슨한 결합을
-            갖고, 확장성 이 있습니다. 이로 인해 개발이 더 쉬워지고 변경 사항을
-            적용하기 쉬워집니다. 이 시스템은 장애 에 대해 더 강한 내성을 지니며,
-            비록 장애가 발생 하더라도, 재난이 일어나기 보다는 간결한 방식으로
-            해결합니다. 리액티브 시스템은 높은 응답성을 가지며 사용자 에게
-            효과적인 상호적 피드백을 제공합니다.
-          </p>
+            </div>
+            <p class="post__article">
+                우리는 시스템 아키텍처에 대한 일관성 있는 접근이 필요하며, 필요한
+                모든 측면은 이미 개별적으로 인식되고 있다고 생각합니다. 즉, 응답이
+                잘 되고, 탄력적이며 유연하고 메시지 기반으로 동작하는 시스템 입니다.
+                우리는 이것을 리액티브 시스템(Reactive Systems)라고 부릅니다.
+                리액티브 시스템으로 구축된 시스템은 보다 유연하고, 느슨한 결합을
+                갖고, 확장성 이 있습니다. 이로 인해 개발이 더 쉬워지고 변경 사항을
+                적용하기 쉬워집니다. 이 시스템은 장애 에 대해 더 강한 내성을 지니며,
+                비록 장애가 발생 하더라도, 재난이 일어나기 보다는 간결한 방식으로
+                해결합니다. 리액티브 시스템은 높은 응답성을 가지며 사용자 에게
+                효과적인 상호적 피드백을 제공합니다.
+            </p>
         </div>
         <ul class="comment">
-          <li class="comment__item">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">
-              군인 또는 군무원이 아닌 국민은 대한민국의 영역안에서는 중대한
-              군사상 기밀·초병·초소·유독음식물공급·포로·군용물에 관한 죄중
-              법률이 정한 경우와 비상계엄이 선포된 경우를 제외하고는 군사법원의
-              재판을 받지 아니한다.
-            </p>
-          </li>
-          <li class="comment__item">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">
-              대통령의 임기연장 또는 중임변경을 위한 헌법개정은 그 헌법개정 제안
-              당시의 대통령에 대하여는 효력이 없다. 민주평화통일자문회의의
-              조직·직무범위 기타 필요한 사항은 법률로 정한다.
-            </p>
-          </li>
-          <li class="comment__item">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">
-              민주평화통일자문회의의 조직·직무범위 기타 필요한 사항은 법률로
-              정한다.
-            </p>
-          </li>
-          <li class="comment__item hidden">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">Comment 1</p>
-          </li>
-          <li class="comment__item hidden">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">Comment 2</p>
-          </li>
-          <li class="comment__item hidden">
-            <div class="comment__item__user">
-              <img class="comment__item__user__img" />
-              <p class="comment__item__user__nickname">account</p>
-            </div>
-            <p class="comment__item__article">Comment 3</p>
-          </li>
-          <button id="show-all-btn" class="btn btn_ghost btn_size_m">
-            모든 댓글 보기(3개)
-          </button>
+            <li class="comment__item">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">
+                    군인 또는 군무원이 아닌 국민은 대한민국의 영역안에서는 중대한
+                    군사상 기밀·초병·초소·유독음식물공급·포로·군용물에 관한 죄중
+                    법률이 정한 경우와 비상계엄이 선포된 경우를 제외하고는 군사법원의
+                    재판을 받지 아니한다.
+                </p>
+            </li>
+            <li class="comment__item">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">
+                    대통령의 임기연장 또는 중임변경을 위한 헌법개정은 그 헌법개정 제안
+                    당시의 대통령에 대하여는 효력이 없다. 민주평화통일자문회의의
+                    조직·직무범위 기타 필요한 사항은 법률로 정한다.
+                </p>
+            </li>
+            <li class="comment__item">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">
+                    민주평화통일자문회의의 조직·직무범위 기타 필요한 사항은 법률로
+                    정한다.
+                </p>
+            </li>
+            <li class="comment__item hidden">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">Comment 1</p>
+            </li>
+            <li class="comment__item hidden">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">Comment 2</p>
+            </li>
+            <li class="comment__item hidden">
+                <div class="comment__item__user">
+                    <img class="comment__item__user__img"/>
+                    <p class="comment__item__user__nickname">account</p>
+                </div>
+                <p class="comment__item__article">Comment 3</p>
+            </li>
+            <button id="show-all-btn" class="btn btn_ghost btn_size_m">
+                모든 댓글 보기(3개)
+            </button>
         </ul>
         <nav class="nav">
-          <ul class="nav__menu">
-            <li class="nav__menu__item">
-              <a class="nav__menu__item__btn" href="">
-                <img
-                  class="nav__menu__item__img"
-                  src="../img/ci_chevron-left.svg"
-                />
-                이전 글
-              </a>
-            </li>
-            <li class="nav__menu__item">
-              <a class="btn btn_ghost btn_size_m" href="/comment">댓글 작성</a>
-            </li>
-            <li class="nav__menu__item">
-              <a class="nav__menu__item__btn" href="">
-                다음 글
-                <img
-                  class="nav__menu__item__img"
-                  src="../img/ci_chevron-right.svg"
-                />
-              </a>
-            </li>
-          </ul>
+            <ul class="nav__menu">
+                <li class="nav__menu__item">
+                    <a class="nav__menu__item__btn" href="">
+                        <img
+                                class="nav__menu__item__img"
+                                src="../img/ci_chevron-left.svg"
+                        />
+                        이전 글
+                    </a>
+                </li>
+                <li class="nav__menu__item">
+                    <a class="btn btn_ghost btn_size_m" href="/comment">댓글 작성</a>
+                </li>
+                <li class="nav__menu__item">
+                    <a class="nav__menu__item__btn" href="">
+                        다음 글
+                        <img
+                                class="nav__menu__item__img"
+                                src="../img/ci_chevron-right.svg"
+                        />
+                    </a>
+                </li>
+            </ul>
         </nav>
-      </div>
     </div>
-  </body>
+</div>
+</body>
 </html>

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -23,7 +23,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" action="/create" method="post">
+        <form class="form" action="/user/create" method="post">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input

--- a/src/main/resources/static/user/login_failed.html
+++ b/src/main/resources/static/user/login_failed.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+    <style>
+        .error-message {
+            color: red;
+            font-size: 14px;
+            margin-top: 10px;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg"/></a>
+        <ul class="header__menu">
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            </li>
+            <li class="header__menu__item">
+                <a class="btn btn_ghost btn_size_s" href="/registration">
+                    회원 가입
+                </a>
+            </li>
+        </ul>
+    </header>
+    <div class="page">
+        <h2 class="page-title">로그인</h2>
+        <div class="error-message">아이디 또는 비밀번호를 잘못 입력했습니다.</div>
+        <form class="form" action="/user/login" method="post">
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">아이디</p>
+                <input
+                        class="input_textfield"
+                        name="userId"
+                        placeholder="아이디를 입력해주세요"
+                        autocomplete="userId"
+                        required
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">비밀번호</p>
+                <input
+                        class="input_textfield"
+                        name="password"
+                        type="password"
+                        placeholder="비밀번호를 입력해주세요"
+                        autocomplete="current-password"
+                        required
+                />
+            </div>
+            <button
+                    id="login-btn"
+                    class="btn btn_contained btn_size_m"
+                    style="margin-top: 24px"
+                    type="submit"
+            >
+                로그인
+            </button>
+        </form>
+    </div>
+</div>
+</body>
+</html>

--- a/src/test/java/codesquad/servlet/SessionStorageTest.java
+++ b/src/test/java/codesquad/servlet/SessionStorageTest.java
@@ -1,0 +1,30 @@
+package codesquad.servlet;
+
+import codesquad.domain.model.User;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SessionStorageTest {
+
+    SessionStorage sessionStorage = new SessionStorage();
+
+    @Nested
+    @DisplayName("세션을 생성하는 기능은")
+    class CreateSessionTest {
+
+        @Test
+        @DisplayName("[Success] key:UUID, value:User로 저장한다.")
+        void create() {
+            // given
+            User user = new User("아이디", "비밀번호", "이름", "이메일");
+            String sessionKey = sessionStorage.createSession(user);
+            // when
+            User sessionValue = sessionStorage.getSessionValue(sessionKey);
+            // then
+            Assertions.assertThat(user).isEqualTo(sessionValue);
+        }
+
+    }
+}

--- a/src/test/java/codesquad/servlet/handler/api/UserRegistrationHandlerTest.java
+++ b/src/test/java/codesquad/servlet/handler/api/UserRegistrationHandlerTest.java
@@ -1,0 +1,85 @@
+package codesquad.servlet.handler.api;
+
+import static codesquad.webserver.http.HttpMethod.POST;
+import static codesquad.webserver.http.HttpVersion.HTTP1_1;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import codesquad.domain.InMemoryUserStorage;
+import codesquad.servlet.SessionStorage;
+import codesquad.webserver.http.HttpHeaders;
+import codesquad.webserver.http.HttpPath;
+import codesquad.webserver.http.HttpRequest;
+import codesquad.webserver.http.HttpRequestBody;
+import codesquad.webserver.http.HttpRequestLine;
+import codesquad.webserver.http.HttpResponse;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UserRegistrationHandlerTest {
+
+    InMemoryUserStorage inMemoryUserStorage = new InMemoryUserStorage();
+    SessionStorage sessionStorage = new SessionStorage();
+    UserRegistrationHandler userRegistrationHandler = new UserRegistrationHandler(inMemoryUserStorage, sessionStorage);
+
+    @Nested
+    @DisplayName("회원가입 API는")
+    class Describe_UserRegistrationAPISpecTest {
+
+        @Test
+        @DisplayName("[Success] 성공 시 /index.html로 리다이렉트 응답을 내려준다.")
+        void redirectSpec() {
+            // given
+            HttpRequest httpRequest = createRegistrationRequest(
+                    createUserRegistrationRequestBodyParams("아이디", "비밀번호", "이름", "이메일")
+            );
+            HttpResponse httpResponse = HttpResponse.ok();
+
+            // when
+            userRegistrationHandler.service(httpRequest, httpResponse);
+
+            // then
+            assertThat(httpResponse.getRedirect()).isPresent();
+            assertThat(httpResponse.getRedirect().get()).isEqualTo("/index.html");
+        }
+
+        @Test
+        @DisplayName("[Success] 성공 시 쿠키를 응답으로 내려준다.")
+        void cookieSpec() {
+            // given
+            HttpRequest httpRequest = createRegistrationRequest(
+                    createUserRegistrationRequestBodyParams("아이디", "비밀번호", "이름", "이메일")
+            );
+            HttpResponse httpResponse = HttpResponse.ok();
+
+            // when
+            userRegistrationHandler.service(httpRequest, httpResponse);
+
+            // then
+            boolean exists = httpResponse.getCookies().stream()
+                    .anyMatch(cookie -> cookie.getName().equals("sid"));
+            assertThat(exists).isTrue();
+        }
+
+        private HttpRequest createRegistrationRequest(Map<String, String> requestBodyParams) {
+            HttpRequestLine httpRequestLine = new HttpRequestLine(POST, HttpPath.of("/create", Map.of()), HTTP1_1);
+            HttpHeaders httpHeaders = HttpHeaders.empty();
+            HttpRequestBody httpRequestBody = new HttpRequestBody(requestBodyParams);
+            return new HttpRequest(httpRequestLine, httpHeaders, httpRequestBody);
+        }
+
+        private Map<String, String> createUserRegistrationRequestBodyParams(String userId, String password,
+                                                                            String name, String email
+        ) {
+            HashMap<String, String> requestBodyParams = new HashMap<>();
+            requestBodyParams.put("userId", userId);
+            requestBodyParams.put("password", password);
+            requestBodyParams.put("name", name);
+            requestBodyParams.put("email", email);
+            return requestBodyParams;
+        }
+
+    }
+}

--- a/src/test/java/codesquad/webserver/http/HttpResponseTest.java
+++ b/src/test/java/codesquad/webserver/http/HttpResponseTest.java
@@ -1,0 +1,106 @@
+package codesquad.webserver.http;
+
+import static codesquad.utils.string.StringUtils.CRLF;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.ZonedDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class HttpResponseTest {
+
+    @Nested
+    class Describe_SetContentType {
+
+        @ParameterizedTest
+        @EnumSource(HttpMediaType.class)
+        @DisplayName("[Success] 응답 헤더가 Content-Type: value 로 설정된다")
+        void contentType(HttpMediaType mediaType) {
+            // given
+            HttpResponse httpResponse = HttpResponse.ok();
+            String expectedHeader = "Content-Type: " + mediaType.getName() + CRLF;
+            // when
+            httpResponse.setContentType(mediaType);
+            // then
+            String header = httpResponse.getHeaders();
+            assertThat(header).isEqualTo(expectedHeader);
+        }
+
+    }
+
+    @Nested
+    class Describe_SetBody {
+
+        @Test
+        @DisplayName("[Success] 응답 헤더가 Content-Length: value 로 설정된다")
+        void setBodyThenContentLength() {
+            // given
+            HttpResponse httpResponse = HttpResponse.ok();
+            byte[] body = "Hello, World!".getBytes();
+            int expectedLength = body.length;
+            String expectedHeader = "Content-Length: " + expectedLength + CRLF;
+
+            // when
+            httpResponse.setBody(body);
+
+            // then
+            String header = httpResponse.getHeaders();
+            assertThat(header).isEqualTo(expectedHeader);
+        }
+    }
+
+    @Nested
+    class Describe_SetDefaultHeaders {
+
+        @Test
+        @DisplayName("[Success] 기본 헤더들이 설정된다")
+        void defaultHeaders() {
+            // given
+            HttpResponse httpResponse = HttpResponse.ok();
+            ZonedDateTime zonedDateTime = ZonedDateTime.now();
+            String expectedDateHeader = "Date: " + zonedDateTime.toString() + CRLF;
+            String expectedServerHeader = "Server: Woowah WAS Server/1.0" + CRLF;
+            String expectedConnectionHeader = "Connection: close" + CRLF;
+
+            // when
+            httpResponse.setDefaultHeaders(zonedDateTime);
+
+            // then
+            String headers = httpResponse.getHeaders();
+            assertThat(headers).contains(expectedDateHeader);
+            assertThat(headers).contains(expectedServerHeader);
+            assertThat(headers).contains(expectedConnectionHeader);
+        }
+    }
+
+
+    @Nested
+    class Describe_AddCookie {
+
+        @Test
+        @DisplayName("[Success] 쿠키가 추가되고 Set-Cookie 헤더가 설정된다")
+        void addCookie() {
+            // given
+            HttpResponse httpResponse = HttpResponse.ok();
+            Cookie cookie = new Cookie("sessionId", "abc123");
+            cookie.setPath("/");
+            cookie.setDomain("woowahcamp.com");
+            String expectedHeader = "Set-Cookie: sessionId=abc123; Path=/; Domain=woowahcamp.com" + CRLF;
+
+            // when
+            httpResponse.addCookie(cookie);
+
+            // then
+            List<Cookie> cookies = httpResponse.getCookies();
+            assertThat(cookies).contains(cookie);
+
+            String headers = httpResponse.getHeaders();
+            assertThat(headers).isEqualTo(expectedHeader);
+        }
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
- [x] 로그인 기능
  - 세션 ID에 대한 쿠키를 응답으로 내린다.
  - 사용자에 대한 세션을 저장한다.
  - /main으로 리다이렉트
- [x] 로그아웃 기능
  - 쿠키와 세션을 초기화한다.
  - /index.html로 리다이렉트
- [x] 쿠키 VO 구현
  - 쿠키의 attributes 중 name, value는 별도로 구분하고 나머지는 Map으로 관리
- [x] 핸들러 매퍼 추가
  - 로그인 핸들러, 로그아웃 핸들러를 추가함

## 고민 사항
### 🤔 세션은 서버 리소스를 사용 → 일정 주기마다 세션을 릴리즈하는 스케줄링이 필요하지 않을까?

- 기본적으로는 사용자 요청 시 세션 validate 과정에서 세션 정리
- 세션 저장 최대 크기를 도달하면, invalid한 세션을 지우는 방법도 가능
- 문제점:
사용자가 인증 API를 호출해야만, 세션 리소스 릴리즈 로직이 수행된다는 점
수백만 사용자가 인증하여 세션이 수백만개 생기고, 이후에 사이트를 사용하지 않는다면
→ 서버가 살아있는 한 세션 리소스가 계속 메모리에 존재

<br>

### 🤔 쿠키 / 세션 인증 → 중복 로직을 제거하기 위한 방법

쿠키 / 세션 인증은 아래의 절차를 수행해야하며, **인증이 필요한 모든 엔드포인트에서 중복으로 로직을 처리하는 문제**가 있다.

1. 요청 헤더에 세션 관련 쿠키가 존재하는지 확인한다.
2. 존재하면, 해당 세션이 유효한지 확인한다.
3. …

→ 앞단에 필터에서 공통 로직을 처리하도록 한다면?
## 기타
