### PR TITLE
[김규원] step-5 쿠키를 이용한 로그인

### DIFF
--- a/src/main/java/codesquad/WasServer.java
+++ b/src/main/java/codesquad/WasServer.java
@@ -6,6 +6,7 @@ import codesquad.handler.DynamicHandler;
 import codesquad.handler.RedirectStaticFileHandler;
 import codesquad.handler.StaticFileHandler;
 import codesquad.handler.StaticFileReader;
+import codesquad.http.HttpMethod;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
 import codesquad.processor.Http11Processor;
@@ -39,7 +40,11 @@ public class WasServer {
         Adapter userAdapter = new UserAdapter();
         List<String> whitelist = List.of(
                 "/",
-                "/registration"
+                "/registration",
+                "/article",
+                "/comment",
+                "/main",
+                "/login"
         );
 
         serverSocket = new ServerSocket(port);
@@ -77,9 +82,9 @@ public class WasServer {
             HttpResponse httpResponse = null;
 
             // file 로 요청이 오거나 정해진 view 로 요청이 오는 경우
-            if (staticFileHandler.canHandle(httpRequest)) {
+            if (httpRequest.getMethod() == HttpMethod.GET && staticFileHandler.canHandle(httpRequest)) {
                 httpResponse = staticFileHandler.handle(httpRequest);
-            } else if (redirectStaticFileHandler.canHandle(httpRequest)) {
+            } else if (httpRequest.getMethod() == HttpMethod.GET && redirectStaticFileHandler.canHandle(httpRequest)) {
                 httpResponse = redirectStaticFileHandler.handle(httpRequest);
             } else if (dynamicHandler.canHandle(httpRequest)) {
                 httpResponse = dynamicHandler.handle(httpRequest);

--- a/src/main/java/codesquad/WasServer.java
+++ b/src/main/java/codesquad/WasServer.java
@@ -9,6 +9,7 @@ import codesquad.handler.StaticFileReader;
 import codesquad.http.HttpMethod;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
+import codesquad.http.HttpStatus;
 import codesquad.processor.Http11Processor;
 import codesquad.processor.HttpProcessor;
 import org.slf4j.Logger;
@@ -23,8 +24,6 @@ import java.net.Socket;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-
-import static codesquad.http.HttpResponse.createNotFoundResponse;
 
 public class WasServer {
     private static Logger logger = LoggerFactory.getLogger(WasServer.class);
@@ -89,7 +88,7 @@ public class WasServer {
             } else if (dynamicHandler.canHandle(httpRequest)) {
                 httpResponse = dynamicHandler.handle(httpRequest);
             } else {
-                httpResponse = createNotFoundResponse(httpRequest);
+                httpResponse = new HttpResponse.Builder(httpRequest, HttpStatus.NOT_FOUND).build();
             }
 
             logger.debug(httpResponse.toString());

--- a/src/main/java/codesquad/adapter/UserAdapter.java
+++ b/src/main/java/codesquad/adapter/UserAdapter.java
@@ -20,6 +20,7 @@ public class UserAdapter implements Adapter {
         if (request.getPath().equals("/user/create") && request.getMethod() == HttpMethod.POST) {
             HttpBody body = request.getBody();
 
+            //TODO parameter 처리
             Parameters parameters = body.getParameters();
             String userId = parameters.getParameter("userId");
             String password = parameters.getParameter("password");
@@ -35,6 +36,7 @@ public class UserAdapter implements Adapter {
             UserDb.print();
             return HttpResponse.createRedirectResponse(request, "/index.html");
         } else if (request.getPath().equals("/user/login") && request.getMethod() == HttpMethod.POST) {
+            logger.info("login start");
             HttpBody body = request.getBody();
 
             Parameters parameters = body.getParameters();
@@ -51,9 +53,12 @@ public class UserAdapter implements Adapter {
 
                 logger.debug("로그인 성공 " + sessionId);
                 HttpHeaders httpHeaders = new HttpHeaders();
-                httpHeaders.put(HttpHeaders.SET_COOKIE, String.format("sid=%s; Path=/", sessionId));
+//                httpHeaders.put(HttpHeaders.SET_COOKIE, String.format("sid=%s; Path=/", sessionId));
 
-                return HttpResponse.createOkResponse(request, httpHeaders, null, null);
+                HttpCookies cookies = new HttpCookies();
+                HttpCookie cookie = new HttpCookie("sid", sessionId, "/");
+                cookies.setCookie(cookie);
+                return HttpResponse.createOkResponse(request, httpHeaders, null, null, cookies);
             } else {
                 return HttpResponse.createIllegalArgumentResponse(request);
             }

--- a/src/main/java/codesquad/adapter/UserAdapter.java
+++ b/src/main/java/codesquad/adapter/UserAdapter.java
@@ -24,10 +24,17 @@ public class UserAdapter implements Adapter {
             String password = parameters.getParameter("password");
             String name = parameters.getParameter("name");
             String email = parameters.getParameter("email");
+
+            if (UserDb.exists(userId)) {
+                return HttpResponse.createIllegalArgumentResponse(request);
+            }
+
             UserDb.add(User.of(userId, password, name, email));
 
             UserDb.print();
             return HttpResponse.createRedirectResponse(request, "/index.html");
+        } else if (request.getPath().equals("/user/login") && request.getMethod() == HttpMethod.POST) {
+            // user session
         }
 
         throw new IllegalArgumentException("처리 가능한 메소드가 존재하지 않습니다." + request.getPath().toString());

--- a/src/main/java/codesquad/adapter/UserAdapter.java
+++ b/src/main/java/codesquad/adapter/UserAdapter.java
@@ -60,7 +60,7 @@ public class UserAdapter implements Adapter {
                 cookies.setCookie(cookie);
                 return HttpResponse.createOkResponse(request, httpHeaders, null, null, cookies);
             } else {
-                return HttpResponse.createIllegalArgumentResponse(request);
+                return HttpResponse.createRedirectResponse(request, "/login/error.html");
             }
         }
 

--- a/src/main/java/codesquad/db/UserDb.java
+++ b/src/main/java/codesquad/db/UserDb.java
@@ -8,14 +8,21 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class UserDb {
-    private static Map<String, User> users = new ConcurrentHashMap();
+    private static Map<String, User> users = new ConcurrentHashMap<>();
     private static final Logger logger = LoggerFactory.getLogger(UserDb.class);
 
     private UserDb() {
     }
 
     public static void add(User user) {
+        if (users.containsKey(user.getUserId())) {
+            throw new IllegalArgumentException("이미 존재하는 유저입니다.");
+        }
         users.put(user.getUserId(), user);
+    }
+
+    public static User get(String userId) {
+        return users.get(userId);
     }
 
     public static int size() {
@@ -26,5 +33,13 @@ public class UserDb {
         for (User user : users.values()) {
             logger.debug(user.toString() + "\n");
         }
+    }
+
+    public static boolean exists(String userId) {
+        return users.containsKey(userId);
+    }
+
+    public static void refresh() {
+        users.clear();
     }
 }

--- a/src/main/java/codesquad/db/UserSession.java
+++ b/src/main/java/codesquad/db/UserSession.java
@@ -1,0 +1,37 @@
+package codesquad.db;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class UserSession {
+    private static final Logger logger = LoggerFactory.getLogger(UserSession.class);
+    private static final Map<String, UUID> sessions = new HashMap<>();
+
+    private UserSession() {
+    }
+
+    public static boolean contains(String userId) {
+        return sessions.containsKey(userId);
+    }
+
+    public static String create(String userId) {
+        UUID uuid = UUID.randomUUID();
+        sessions.put(userId, uuid);
+
+        return uuid.toString();
+    }
+
+    public static void refresh() {
+        sessions.clear();
+    }
+
+    public static void print() {
+        for (String userId : sessions.keySet()) {
+            logger.debug(userId + ": " + sessions.get(userId));
+        }
+    }
+}

--- a/src/main/java/codesquad/handler/RedirectStaticFileHandler.java
+++ b/src/main/java/codesquad/handler/RedirectStaticFileHandler.java
@@ -1,5 +1,6 @@
 package codesquad.handler;
 
+import codesquad.http.HttpHeaders;
 import codesquad.http.HttpRequest;
 import codesquad.http.HttpResponse;
 import codesquad.http.MimeType;
@@ -40,7 +41,11 @@ public class RedirectStaticFileHandler implements HttpHandler {
         try {
             byte[] bytes = staticFileReader.readFile(path);
             MimeType contentType = MimeType.fromExt("html");
-            return createOkResponse(request, bytes, contentType);
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.put(HttpHeaders.CONTENT_TYPE, contentType.getMimeType());
+            httpHeaders.put(HttpHeaders.CONTENT_LENGTH, String.valueOf(bytes != null ? bytes.length : 0));
+            return createOkResponse(request, httpHeaders, bytes, contentType);
         } catch (IOException ex) {
             logger.error("Error reading file: " + path);
             return createErrorResponse(request);

--- a/src/main/java/codesquad/handler/StaticFileHandler.java
+++ b/src/main/java/codesquad/handler/StaticFileHandler.java
@@ -46,7 +46,11 @@ public class StaticFileHandler implements HttpHandler {
         try {
             byte[] bytes = staticFileReader.readFile(request.getPath());
             MimeType contentType = MimeType.fromExt(request.getExt());
-            return createOkResponse(request, bytes, contentType);
+
+            HttpHeaders httpHeaders = new HttpHeaders();
+            httpHeaders.put(HttpHeaders.CONTENT_TYPE, contentType.getMimeType());
+            httpHeaders.put(HttpHeaders.CONTENT_LENGTH, String.valueOf(bytes != null ? bytes.length : 0));
+            return createOkResponse(request, httpHeaders, bytes, contentType);
         } catch (IOException ex) {
             logger.error("Error reading file: " + request.getPath());
             return createErrorResponse(request);

--- a/src/main/java/codesquad/handler/StaticFileHandler.java
+++ b/src/main/java/codesquad/handler/StaticFileHandler.java
@@ -6,9 +6,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static codesquad.http.HttpResponse.createErrorResponse;
-import static codesquad.http.HttpResponse.createOkResponse;
-
 public class StaticFileHandler implements HttpHandler {
     private static final Logger logger = LoggerFactory.getLogger(StaticFileHandler.class);
     private StaticFileReaderSpec staticFileReader;
@@ -22,7 +19,7 @@ public class StaticFileHandler implements HttpHandler {
         String path = request.getPath();
         try {
             if (!isValid(path)) {
-                return createNotFoundResponse(request);
+                return new HttpResponse.Builder(request, HttpStatus.NOT_FOUND).build();
             }
         } catch (IOException e) {
             throw new RuntimeException("error reading file " + path);
@@ -35,13 +32,6 @@ public class StaticFileHandler implements HttpHandler {
         return staticFileReader.exists(path);
     }
 
-    private HttpResponse createNotFoundResponse(HttpRequest request) {
-        HttpHeaders resHeaders = new HttpHeaders();
-        resHeaders.put(HttpHeaders.HTTP_VERSION, request.getHttpVersion().getRepresentation());
-
-        return new HttpResponse(request, HttpStatus.NOT_FOUND, resHeaders, new HttpBody(null, MimeType.NONE));
-    }
-
     private HttpResponse readFileAndCreateResponse(HttpRequest request) {
         try {
             byte[] bytes = staticFileReader.readFile(request.getPath());
@@ -50,10 +40,15 @@ public class StaticFileHandler implements HttpHandler {
             HttpHeaders httpHeaders = new HttpHeaders();
             httpHeaders.put(HttpHeaders.CONTENT_TYPE, contentType.getMimeType());
             httpHeaders.put(HttpHeaders.CONTENT_LENGTH, String.valueOf(bytes != null ? bytes.length : 0));
-            return createOkResponse(request, httpHeaders, bytes, contentType);
+
+            return new HttpResponse.Builder(request, HttpStatus.OK)
+                    .headers(httpHeaders)
+                    .body(HttpBody.of(bytes, contentType))
+                    .build();
         } catch (IOException ex) {
             logger.error("Error reading file: " + request.getPath());
-            return createErrorResponse(request);
+            return new HttpResponse.Builder(request, HttpStatus.INTERNAL_SERVER_ERROR)
+                    .build();
         }
     }
 

--- a/src/main/java/codesquad/http/HttpBody.java
+++ b/src/main/java/codesquad/http/HttpBody.java
@@ -6,9 +6,17 @@ public class HttpBody {
     private byte[] bytes;
     private MimeType contentType;
 
-    public HttpBody(byte[] bytes, MimeType contentType) {
+    private HttpBody(byte[] bytes, MimeType contentType) {
         this.bytes = bytes;
         this.contentType = contentType;
+    }
+
+    public static HttpBody of(byte[] bytes, MimeType contentType) {
+        return new HttpBody(bytes, contentType);
+    }
+
+    public static HttpBody empty() {
+        return new HttpBody(null, null);
     }
 
     public byte[] getBytes() {
@@ -28,5 +36,9 @@ public class HttpBody {
     @Override
     public String toString() {
         return new String(bytes);
+    }
+
+    public boolean isEmpty() {
+        return bytes == null;
     }
 }

--- a/src/main/java/codesquad/http/HttpCookie.java
+++ b/src/main/java/codesquad/http/HttpCookie.java
@@ -1,0 +1,31 @@
+package codesquad.http;
+
+public class HttpCookie {
+    private String name;
+    private String value;
+    private String path;
+
+    public HttpCookie(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+
+    public HttpCookie(String name, String value, String path) {
+        this.name = name;
+        this.value = value;
+        this.path = path;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public String getPath() {
+        return path;
+    }
+}

--- a/src/main/java/codesquad/http/HttpCookie.java
+++ b/src/main/java/codesquad/http/HttpCookie.java
@@ -5,16 +5,30 @@ public class HttpCookie {
     private String value;
     private String path;
 
-    public HttpCookie(String name, String value) {
-        this.name = name;
-        this.value = value;
+    private HttpCookie(Builder builder) {
+        this.name = builder.name;
+        this.value = builder.value;
+        this.path = builder.path;
     }
 
+    public static class Builder {
+        private final String name;
+        private final String value;
+        private String path;
 
-    public HttpCookie(String name, String value, String path) {
-        this.name = name;
-        this.value = value;
-        this.path = path;
+        public Builder(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        public Builder path(String path) {
+            this.path = path;
+            return this;
+        }
+
+        public HttpCookie build() {
+            return new HttpCookie(this);
+        }
     }
 
     public String getName() {

--- a/src/main/java/codesquad/http/HttpCookies.java
+++ b/src/main/java/codesquad/http/HttpCookies.java
@@ -27,4 +27,8 @@ public class HttpCookies {
     public boolean contains(String key) {
         return cookies.stream().anyMatch(httpCookie -> httpCookie.getName().equals(key));
     }
+
+    public void extend(HttpCookies other) {
+        this.cookies.addAll(other.getCookies());
+    }
 }

--- a/src/main/java/codesquad/http/HttpCookies.java
+++ b/src/main/java/codesquad/http/HttpCookies.java
@@ -1,0 +1,30 @@
+package codesquad.http;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class HttpCookies {
+    private List<HttpCookie> cookies;
+
+    public HttpCookies() {
+        this.cookies = new ArrayList<>();
+    }
+
+    public void setCookie(HttpCookie cookie) {
+        cookies.add(cookie);
+    }
+
+    public HttpCookie getCookie(String key) {
+        return cookies.stream().filter(httpCookie -> httpCookie.getName().equals(key)).findAny()
+                .orElse(null);
+    }
+
+    public List<HttpCookie> getCookies() {
+        return Collections.unmodifiableList(cookies);
+    }
+
+    public boolean contains(String key) {
+        return cookies.stream().anyMatch(httpCookie -> httpCookie.getName().equals(key));
+    }
+}

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -15,6 +15,7 @@ public class HttpHeaders {
     public static String CONTENT_TYPE = "Content-Type";
     public static String CONTENT_LENGTH = "Content-Length";
     public static String HOST = "Host";
+    public static String SET_COOKIE = "Set-Cookie";
 
     public HttpHeaders() {
         this.headers = new HashMap<>();

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -15,7 +15,6 @@ public class HttpHeaders {
     public static String CONTENT_TYPE = "Content-Type";
     public static String CONTENT_LENGTH = "Content-Length";
     public static String HOST = "Host";
-    public static String SET_COOKIE = "Set-Cookie";
 
     public HttpHeaders() {
         this.headers = new HashMap<>();

--- a/src/main/java/codesquad/http/HttpHeaders.java
+++ b/src/main/java/codesquad/http/HttpHeaders.java
@@ -2,6 +2,7 @@ package codesquad.http;
 
 import codesquad.utils.StringUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -28,6 +29,10 @@ public class HttpHeaders {
         return headers.get(key);
     }
 
+    public Map<String, String> getHeaders() {
+        return Collections.unmodifiableMap(headers);
+    }
+
     public int size() {
         return headers.size();
     }
@@ -38,6 +43,10 @@ public class HttpHeaders {
 
     public Set<String> keySet() {
         return headers.keySet();
+    }
+
+    public void extend(HttpHeaders others) {
+        this.headers.putAll(others.getHeaders());
     }
 
     @Override

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -66,6 +66,7 @@ public class HttpRequest {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("----request----").append(StringUtils.LINE_SEPERATOR);
+        sb.append(method + " " + path).append(StringUtils.LINE_SEPERATOR);
         sb.append("*headers*").append(StringUtils.LINE_SEPERATOR);
         sb.append(headers.toString());
 

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -11,39 +11,73 @@ public class HttpRequest {
     private Parameters parameters;
     private HttpCookies httpCookies;
 
-    public HttpRequest(
-            HttpMethod method,
-            String path,
-            HttpVersion httpVersion,
-            HttpHeaders headers,
-            HttpBody body,
-            Parameters parameters
-    ) {
-        this.method = method;
-        this.path = path;
-        this.httpVersion = httpVersion;
-        this.headers = headers;
-        this.body = body;
-        this.parameters = parameters;
-        this.httpCookies = new HttpCookies();
+    private HttpRequest(Builder builder) {
+        this.method = builder.method;
+        this.path = builder.path;
+        this.httpVersion = builder.httpVersion;
+        this.headers = builder.headers;
+        this.body = builder.body;
+        this.parameters = builder.parameters;
+        this.httpCookies = builder.httpCookies;
     }
 
-    public HttpRequest(
-            HttpMethod method,
-            String path,
-            HttpVersion httpVersion,
-            HttpHeaders headers,
-            HttpBody body,
-            Parameters parameters,
-            HttpCookies cookies
-    ) {
-        this.method = method;
-        this.path = path;
-        this.httpVersion = httpVersion;
-        this.headers = headers;
-        this.body = body;
-        this.parameters = parameters;
-        this.httpCookies = cookies;
+    public static class Builder {
+        private HttpMethod method;
+        private String path;
+        private HttpVersion httpVersion;
+        private HttpHeaders headers;
+        private HttpBody body;
+        private Parameters parameters;
+        private HttpCookies httpCookies;
+
+        public Builder(HttpMethod method, String path, HttpVersion httpVersion) {
+            this.method = method;
+            this.path = path;
+            this.httpVersion = httpVersion;
+            this.body = HttpBody.empty();
+            this.headers = new HttpHeaders();
+            this.parameters = new Parameters();
+            this.httpCookies = new HttpCookies();
+        }
+
+        public Builder headers(HttpHeaders headers) {
+            this.headers.extend(headers);
+            return this;
+        }
+
+        public Builder header(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        public Builder body(HttpBody body) {
+            this.body = body;
+            return this;
+        }
+
+        public Builder parameters(Parameters parameters) {
+            this.parameters.extend(parameters);
+            return this;
+        }
+
+        public Builder parameter(String key, String value) {
+            this.parameters.addParameter(key, value);
+            return this;
+        }
+
+        public Builder cookies(HttpCookies cookies) {
+            this.httpCookies.extend(cookies);
+            return this;
+        }
+
+        public Builder cookie(HttpCookie cookie) {
+            this.httpCookies.setCookie(cookie);
+            return this;
+        }
+
+        public HttpRequest build() {
+            return new HttpRequest(this);
+        }
     }
 
     public HttpMethod getMethod() {
@@ -90,9 +124,9 @@ public class HttpRequest {
         sb.append("*headers*").append(StringUtils.LINE_SEPERATOR);
         sb.append(headers.toString());
 
-        if (body != null) {
+        if (!body.isEmpty()) {
             sb.append("*body*").append(StringUtils.LINE_SEPERATOR);
-            sb.append(body); //TODO body 구현
+            sb.append(body);
         }
 
         return sb.toString();

--- a/src/main/java/codesquad/http/HttpRequest.java
+++ b/src/main/java/codesquad/http/HttpRequest.java
@@ -9,6 +9,7 @@ public class HttpRequest {
     private HttpHeaders headers;
     private HttpBody body;
     private Parameters parameters;
+    private HttpCookies httpCookies;
 
     public HttpRequest(
             HttpMethod method,
@@ -24,6 +25,25 @@ public class HttpRequest {
         this.headers = headers;
         this.body = body;
         this.parameters = parameters;
+        this.httpCookies = new HttpCookies();
+    }
+
+    public HttpRequest(
+            HttpMethod method,
+            String path,
+            HttpVersion httpVersion,
+            HttpHeaders headers,
+            HttpBody body,
+            Parameters parameters,
+            HttpCookies cookies
+    ) {
+        this.method = method;
+        this.path = path;
+        this.httpVersion = httpVersion;
+        this.headers = headers;
+        this.body = body;
+        this.parameters = parameters;
+        this.httpCookies = cookies;
     }
 
     public HttpMethod getMethod() {

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -9,20 +9,62 @@ public class HttpResponse {
     private HttpBody body;
     private HttpCookies httpCookies;
 
-    public HttpResponse(HttpRequest request, HttpStatus status, HttpHeaders headers, HttpBody body) {
-        this.request = request;
-        this.status = status;
-        this.headers = headers;
-        this.body = body;
-        this.httpCookies = new HttpCookies();
+    private HttpResponse(Builder builder) {
+        this.request = builder.request;
+        this.status = builder.status;
+        this.headers = builder.headers;
+        this.body = builder.body;
+        this.httpCookies = builder.httpCookies;
     }
 
-    public HttpResponse(HttpRequest request, HttpStatus status, HttpHeaders headers, HttpBody body, HttpCookies cookies) {
-        this.request = request;
-        this.status = status;
-        this.headers = headers;
-        this.body = body;
-        this.httpCookies = cookies;
+    public static class Builder {
+        private final HttpRequest request;
+        private final HttpStatus status;
+        private HttpHeaders headers;
+        private HttpBody body;
+        private HttpCookies httpCookies;
+
+        public Builder(HttpRequest request, HttpStatus status) {
+            this.request = request;
+            this.status = status;
+            this.headers = new HttpHeaders();
+            this.body = HttpBody.empty();
+            this.httpCookies = new HttpCookies();
+        }
+
+        public HttpResponse.Builder headers(HttpHeaders headers) {
+            this.headers.extend(headers);
+            return this;
+        }
+
+        public HttpResponse.Builder header(String key, String value) {
+            this.headers.put(key, value);
+            return this;
+        }
+
+        public Builder body(HttpBody body) {
+            this.body = body;
+            return this;
+        }
+
+        public HttpResponse.Builder cookies(HttpCookies cookies) {
+            this.httpCookies.extend(cookies);
+            return this;
+        }
+
+        public HttpResponse.Builder cookie(HttpCookie cookie) {
+            this.httpCookies.setCookie(cookie);
+            return this;
+        }
+
+        public HttpResponse.Builder redirect(String path) {
+            this.headers.put("Location", path);
+            return this;
+        }
+
+        public HttpResponse build() {
+            return new HttpResponse(this);
+        }
     }
 
     public HttpRequest getRequest() {
@@ -49,45 +91,45 @@ public class HttpResponse {
         httpCookies.setCookie(cookie);
     }
 
-    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType) {
-        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType));
-    }
-
-    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType, HttpCookies cookies) {
-        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType), cookies);
-    }
-
-    public static HttpResponse createErrorResponse(HttpRequest request) {
-        HttpHeaders resHeaders = new HttpHeaders();
-
-        return new HttpResponse(request, HttpStatus.INTERNAL_SERVER_ERROR, resHeaders, new HttpBody(null, MimeType.NONE));
-    }
-
-
-    public static HttpResponse createNotFoundResponse(HttpRequest request) {
-        HttpHeaders resHeaders = new HttpHeaders();
-
-        return new HttpResponse(request, HttpStatus.NOT_FOUND, resHeaders, new HttpBody(null, MimeType.NONE));
-    }
-
-    public static HttpResponse createNoContentResponse(HttpRequest request) {
-        HttpHeaders resHeaders = new HttpHeaders();
-
-        return new HttpResponse(request, HttpStatus.NO_CONTENT, resHeaders, null);
-    }
-
-    public static HttpResponse createRedirectResponse(HttpRequest request, String location) {
-        HttpHeaders resHeaders = new HttpHeaders();
-        resHeaders.put("Location", location);
-
-        return new HttpResponse(request, HttpStatus.FOUND, resHeaders, null);  // 302 Found
-    }
-
-    public static HttpResponse createIllegalArgumentResponse(HttpRequest request) {
-        HttpHeaders httpHeaders = new HttpHeaders();
-
-        return new HttpResponse(request, HttpStatus.ILLEGAL_ARGUMENT, httpHeaders, null);
-    }
+//    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType) {
+//        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType));
+//    }
+//
+//    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType, HttpCookies cookies) {
+//        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType), cookies);
+//    }
+//
+//    public static HttpResponse createErrorResponse(HttpRequest request) {
+//        HttpHeaders resHeaders = new HttpHeaders();
+//
+//        return new HttpResponse(request, HttpStatus.INTERNAL_SERVER_ERROR, resHeaders, new HttpBody(null, MimeType.NONE));
+//    }
+//
+//
+//    public static HttpResponse createNotFoundResponse(HttpRequest request) {
+//        HttpHeaders resHeaders = new HttpHeaders();
+//
+//        return new HttpResponse(request, HttpStatus.NOT_FOUND, resHeaders, new HttpBody(null, MimeType.NONE));
+//    }
+//
+//    public static HttpResponse createNoContentResponse(HttpRequest request) {
+//        HttpHeaders resHeaders = new HttpHeaders();
+//
+//        return new HttpResponse(request, HttpStatus.NO_CONTENT, resHeaders, null);
+//    }
+//
+//    public static HttpResponse createRedirectResponse(HttpRequest request, String location) {
+//        HttpHeaders resHeaders = new HttpHeaders();
+//        resHeaders.put("Location", location);
+//
+//        return new HttpResponse(request, HttpStatus.FOUND, resHeaders, null);  // 302 Found
+//    }
+//
+//    public static HttpResponse createIllegalArgumentResponse(HttpRequest request) {
+//        HttpHeaders httpHeaders = new HttpHeaders();
+//
+//        return new HttpResponse(request, HttpStatus.ILLEGAL_ARGUMENT, httpHeaders, null);
+//    }
 
     @Override
     public String toString() {

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -65,11 +65,17 @@ public class HttpResponse {
         return new HttpResponse(request, HttpStatus.FOUND, resHeaders, null);  // 302 Found
     }
 
+    public static HttpResponse createIllegalArgumentResponse(HttpRequest request) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        return new HttpResponse(request, HttpStatus.ILLEGAL_ARGUMENT, httpHeaders, null);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("----response----").append(StringUtils.LINE_SEPERATOR);
-        sb.append("status: " + status).append(StringUtils.LINE_SEPERATOR);
+        sb.append("status: ").append(status).append(StringUtils.LINE_SEPERATOR);
         sb.append("*headers*").append(StringUtils.LINE_SEPERATOR);
         sb.append(headers.toString());
 

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -91,46 +91,6 @@ public class HttpResponse {
         httpCookies.setCookie(cookie);
     }
 
-//    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType) {
-//        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType));
-//    }
-//
-//    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType, HttpCookies cookies) {
-//        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType), cookies);
-//    }
-//
-//    public static HttpResponse createErrorResponse(HttpRequest request) {
-//        HttpHeaders resHeaders = new HttpHeaders();
-//
-//        return new HttpResponse(request, HttpStatus.INTERNAL_SERVER_ERROR, resHeaders, new HttpBody(null, MimeType.NONE));
-//    }
-//
-//
-//    public static HttpResponse createNotFoundResponse(HttpRequest request) {
-//        HttpHeaders resHeaders = new HttpHeaders();
-//
-//        return new HttpResponse(request, HttpStatus.NOT_FOUND, resHeaders, new HttpBody(null, MimeType.NONE));
-//    }
-//
-//    public static HttpResponse createNoContentResponse(HttpRequest request) {
-//        HttpHeaders resHeaders = new HttpHeaders();
-//
-//        return new HttpResponse(request, HttpStatus.NO_CONTENT, resHeaders, null);
-//    }
-//
-//    public static HttpResponse createRedirectResponse(HttpRequest request, String location) {
-//        HttpHeaders resHeaders = new HttpHeaders();
-//        resHeaders.put("Location", location);
-//
-//        return new HttpResponse(request, HttpStatus.FOUND, resHeaders, null);  // 302 Found
-//    }
-//
-//    public static HttpResponse createIllegalArgumentResponse(HttpRequest request) {
-//        HttpHeaders httpHeaders = new HttpHeaders();
-//
-//        return new HttpResponse(request, HttpStatus.ILLEGAL_ARGUMENT, httpHeaders, null);
-//    }
-
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -31,12 +31,8 @@ public class HttpResponse {
         return body;
     }
 
-    public static HttpResponse createOkResponse(HttpRequest request, byte[] bytes, MimeType contentType) {
-        HttpHeaders resHeaders = new HttpHeaders();
-        resHeaders.put(HttpHeaders.CONTENT_TYPE, contentType.getMimeType());
-        resHeaders.put(HttpHeaders.CONTENT_LENGTH, String.valueOf(bytes != null ? bytes.length : 0));
-
-        return new HttpResponse(request, HttpStatus.OK, resHeaders, new HttpBody(bytes, contentType));
+    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType) {
+        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType));
     }
 
     public static HttpResponse createErrorResponse(HttpRequest request) {

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -69,6 +69,7 @@ public class HttpResponse {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         sb.append("----response----").append(StringUtils.LINE_SEPERATOR);
+        sb.append("status: " + status).append(StringUtils.LINE_SEPERATOR);
         sb.append("*headers*").append(StringUtils.LINE_SEPERATOR);
         sb.append(headers.toString());
 

--- a/src/main/java/codesquad/http/HttpResponse.java
+++ b/src/main/java/codesquad/http/HttpResponse.java
@@ -7,12 +7,22 @@ public class HttpResponse {
     private HttpStatus status;
     private HttpHeaders headers;
     private HttpBody body;
+    private HttpCookies httpCookies;
 
     public HttpResponse(HttpRequest request, HttpStatus status, HttpHeaders headers, HttpBody body) {
         this.request = request;
         this.status = status;
         this.headers = headers;
         this.body = body;
+        this.httpCookies = new HttpCookies();
+    }
+
+    public HttpResponse(HttpRequest request, HttpStatus status, HttpHeaders headers, HttpBody body, HttpCookies cookies) {
+        this.request = request;
+        this.status = status;
+        this.headers = headers;
+        this.body = body;
+        this.httpCookies = cookies;
     }
 
     public HttpRequest getRequest() {
@@ -31,8 +41,20 @@ public class HttpResponse {
         return body;
     }
 
+    public HttpCookies getHttpCookies() {
+        return httpCookies;
+    }
+
+    public void setCookie(HttpCookie cookie) {
+        httpCookies.setCookie(cookie);
+    }
+
     public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType) {
         return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType));
+    }
+
+    public static HttpResponse createOkResponse(HttpRequest request, HttpHeaders httpHeaders, byte[] bytes, MimeType contentType, HttpCookies cookies) {
+        return new HttpResponse(request, HttpStatus.OK, httpHeaders, new HttpBody(bytes, contentType), cookies);
     }
 
     public static HttpResponse createErrorResponse(HttpRequest request) {
@@ -75,9 +97,9 @@ public class HttpResponse {
         sb.append("*headers*").append(StringUtils.LINE_SEPERATOR);
         sb.append(headers.toString());
 
-        if (body != null) {
+        if (body != null && body.getBytes() != null) {
             sb.append("*body*").append(StringUtils.LINE_SEPERATOR);
-            sb.append(body); //TODO body 구현
+            sb.append(body);
         }
 
         return sb.toString();

--- a/src/main/java/codesquad/http/HttpStatus.java
+++ b/src/main/java/codesquad/http/HttpStatus.java
@@ -5,6 +5,7 @@ public enum HttpStatus {
     OK(200, "OK"),
     NO_CONTENT(204, "NO CONTENT"),
     FOUND(302, "FOUND"),
+    ILLEGAL_ARGUMENT(400, "ILLEGAL ARGUMENT"),
     INTERNAL_SERVER_ERROR(500, "INTERNAL SERVER ERROR");
 
     private int statusCode;

--- a/src/main/java/codesquad/http/Parameters.java
+++ b/src/main/java/codesquad/http/Parameters.java
@@ -9,19 +9,23 @@ import static codesquad.utils.StringUtils.LINE_SEPERATOR;
 public class Parameters {
     private Map<String, String> parameter;
 
-    private Parameters(Map<String, String> parameter) {
-        this.parameter = parameter;
+    public Parameters() {
+        this.parameter = new HashMap<>();
     }
 
     public static Parameters of(String paramString) {
-        HashMap<String, String> map = new HashMap<>();
+        if (paramString == null) {
+            return new Parameters();
+        }
+
+        Parameters parameters = new Parameters();
         String[] split = paramString.split("&");
         for (String entry : split) {
             String[] keyValue = entry.split("=");
-            map.put(keyValue[0], keyValue[1]);
+            parameters.addParameter(keyValue[0], keyValue[1]);
         }
 
-        return new Parameters(map);
+        return parameters;
     }
 
     public Map<String, String> getParameters() {
@@ -50,5 +54,9 @@ public class Parameters {
             sb.append("(" + key + ", " + parameter.get(key) + ")").append(LINE_SEPERATOR);
         }
         return sb.toString();
+    }
+
+    public void extend(Parameters other) {
+        parameter.putAll(other.getParameters());
     }
 }

--- a/src/main/java/codesquad/model/User.java
+++ b/src/main/java/codesquad/model/User.java
@@ -21,6 +21,10 @@ public class User {
         return userId;
     }
 
+    public String getPassword() {
+        return password;
+    }
+
     @Override
     public String toString() {
         return "User{" +

--- a/src/main/resources/static/login/error.html
+++ b/src/main/resources/static/login/error.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg"/></a>
+        <ul class="header__menu">
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            </li>
+            <li class="header__menu__item">
+                <a class="btn btn_ghost btn_size_s" href="/registration">
+                    회원 가입
+                </a>
+            </li>
+        </ul>
+    </header>
+    <div class="page">
+        <h2 class="page-title">로그인 실패</h2>
+        <button
+                id="login-btn"
+                class="btn btn_contained btn_size_m"
+                style="margin-top: 24px"
+                type="button"
+        >
+            홈화면으로
+        </button>
+    </div>
+</div>
+</body>
+
+<script>
+    document.getElementById('login-btn').addEventListener('click', function () {
+        window.location.href = '/index.html';
+    });
+</script>
+</html>

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -1,56 +1,100 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/"><img src="../img/signiture.svg" /></a>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/"><img src="../img/signiture.svg"/></a>
         <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
-          </li>
-          <li class="header__menu__item">
-            <a class="btn btn_ghost btn_size_s" href="/registration">
-              회원 가입
-            </a>
-          </li>
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
+            </li>
+            <li class="header__menu__item">
+                <a class="btn btn_ghost btn_size_s" href="/registration">
+                    회원 가입
+                </a>
+            </li>
         </ul>
-      </header>
-      <div class="page">
+    </header>
+    <div class="page">
         <h2 class="page-title">로그인</h2>
         <form class="form">
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">아이디</p>
-            <input
-              class="input_textfield"
-              placeholder="아이디를 입력해주세요"
-              autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_s">
-            <p class="title_textfield">비밀번호</p>
-            <input
-              class="input_textfield"
-              type="password"
-              placeholder="비밀번호를 입력해주세요"
-              autocomplete="current-password"
-            />
-          </div>
-          <button
-            id="login-btn"
-            class="btn btn_contained btn_size_m"
-            style="margin-top: 24px"
-            type="button"
-          >
-            로그인
-          </button>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">아이디</p>
+                <input
+                        id="userId"
+                        class="input_textfield"
+                        placeholder="아이디를 입력해주세요"
+                        autocomplete="username"
+                />
+            </div>
+            <div class="textfield textfield_size_s">
+                <p class="title_textfield">비밀번호</p>
+                <input
+                        id="password"
+                        class="input_textfield"
+                        type="password"
+                        placeholder="비밀번호를 입력해주세요"
+                        autocomplete="current-password"
+                />
+            </div>
+            <button
+                    id="login-btn"
+                    class="btn btn_contained btn_size_m"
+                    style="margin-top: 24px"
+                    type="button"
+            >
+                로그인
+            </button>
         </form>
-      </div>
     </div>
-  </body>
+</div>
+</body>
+<script>
+    document.getElementById('login-btn').addEventListener('click', function () {
+        const userId = document.getElementById('userId').value;
+        const password = document.getElementById('password').value;
+
+        const data = new URLSearchParams();
+        data.append('userId', userId);
+        data.append('password', password);
+
+        fetch('http://localhost:8080/user/login', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                'Accept': '*/*',
+                'Connection': 'keep-alive'
+            },
+            body: data.toString(),
+            redirect: 'follow' // Ensure redirects are followed
+        })
+            .then(response => {
+                if (response.ok) {
+                    return response.text().then(text => {
+                        if (response.redirected) {
+                            window.location.href = response.url; // Handle the redirect if necessary
+                        } else {
+                            window.alert("로그인 성공");
+                        }
+                    });
+                } else if (response.status === 400) {
+                    window.alert("로그인 실패: 잘못된 아이디 또는 비밀번호입니다.");
+                } else {
+                    return response.text().then(text => {
+                        throw new Error(text);
+                    });
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('로그인 중 오류가 발생했습니다.');
+            });
+    });
+</script>
 </html>

--- a/src/main/resources/static/login/index.html
+++ b/src/main/resources/static/login/index.html
@@ -84,7 +84,7 @@
                         }
                     });
                 } else if (response.status === 400) {
-                    window.alert("로그인 실패: 잘못된 아이디 또는 비밀번호입니다.");
+                    window.alert("로그인 실패");
                 } else {
                     return response.text().then(text => {
                         throw new Error(text);

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -96,14 +96,18 @@
         })
             .then((response) => {
                 if (response.redirected) {
+                    window.alert("회원가입 성공")
                     window.location.href = response.url; // Manually handle the redirect if necessary
-                } else if (response.status === 200) {
-                    window.alert("회원가입 성공");
+                } else if (response.status === 400) {
+                    return response.text().then(text => {
+                        window.alert("중복된 아이디가 있습니다");
+                    });
                 } else {
                     return response.text().then(text => {
                         throw new Error(text);
                     });
                 }
+
             })
             .catch(error => {
                 console.error('Error:', error);

--- a/src/test/java/codesquad/adapter/UserAdapterTest.java
+++ b/src/test/java/codesquad/adapter/UserAdapterTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserAdapterTest {
     private UserAdapter userAdapter;
@@ -41,6 +42,22 @@ class UserAdapterTest {
         assertEquals(HttpStatus.FOUND, response1.getStatus());
         assertEquals(HttpStatus.FOUND, response2.getStatus());
         assertEquals(2, UserDb.size());
+    }
+
+    @Test
+    public void UserAdapter가_주어졌을때_create메소드를_통해_유저를_저장할때_이미_존재하는_유저이면_400에러를_던진다() {
+        String sameId = "똑같은 아이디~";
+        byte[] bytes1 = String.format("userId=%s&password=1234&name=kyu1&email=email1", sameId).getBytes();
+        byte[] bytes2 = String.format("userId=%s&password=1234&name=kyu2&email=email2", sameId).getBytes();
+
+        HttpRequest request1 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes1, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest request2 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes2, MimeType.X_WWW_FORM_URLENCODED), null);
+
+        HttpResponse response1 = userAdapter.handle(request1);
+        assertEquals(HttpStatus.FOUND, response1.getStatus());
+
+        assertThrows(IllegalArgumentException.class, () -> userAdapter.handle(request2));
+        assertEquals(1, UserDb.size());
     }
 
     @Test

--- a/src/test/java/codesquad/adapter/UserAdapterTest.java
+++ b/src/test/java/codesquad/adapter/UserAdapterTest.java
@@ -114,7 +114,7 @@ class UserAdapterTest {
                 .build();
         HttpResponse loginResponse = userAdapter.handle(loginRequest);
 
-        Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
+        Assertions.assertEquals(302, loginResponse.getStatus().getStatusCode());
         assertTrue(UserSession.contains(userId));
     }
 
@@ -147,7 +147,7 @@ class UserAdapterTest {
                 .build();
         HttpResponse loginResponse = userAdapter.handle(loginRequest);
 
-        Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
+        Assertions.assertEquals(302, loginResponse.getStatus().getStatusCode());
 
         HttpCookies httpCookies = loginResponse.getHttpCookies();
         Assertions.assertNotNull(httpCookies);

--- a/src/test/java/codesquad/adapter/UserAdapterTest.java
+++ b/src/test/java/codesquad/adapter/UserAdapterTest.java
@@ -126,8 +126,16 @@ class UserAdapterTest {
         HttpResponse loginResponse = userAdapter.handle(loginRequest);
 
         Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
-        Assertions.assertTrue(loginResponse.getHeaders().contains(HttpHeaders.SET_COOKIE));
 
-        //TODO sid, path 검증
+        HttpCookies httpCookies = loginResponse.getHttpCookies();
+        Assertions.assertNotNull(httpCookies);
+
+        Assertions.assertTrue(httpCookies.contains("sid"));
+
+        HttpCookie cookie = httpCookies.getCookie("sid");
+        Assertions.assertEquals("/", cookie.getPath());
+//        // Check that the Set-Cookie header contains 'sid' and 'Path=/'
+//        assertTrue(setCookieHeader.contains("sid="));
+//        assertTrue(setCookieHeader.contains("Path=/"));
     }
 }

--- a/src/test/java/codesquad/adapter/UserAdapterTest.java
+++ b/src/test/java/codesquad/adapter/UserAdapterTest.java
@@ -1,13 +1,13 @@
 package codesquad.adapter;
 
 import codesquad.db.UserDb;
+import codesquad.db.UserSession;
 import codesquad.http.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserAdapterTest {
     private UserAdapter userAdapter;
@@ -15,10 +15,12 @@ class UserAdapterTest {
     @BeforeEach
     public void setUp() {
         userAdapter = new UserAdapter();
+        UserSession.refresh();
+        UserDb.refresh();
     }
 
     @Test
-    public void UserAdapter는_prefix가_user인_api를_제공한다() {
+    public void prefix가_user인_api를_제공한다() {
         String path = "/user/create";
         boolean supports = userAdapter.supports(path);
         assertEquals(true, supports);
@@ -29,7 +31,7 @@ class UserAdapterTest {
     }
 
     @Test
-    public void UserAdapter가_주어졌을때_create메소드를_통해_유저를_저장한다() {
+    public void create메소드를_통해_유저를_저장한다() {
         byte[] bytes1 = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
         byte[] bytes2 = "userId=id2&password=1234&name=kyu2&email=email2".getBytes();
 
@@ -45,7 +47,7 @@ class UserAdapterTest {
     }
 
     @Test
-    public void UserAdapter가_주어졌을때_create메소드를_통해_유저를_저장할때_이미_존재하는_유저이면_400에러를_던진다() {
+    public void create메소드를_통해_유저를_저장할때_이미_존재하는_유저이면_400에러를_던진다() {
         String sameId = "똑같은 아이디~";
         byte[] bytes1 = String.format("userId=%s&password=1234&name=kyu1&email=email1", sameId).getBytes();
         byte[] bytes2 = String.format("userId=%s&password=1234&name=kyu2&email=email2", sameId).getBytes();
@@ -54,14 +56,16 @@ class UserAdapterTest {
         HttpRequest request2 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes2, MimeType.X_WWW_FORM_URLENCODED), null);
 
         HttpResponse response1 = userAdapter.handle(request1);
-        assertEquals(HttpStatus.FOUND, response1.getStatus());
+        HttpResponse response2 = userAdapter.handle(request2);
 
-        assertThrows(IllegalArgumentException.class, () -> userAdapter.handle(request2));
+
+        assertEquals(HttpStatus.FOUND, response1.getStatus());
+        assertEquals(HttpStatus.ILLEGAL_ARGUMENT, response2.getStatus());
         assertEquals(1, UserDb.size());
     }
 
     @Test
-    public void UserAdapter가_주어졌을때_create메소드를_실행하면_메인화면으로_리다이렉트된다() {
+    public void create메소드를_실행하면_메인화면으로_리다이렉트된다() {
         byte[] bytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
         HttpRequest request = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes, MimeType.X_WWW_FORM_URLENCODED), null);
 
@@ -72,11 +76,58 @@ class UserAdapterTest {
     }
 
     @Test
-    public void UserAdapter가_주어졌을때_create메소드는_GET으로_동작하지_않는다() {
+    public void create메소드는_GET으로_동작하지_않는다() {
         byte[] bytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
 
         HttpRequest request = new HttpRequest(HttpMethod.GET, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes, MimeType.X_WWW_FORM_URLENCODED), null);
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> userAdapter.handle(request));
+    }
+
+    @Test
+    public void login메소드는_회원가입했던_유저에_대해서_세션을_만들어준다() {
+        String userId = "id1";
+        byte[] signupBytes = String.format("userId=%s&password=1234&name=kyu1&email=email1", userId).getBytes();
+
+        HttpRequest signupRequest = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(signupBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpResponse signupResponse = userAdapter.handle(signupRequest);
+
+        Assertions.assertEquals(302, signupResponse.getStatus().getStatusCode());
+
+        byte[] loginBytes = "userId=id1&password=1234".getBytes();
+        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpResponse loginResponse = userAdapter.handle(loginRequest);
+
+        Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
+        Assertions.assertTrue(UserSession.contains(userId));
+    }
+
+    @Test
+    public void login메소드는_회원가입안한_유저에_대해서_400에러를_던진다() {
+        byte[] loginBytes = "userId=id1&password=1234".getBytes();
+        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+
+        HttpResponse response = userAdapter.handle(loginRequest);
+
+        Assertions.assertEquals(400, response.getStatus().getStatusCode());
+    }
+
+    @Test
+    public void login메소드는_회원가입했던_유저에대해서_Set_Cookie헤더를_갖고_sid와_path를_포함한다() {
+        byte[] signupBytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
+
+        HttpRequest signupRequest = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(signupBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpResponse signupResponse = userAdapter.handle(signupRequest);
+
+        Assertions.assertEquals(302, signupResponse.getStatus().getStatusCode());
+
+        byte[] loginBytes = "userId=id1&password=1234".getBytes();
+        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpResponse loginResponse = userAdapter.handle(loginRequest);
+
+        Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
+        Assertions.assertTrue(loginResponse.getHeaders().contains(HttpHeaders.SET_COOKIE));
+
+        //TODO sid, path 검증
     }
 }

--- a/src/test/java/codesquad/adapter/UserAdapterTest.java
+++ b/src/test/java/codesquad/adapter/UserAdapterTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class UserAdapterTest {
     private UserAdapter userAdapter;
@@ -35,8 +36,12 @@ class UserAdapterTest {
         byte[] bytes1 = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
         byte[] bytes2 = "userId=id2&password=1234&name=kyu2&email=email2".getBytes();
 
-        HttpRequest request1 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes1, MimeType.X_WWW_FORM_URLENCODED), null);
-        HttpRequest request2 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes2, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest request1 = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes1, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
+        HttpRequest request2 = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes2, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
 
         HttpResponse response1 = userAdapter.handle(request1);
         HttpResponse response2 = userAdapter.handle(request2);
@@ -52,12 +57,15 @@ class UserAdapterTest {
         byte[] bytes1 = String.format("userId=%s&password=1234&name=kyu1&email=email1", sameId).getBytes();
         byte[] bytes2 = String.format("userId=%s&password=1234&name=kyu2&email=email2", sameId).getBytes();
 
-        HttpRequest request1 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes1, MimeType.X_WWW_FORM_URLENCODED), null);
-        HttpRequest request2 = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes2, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest request1 = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes1, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
+        HttpRequest request2 = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes2, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
 
         HttpResponse response1 = userAdapter.handle(request1);
         HttpResponse response2 = userAdapter.handle(request2);
-
 
         assertEquals(HttpStatus.FOUND, response1.getStatus());
         assertEquals(HttpStatus.ILLEGAL_ARGUMENT, response2.getStatus());
@@ -67,7 +75,9 @@ class UserAdapterTest {
     @Test
     public void create메소드를_실행하면_메인화면으로_리다이렉트된다() {
         byte[] bytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
-        HttpRequest request = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
 
         HttpResponse response = userAdapter.handle(request);
 
@@ -79,7 +89,9 @@ class UserAdapterTest {
     public void create메소드는_GET으로_동작하지_않는다() {
         byte[] bytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
 
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(bytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(bytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
 
         Assertions.assertThrows(IllegalArgumentException.class, () -> userAdapter.handle(request));
     }
@@ -89,23 +101,29 @@ class UserAdapterTest {
         String userId = "id1";
         byte[] signupBytes = String.format("userId=%s&password=1234&name=kyu1&email=email1", userId).getBytes();
 
-        HttpRequest signupRequest = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(signupBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest signupRequest = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(signupBytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
         HttpResponse signupResponse = userAdapter.handle(signupRequest);
 
         Assertions.assertEquals(302, signupResponse.getStatus().getStatusCode());
 
         byte[] loginBytes = "userId=id1&password=1234".getBytes();
-        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest loginRequest = new HttpRequest.Builder(HttpMethod.POST, "/user/login", HttpVersion.HTTP11)
+                .body(HttpBody.of(loginBytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
         HttpResponse loginResponse = userAdapter.handle(loginRequest);
 
         Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
-        Assertions.assertTrue(UserSession.contains(userId));
+        assertTrue(UserSession.contains(userId));
     }
 
     @Test
     public void login메소드는_회원가입안한_유저에_대해서_400에러를_던진다() {
         byte[] loginBytes = "userId=id1&password=1234".getBytes();
-        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest loginRequest = new HttpRequest.Builder(HttpMethod.POST, "/user/login", HttpVersion.HTTP11)
+                .body(HttpBody.of(loginBytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
 
         HttpResponse response = userAdapter.handle(loginRequest);
 
@@ -116,13 +134,17 @@ class UserAdapterTest {
     public void login메소드는_회원가입했던_유저에대해서_Set_Cookie헤더를_갖고_sid와_path를_포함한다() {
         byte[] signupBytes = "userId=id1&password=1234&name=kyu1&email=email1".getBytes();
 
-        HttpRequest signupRequest = new HttpRequest(HttpMethod.POST, "/user/create", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(signupBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest signupRequest = new HttpRequest.Builder(HttpMethod.POST, "/user/create", HttpVersion.HTTP11)
+                .body(HttpBody.of(signupBytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
         HttpResponse signupResponse = userAdapter.handle(signupRequest);
 
         Assertions.assertEquals(302, signupResponse.getStatus().getStatusCode());
 
         byte[] loginBytes = "userId=id1&password=1234".getBytes();
-        HttpRequest loginRequest = new HttpRequest(HttpMethod.POST, "/user/login", HttpVersion.HTTP11, new HttpHeaders(), new HttpBody(loginBytes, MimeType.X_WWW_FORM_URLENCODED), null);
+        HttpRequest loginRequest = new HttpRequest.Builder(HttpMethod.POST, "/user/login", HttpVersion.HTTP11)
+                .body(HttpBody.of(loginBytes, MimeType.X_WWW_FORM_URLENCODED))
+                .build();
         HttpResponse loginResponse = userAdapter.handle(loginRequest);
 
         Assertions.assertEquals(200, loginResponse.getStatus().getStatusCode());
@@ -130,12 +152,9 @@ class UserAdapterTest {
         HttpCookies httpCookies = loginResponse.getHttpCookies();
         Assertions.assertNotNull(httpCookies);
 
-        Assertions.assertTrue(httpCookies.contains("sid"));
+        assertTrue(httpCookies.contains("sid"));
 
         HttpCookie cookie = httpCookies.getCookie("sid");
-        Assertions.assertEquals("/", cookie.getPath());
-//        // Check that the Set-Cookie header contains 'sid' and 'Path=/'
-//        assertTrue(setCookieHeader.contains("sid="));
-//        assertTrue(setCookieHeader.contains("Path=/"));
+        assertEquals(cookie.getPath(), "/");
     }
 }

--- a/src/test/java/codesquad/handler/DynamicHandlerTest.java
+++ b/src/test/java/codesquad/handler/DynamicHandlerTest.java
@@ -22,7 +22,7 @@ class DynamicHandlerTest {
 
             @Override
             public HttpResponse handle(HttpRequest request) {
-                return HttpResponse.createOkResponse(request, null, MimeType.NONE);
+                return HttpResponse.createOkResponse(request, new HttpHeaders(), null, MimeType.NONE);
             }
         }));
     }

--- a/src/test/java/codesquad/handler/DynamicHandlerTest.java
+++ b/src/test/java/codesquad/handler/DynamicHandlerTest.java
@@ -22,15 +22,15 @@ class DynamicHandlerTest {
 
             @Override
             public HttpResponse handle(HttpRequest request) {
-                return HttpResponse.createOkResponse(request, new HttpHeaders(), null, MimeType.NONE);
+                return new HttpResponse.Builder(request, HttpStatus.OK)
+                        .build();
             }
         }));
     }
 
     @Test
     void DynamicHandler가_주어지고_존재하는_어댑터에_대한_요청이_주어졌을때_200상태코드가_주어진다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/exist", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/exist", HttpVersion.HTTP11).build();
         assertTrue(handler.canHandle(request));
 
         HttpResponse response = handler.handle(request);
@@ -39,8 +39,7 @@ class DynamicHandlerTest {
 
     @Test
     void DynamicHandler가_주어지고_존재하지않는_어댑터에_대한_요청이_주어졌을때_예외가_발생한다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/non-existent", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/non-existent", HttpVersion.HTTP11).build();
 
         assertThrows(IllegalArgumentException.class, () -> {
             handler.handle(request);
@@ -50,11 +49,11 @@ class DynamicHandlerTest {
     @Test
     void DynamicHandler_canHandle_메서드가_정확하게_작동하는지_검증한다() {
         // 지원하는 경로에 대한 요청
-        HttpRequest supportedRequest = new HttpRequest(HttpMethod.GET, "/exist", HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest supportedRequest = new HttpRequest.Builder(HttpMethod.GET, "/exist", HttpVersion.HTTP11).build();
         assertTrue(handler.canHandle(supportedRequest));
 
         // 지원하지 않는 경로에 대한 요청
-        HttpRequest unsupportedRequest = new HttpRequest(HttpMethod.GET, "/non-existent", HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest unsupportedRequest = new HttpRequest.Builder(HttpMethod.GET, "/non-existent", HttpVersion.HTTP11).build();
         assertFalse(handler.canHandle(unsupportedRequest));
     }
 }

--- a/src/test/java/codesquad/handler/RedirectStaticFileHandlerTest.java
+++ b/src/test/java/codesquad/handler/RedirectStaticFileHandlerTest.java
@@ -25,8 +25,7 @@ class RedirectStaticFileHandlerTest {
 
     @Test
     void RedirectStaticFileHandler가_주어지고_존재하지않는_Path가_주어졌으나_디렉토리의_index_html가_존재할때_200상태코드가_주어진다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11).build();
 
         HttpResponse response = handler.handle(request);
 
@@ -41,8 +40,7 @@ class RedirectStaticFileHandlerTest {
                 List.of(nonExistentPath)
         );
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, nonExistentPath, HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, nonExistentPath, HttpVersion.HTTP11).build();
 
         HttpResponse response = handler.handle(request);
 
@@ -67,8 +65,7 @@ class RedirectStaticFileHandlerTest {
                 List.of(redirectNeededPath)
         );
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11).build();
 
         HttpResponse response = faultyHandler.handle(request);
 
@@ -78,11 +75,11 @@ class RedirectStaticFileHandlerTest {
     @Test
     void RedirectStaticFileHandler_canHandle_메서드가_정확하게_작동하는지_검증한다() {
         // whitelist에 존재하는 경로에 대한 요청
-        HttpRequest validRequest = new HttpRequest(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest validRequest = new HttpRequest.Builder(HttpMethod.GET, redirectNeededPath, HttpVersion.HTTP11).build();
         Assertions.assertTrue(handler.canHandle(validRequest));
 
         // whitelist에 존재하지 않는 경로에 대한 요청
-        HttpRequest invalidRequest = new HttpRequest(HttpMethod.GET, nonExistentPath, HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest invalidRequest = new HttpRequest.Builder(HttpMethod.GET, nonExistentPath, HttpVersion.HTTP11).build();
         Assertions.assertFalse(handler.canHandle(invalidRequest));
     }
 }

--- a/src/test/java/codesquad/handler/StaticFileHandlerTest.java
+++ b/src/test/java/codesquad/handler/StaticFileHandlerTest.java
@@ -10,10 +10,14 @@ import java.io.IOException;
 class StaticFileHandlerTest {
     private StaticFileHandler handler;
 
+    @BeforeEach
+    void setup() {
+        handler = new StaticFileHandler(new StaticFileReader());
+    }
+
     @Test
     void StaticFileHandler가_주어지고_존재하지않는_Path가_주어졌을때_404상태코드가_주어진다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/not-index.html", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/not-index.html", HttpVersion.HTTP11).build();
 
         HttpResponse response = handler.handle(request);
 
@@ -21,11 +25,9 @@ class StaticFileHandlerTest {
         Assertions.assertNull(response.getBody().getBytes());
     }
 
-
     @Test
     void StaticFileHandler가_주어지고_존재하는_Path가_주어졌을때_200상태코드가_주어진다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/index.html", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/index.html", HttpVersion.HTTP11).build();
 
         HttpResponse response = handler.handle(request);
 
@@ -36,8 +38,7 @@ class StaticFileHandlerTest {
 
     @Test
     void StaticFileHandler가_주어지고_CSS파일_요청시_200상태코드와_올바른_컨텐츠타입이_주어진다() {
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/main.css", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/main.css", HttpVersion.HTTP11).build();
 
         HttpResponse response = handler.handle(request);
 
@@ -49,7 +50,6 @@ class StaticFileHandlerTest {
     @Test
     void StaticFileHandler가_주어지고_파일읽기_중_에러가_발생했을때_500상태코드가_주어진다() throws IOException {
         StaticFileHandler faultyHandler = new StaticFileHandler(new StaticFileReaderSpec() {
-
             @Override
             public byte[] readFile(String path) throws IOException {
                 throw new IOException("IO 에러 발생");
@@ -61,8 +61,7 @@ class StaticFileHandlerTest {
             }
         });
 
-        HttpHeaders httpHeaders = new HttpHeaders();
-        HttpRequest request = new HttpRequest(HttpMethod.GET, "/index.html", HttpVersion.HTTP11, httpHeaders, null, null);
+        HttpRequest request = new HttpRequest.Builder(HttpMethod.GET, "/index.html", HttpVersion.HTTP11).build();
 
         HttpResponse response = faultyHandler.handle(request);
 
@@ -72,20 +71,15 @@ class StaticFileHandlerTest {
     @Test
     void StaticFileHandler_canHandle_메서드가_정확하게_작동하는지_검증한다() {
         // 파일 경로에 대한 요청
-        HttpRequest fileRequest = new HttpRequest(HttpMethod.GET, "/index.html", HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest fileRequest = new HttpRequest.Builder(HttpMethod.GET, "/index.html", HttpVersion.HTTP11).build();
         Assertions.assertTrue(handler.canHandle(fileRequest));
 
         // 디렉토리 경로에 대한 요청
-        HttpRequest directoryRequest = new HttpRequest(HttpMethod.GET, "/directory/", HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest directoryRequest = new HttpRequest.Builder(HttpMethod.GET, "/directory/", HttpVersion.HTTP11).build();
         Assertions.assertFalse(handler.canHandle(directoryRequest));
 
         // 비어 있는 경로에 대한 요청
-        HttpRequest emptyRequest = new HttpRequest(HttpMethod.GET, "", HttpVersion.HTTP11, new HttpHeaders(), null, null);
+        HttpRequest emptyRequest = new HttpRequest.Builder(HttpMethod.GET, "", HttpVersion.HTTP11).build();
         Assertions.assertFalse(handler.canHandle(emptyRequest));
-    }
-
-    @BeforeEach
-    void setup() {
-        handler = new StaticFileHandler(new StaticFileReader());
     }
 }

--- a/src/test/java/codesquad/processor/Http11ProcessorTest.java
+++ b/src/test/java/codesquad/processor/Http11ProcessorTest.java
@@ -215,7 +215,7 @@ class Http11ProcessorTest {
         assertEquals("keep-alive", request.getHeaders().get("Connection"));
         assertEquals("localhost:8080", request.getHeaders().get("Host"));
 
-        assertNull(request.getBody());
+        assertTrue(request.getBody().isEmpty());
     }
 
     @Test
@@ -243,7 +243,7 @@ class Http11ProcessorTest {
         assertEquals("body body body".getBytes().length, Integer.parseInt(request.getHeaders().get(HttpHeaders.CONTENT_LENGTH)));
         assertEquals(MimeType.HTML.getMimeType(), request.getHeaders().get(HttpHeaders.CONTENT_TYPE));
 
-        assertNotNull(request.getBody());
+        assertFalse(request.getBody().isEmpty());
     }
 
     @BeforeEach


### PR DESCRIPTION
## 구현 내용
- 커버리지 결과 (라인 커버리지 72%)
<img width="609" alt="image" src="https://github.com/woowa-techcamp-2024/java-was/assets/80209277/c1a3cc14-d202-436f-979d-a967d0e62c42">

- HttpHeader, HttpCookie, HttpResponse, HttpRequest 모두 빌더 클래스 추가 (optional 한 값들이 많은 클래스들이기 때문에 Builder 로 다양한 생성자를 제공함이 맞다고 판단)
- 로그인 기능과 그 후의 세션 기능 추가
- 쿠키를 Request 와 Response 으로 파싱하는 로직 추가

## 고민 사항
- 현재 handler 가 support 하는 Url 를 직접 넣어주어 컴파일 타임에 결정되도록 하였지만 동적으로 런타임에 바인딩 될 수 있도록 어노테이션 도입을 고려 중입니다.
- 빌더 패턴 도입에 대한 고민이 많았습니다. 예를 들면 HttpRequest 안에 HttpBody 가 있는데 만약에 바디가 없는 요청이라면 HttpBody 클래스를 null 로 할지, 아니면 그 안에 있는 변수 bytes 를 null 로 할지 고민이 많았습니다. 현재 내린 결론은 HttpBody 클래스는 두되 bytes 를 null 로 두고 isEmpty 메소드를 통해 클래스 내부에 대한 검사를 할 수 있는 방법을 제공하였습니다. 
- Cookie 헤더가 rfc 문서 상 예외적인 헤더로 분류되어 파싱에 어려움이 많았습니다. 특히 request 가 올때는 Cookie 헤더 라인 하나에 다수의 쿠키가 모두 포함되지만, response 로 나갈 때는 Set-Cookie 라인이 여러 번 나올 수 있다는 예외 사항을 파악했습니다. 이에 맞게 구현하기 위해 `HttpCookies` 클래스 안에 `HttpCookie` 를 갖도록 구현하였습니다.
- 요구사항 완료 후 라인 커버리지를 높일 계획입니다. 