### PR TITLE
[최현식] step-8 이미지 업로드 및 표시 구현

### DIFF
--- a/src/main/java/codesquad/application/domain/Article.java
+++ b/src/main/java/codesquad/application/domain/Article.java
@@ -3,6 +3,7 @@ package codesquad.application.domain;
 public record Article(
         Long id,
         String title,
-        String content
+        String content,
+        String imagePath
 ) {
 }

--- a/src/main/java/codesquad/application/handler/ArticleHandler.java
+++ b/src/main/java/codesquad/application/handler/ArticleHandler.java
@@ -47,8 +47,9 @@ public class ArticleHandler {
 
         final String title = request.body().get("title");
         final String content = request.body().get("content");
+        final String imagePath = request.body().get("image");
 
-        final Article article = new Article(null, title, content);
+        final Article article = new Article(null, title, content, imagePath);
         articleDao.add(article);
 
         return HttpResponse.found("/", "글쓰기 성공!");
@@ -99,6 +100,8 @@ public class ArticleHandler {
             "articleId", String.valueOf(article.id()),
             "title", article.title(),
             "content", article.content(),
+            "imagePath", article.imagePath(),
+//            "imagePath", OnlineFileManager.getRelativePath(article.imagePath()),
             "comments", commentBuilder.toString(),
             "holder", holderValue,
             "signupOrLogoutButton", buttonValue

--- a/src/main/java/codesquad/database/h2/ArticleH2.java
+++ b/src/main/java/codesquad/database/h2/ArticleH2.java
@@ -23,7 +23,8 @@ public class ArticleH2 implements ArticleDao {
                     CREATE TABLE IF NOT EXISTS article (
                         id BIGINT AUTO_INCREMENT PRIMARY KEY,
                         title VARCHAR(255) NOT NULL,
-                        content TEXT NOT NULL
+                        content TEXT NOT NULL,
+                        imagePath VARCHAR(255) NOT NULL
                     );
                 """;
         jdbcConnector.execute(createTableQuery);
@@ -31,13 +32,13 @@ public class ArticleH2 implements ArticleDao {
 
     @Override
     public void add(Article article) {
-        jdbcConnector.execute("INSERT INTO article (title, content) VALUES (?, ?)",
-                List.of(article.title(), article.content()));
+        jdbcConnector.execute("INSERT INTO article (title, content, imagePath) VALUES (?, ?, ?)",
+                List.of(article.title(), article.content(), article.imagePath()));
     }
 
     @Override
     public List<Article> findAll() {
-        return jdbcConnector.executeQuery("SELECT id, title, content FROM article",
+        return jdbcConnector.executeQuery("SELECT id, title, content, imagePath FROM article",
                 resultSet -> {
                     List<Article> articles = new ArrayList<>();
                     try {
@@ -45,7 +46,8 @@ public class ArticleH2 implements ArticleDao {
                             Long id = resultSet.getLong("id");
                             String title = resultSet.getString("title");
                             String content = resultSet.getString("content");
-                            articles.add(new Article(id, title, content));
+                            String imagePath = resultSet.getString("imagePath");
+                            articles.add(new Article(id, title, content, imagePath));
                         }
                     } catch (SQLException e) {
                         throw new JdbcException(e);
@@ -56,7 +58,7 @@ public class ArticleH2 implements ArticleDao {
 
     @Override
     public Optional<Article> get(long id) {
-        return jdbcConnector.executeQuery("SELECT id, title, content FROM article WHERE id = ?",
+        return jdbcConnector.executeQuery("SELECT id, title, content, imagePath FROM article WHERE id = ?",
                 List.of(String.valueOf(id)),
                 resultSet -> {
                     try {
@@ -64,7 +66,8 @@ public class ArticleH2 implements ArticleDao {
                             Long articleId = resultSet.getLong("id");
                             String title = resultSet.getString("title");
                             String content = resultSet.getString("content");
-                            return Optional.of(new Article(articleId, title, content));
+                            String imagePath = resultSet.getString("imagePath");
+                            return Optional.of(new Article(articleId, title, content, imagePath));
                         }
                         return Optional.empty();
                     } catch (SQLException e) {

--- a/src/main/java/codesquad/webserver/HttpTask.java
+++ b/src/main/java/codesquad/webserver/HttpTask.java
@@ -28,8 +28,7 @@ public record HttpTask(Socket clientSocket, RequestHandler requestHandler) imple
         SocketWriter socketWriter = new SocketWriter(clientSocket);
 
         try (clientSocket) {
-            String message = socketReader.read();
-
+            byte[] message = socketReader.readBytes();
             HttpRequest request = HttpRequestParser.parse(message);
 
             // TODO Filter 묶음을 만들고 그곳에 사용할 필터들을 등록한뒤 처리할 것
@@ -44,6 +43,9 @@ public record HttpTask(Socket clientSocket, RequestHandler requestHandler) imple
             e.printStackTrace();
         } catch (IOException e) {
             logger.error("Socket을 close하는 중에 예외가 발생했습니다.");
+            e.printStackTrace();
+        } catch (Exception e) {
+            logger.error("예상치 못한 에러가 발생했습니다.");
             e.printStackTrace();
         }
     }

--- a/src/main/java/codesquad/webserver/RequestHandler.java
+++ b/src/main/java/codesquad/webserver/RequestHandler.java
@@ -26,6 +26,7 @@ public class RequestHandler {
     }
 
     private HttpResponse createBadRequest() {
+        // TODO 이게 왜 자꾸 실행도지?
         return ErrorPageResponseFactory.badRequest();
     }
 }

--- a/src/main/java/codesquad/webserver/WebServer.java
+++ b/src/main/java/codesquad/webserver/WebServer.java
@@ -1,6 +1,7 @@
 package codesquad.webserver;
 
 import codesquad.webserver.handler.HandlerPath;
+import codesquad.webserver.handler.StorageFileHandler;
 import codesquad.webserver.util.AnnotationScanner;
 import codesquad.webserver.handler.DynamicRequestHandler;
 import codesquad.webserver.handler.RouterHandler;
@@ -27,8 +28,11 @@ public class WebServer {
     public void init(int port, String basePackage) throws IOException, ClassNotFoundException {
         logger.debug("Listening for connection on port {} ....", port);
         serverSocket = new ServerSocket(port);
-        RouterHandler dynamicHandler = getDynamicHandler(basePackage);
-        requestHandler = new RequestHandler(List.of(dynamicHandler, new StaticRequestHandler()));
+        requestHandler = new RequestHandler(List.of(
+            getDynamicHandler(basePackage),
+            new StorageFileHandler(),
+            new StaticRequestHandler()
+        ));
         httpThreadPool = new HttpThreadPool(Executors.newFixedThreadPool(THREAD_POOL_SIZE));
     }
 

--- a/src/main/java/codesquad/webserver/file/StorageFileManager.java
+++ b/src/main/java/codesquad/webserver/file/StorageFileManager.java
@@ -1,0 +1,61 @@
+package codesquad.webserver.file;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class StorageFileManager {
+    private static final Logger logger = LoggerFactory.getLogger(StorageFileManager.class);
+    private static final String uploadDir = "uploads/";
+
+    public static String saveFile(byte[] content, String fileExtension) {
+        File dir = new File(uploadDir);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        String fileName = UUID.randomUUID() + fileExtension;
+        String filePath = uploadDir + fileName;
+
+        try (FileOutputStream fos = new FileOutputStream(filePath);
+             BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            bos.write(content);
+            logger.debug("파일을 저장했습니다. 경로: {}", filePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return filePath;
+    }
+
+    public static byte[] readFile(String filePath) {
+        if (filePath.startsWith("/")) {
+            filePath = filePath.substring(1);
+        }
+        File file = new File(filePath);
+        byte[] fileContent = new byte[(int) file.length()];
+
+        try (FileInputStream fis = new FileInputStream(file)) {
+            fis.read(fileContent);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        logger.debug("스토리지에서 파일을 읽어옵니다. 경로: {}", filePath);
+        return fileContent;
+    }
+
+    public static String getRelativePath(String path) {
+        return getUploadDir() + path;
+    }
+
+    private static String getUploadDir() {
+        String currentDir = System.getProperty("user.dir");
+        return currentDir + File.separator + uploadDir;
+    }
+}

--- a/src/main/java/codesquad/webserver/handler/StorageFileHandler.java
+++ b/src/main/java/codesquad/webserver/handler/StorageFileHandler.java
@@ -1,0 +1,30 @@
+package codesquad.webserver.handler;
+
+import codesquad.webserver.file.FileHttpResponseCreator;
+import codesquad.webserver.file.StorageFileManager;
+import codesquad.webserver.http.HttpRequest;
+import codesquad.webserver.http.HttpResponse;
+import codesquad.webserver.http.type.ContentType;
+import codesquad.webserver.http.type.HttpHeader;
+import codesquad.webserver.http.type.HttpMethod;
+import codesquad.webserver.util.StringUtil;
+import java.util.Arrays;
+
+public class StorageFileHandler implements RouterHandler {
+    @Override
+    public boolean support(final HttpRequest httpRequest) {
+        final String path = httpRequest.path();
+        final HttpMethod method = httpRequest.method();
+        return method.isGet() && path.startsWith("/uploads");
+    }
+
+    @Override
+    public HttpResponse handle(final HttpRequest httpRequest) {
+        final String path = httpRequest.path();
+        final byte[] bytes = StorageFileManager.readFile(path);
+
+        String extension = StringUtil.getExtension(path);
+        final String mimeType = ContentType.from(extension).getMimeType();
+        return HttpResponse.ok(HttpHeader.of("Content-Type", mimeType), Arrays.toString(bytes));
+    }
+}

--- a/src/main/java/codesquad/webserver/handler/StorageFileHandler.java
+++ b/src/main/java/codesquad/webserver/handler/StorageFileHandler.java
@@ -1,14 +1,10 @@
 package codesquad.webserver.handler;
 
-import codesquad.webserver.file.FileHttpResponseCreator;
 import codesquad.webserver.file.StorageFileManager;
 import codesquad.webserver.http.HttpRequest;
 import codesquad.webserver.http.HttpResponse;
-import codesquad.webserver.http.type.ContentType;
-import codesquad.webserver.http.type.HttpHeader;
-import codesquad.webserver.http.type.HttpMethod;
+import codesquad.webserver.http.type.*;
 import codesquad.webserver.util.StringUtil;
-import java.util.Arrays;
 
 public class StorageFileHandler implements RouterHandler {
     @Override
@@ -25,6 +21,8 @@ public class StorageFileHandler implements RouterHandler {
 
         String extension = StringUtil.getExtension(path);
         final String mimeType = ContentType.from(extension).getMimeType();
-        return HttpResponse.ok(HttpHeader.of("Content-Type", mimeType), Arrays.toString(bytes));
+
+        HttpHeader httpHeader = HttpHeader.of("Content-Type", mimeType, "Content-Length", String.valueOf(bytes.length));
+        return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.OK, httpHeader, bytes);
     }
 }

--- a/src/main/java/codesquad/webserver/http/HttpResponse.java
+++ b/src/main/java/codesquad/webserver/http/HttpResponse.java
@@ -4,12 +4,60 @@ import codesquad.webserver.http.type.HttpHeader;
 import codesquad.webserver.http.type.HttpProtocol;
 import codesquad.webserver.http.type.HttpStatus;
 
-public record HttpResponse(
-        HttpProtocol protocol,
-        HttpStatus status,
-        HttpHeader headers,
-        String body
-) {
+public class HttpResponse {
+    private final HttpProtocol protocol;
+    private final HttpStatus status;
+    private final HttpHeader headers;
+    private final String body;  // TODO ResponseBody 타입으로 합치기
+    private final byte[] bodyBytes;
+    private final boolean isBytes;
+
+    public HttpResponse(final HttpProtocol protocol, final HttpStatus status, final HttpHeader headers,
+                        final String body) {
+        this.protocol = protocol;
+        this.status = status;
+        this.headers = headers;
+        this.body = body;
+
+        bodyBytes = new byte[0];
+        isBytes = false;
+    }
+
+    public HttpResponse(final HttpProtocol protocol, final HttpStatus status, final HttpHeader headers,
+                        final byte[] bodyBytes) {
+        this.protocol = protocol;
+        this.status = status;
+        this.headers = headers;
+        this.bodyBytes = bodyBytes;
+
+        body = "";
+        isBytes = true;
+    }
+
+    public HttpProtocol getProtocol() {
+        return protocol;
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public HttpHeader getHeaders() {
+        return headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public byte[] getBodyBytes() {
+        return bodyBytes;
+    }
+
+    public boolean isBytes() {
+        return isBytes;
+    }
+
     public static HttpResponse ok(HttpHeader headers, String body) {
         return new HttpResponse(HttpProtocol.HTTP_1_1, HttpStatus.OK, headers, body);
     }

--- a/src/main/java/codesquad/webserver/http/ResponseConverter.java
+++ b/src/main/java/codesquad/webserver/http/ResponseConverter.java
@@ -29,7 +29,8 @@ public class ResponseConverter {
         }
 
         // Body
-        if (response.getBody() != null && !response.getBody().isEmpty()) {
+        if ((response.getBodyBytes() != null && response.getBodyBytes().length != 0) ||
+                (response.getBody() != null && !response.getBody().isEmpty())) {
             sb.append("\r\n");
 
             if (!response.isBytes()) {  // 일반 String Type Body인 경우

--- a/src/main/java/codesquad/webserver/http/ResponseConverter.java
+++ b/src/main/java/codesquad/webserver/http/ResponseConverter.java
@@ -15,12 +15,12 @@ public class ResponseConverter {
         StringBuilder sb = new StringBuilder();
 
         // StartLine
-        String responseLine = response.protocol() + " " + response.status().getCode() + " " + response.status().getMessage() + "\r\n";
+        String responseLine = response.getProtocol() + " " + response.getStatus().getCode() + " " + response.getStatus().getMessage() + "\r\n";
         sb.append(responseLine);
 
         // Headers
-        if (response.headers() != null) {
-            for (Entry<String, List<String>> entry : response.headers().entrySet()) {
+        if (response.getHeaders() != null) {
+            for (Entry<String, List<String>> entry : response.getHeaders().entrySet()) {
                 for (String value : entry.getValue()) {
                     String header = entry.getKey() + ": " + value + "\r\n";
                     sb.append(header);
@@ -29,15 +29,32 @@ public class ResponseConverter {
         }
 
         // Body
-        if (response.body() != null && !response.body().isEmpty()) {
+        if (response.getBody() != null && !response.getBody().isEmpty()) {
             sb.append("\r\n");
-            sb.append(response.body());
+
+            if (!response.isBytes()) {  // 일반 String Type Body인 경우
+                sb.append(response.getBody());
+            }
         }
 
+        byte[] bytes;
         try {
-            return sb.toString().getBytes("UTF-8");
+            bytes = sb.toString().getBytes("UTF-8");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException("UTF-8를 사용할 수 없습니다.", e);
         }
+
+        // Bytes Type Body
+        if (response.isBytes()) {
+            bytes = concatenateByteArrays(bytes, response.getBodyBytes());
+        }
+        return bytes;
+    }
+
+    public static byte[] concatenateByteArrays(byte[] array1, byte[] array2) {
+        byte[] result = new byte[array1.length + array2.length];
+        System.arraycopy(array1, 0, result, 0, array1.length);
+        System.arraycopy(array2, 0, result, array1.length, array2.length);
+        return result;
     }
 }

--- a/src/main/java/codesquad/webserver/http/parser/BodyParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/BodyParser.java
@@ -9,7 +9,11 @@ public class BodyParser {
         return extractBody(lines, contentLength);
     }
 
-    public static Map<String, String> parseFormBody(String[] lines, int contentLength) {
+    public static Map<String, String> parseFormMultiPart(String[] lines, int contentLength) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static Map<String, String> pasreFormXwww(String[] lines, int contentLength) {
         String body = extractBody(lines, contentLength);
         return KeyValueParser.parseQuertString(body);
     }

--- a/src/main/java/codesquad/webserver/http/parser/BodyParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/BodyParser.java
@@ -1,49 +1,16 @@
 package codesquad.webserver.http.parser;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BodyParser {
+    private static final Logger logger = LoggerFactory.getLogger(BodyParser.class);
     private BodyParser() {}
 
     public static String parse(String[] lines, int contentLength) {
         return extractBody(lines, contentLength);
     }
-
-    public static Map<String, String> parseFormMultiPart(String[] lines, int contentLength, String boundary) {
-        String body = extractBodyOnlyLength(lines, contentLength);
-        String[] multiPart = body.split(boundary);
-
-        for (String s : multiPart) {
-            System.out.println("Target: " + s);
-            parseMultipartData(s);
-        }
-
-        throw new UnsupportedOperationException();
-    }
-
-    private static void parseMultipartData(String line) {
-        Map<String, String> multiPart = KeyValueParser.parseMultiPart(line);
-        System.out.println("헤더반환: " + multiPart);
-
-        // Header
-
-        // Body
-
-    }
-
-    private static void saveFile(byte[] content, String fileName) {
-        try (FileOutputStream fos = new FileOutputStream(new File(fileName))) {
-            fos.write(content);
-            System.out.println("File saved: " + fileName);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-
 
     public static Map<String, String> pasreFormXwww(String[] lines, int contentLength) {
         String body = extractBody(lines, contentLength);
@@ -64,36 +31,6 @@ public class BodyParser {
 
         if (body.length() > contentLength) {
             body.setLength(contentLength);
-        }
-
-        return body.toString();
-    }
-
-    private static String extractBodyOnlyLength(String[] lines, int contentLength) {
-        StringBuilder body = new StringBuilder();
-
-        int bodyStartIndex = getBodyStartIndex(lines);
-        int currentLength = 0;
-
-        for (int i = bodyStartIndex; i < lines.length; i++) {
-            String line = lines[i];
-            int lineLength = line.length() + 1; // '\n' 문자를 고려하여 1을 더함
-
-            if (currentLength + lineLength > contentLength) {
-                int remainingLength = contentLength - currentLength;
-                body.append(line, 0, Math.min(remainingLength, line.length()));
-                if (remainingLength > line.length()) {
-                    body.append('\n');
-                }
-                break;
-            } else {
-                body.append(line).append('\n');
-                currentLength += lineLength;
-            }
-        }
-
-        if (body.length() > 0 && body.charAt(body.length() - 1) == '\n') {
-            body.deleteCharAt(body.length() - 1);
         }
 
         return body.toString();

--- a/src/main/java/codesquad/webserver/http/parser/BodyParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/BodyParser.java
@@ -1,5 +1,8 @@
 package codesquad.webserver.http.parser;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Map;
 
 public class BodyParser {
@@ -9,9 +12,38 @@ public class BodyParser {
         return extractBody(lines, contentLength);
     }
 
-    public static Map<String, String> parseFormMultiPart(String[] lines, int contentLength) {
+    public static Map<String, String> parseFormMultiPart(String[] lines, int contentLength, String boundary) {
+        String body = extractBodyOnlyLength(lines, contentLength);
+        String[] multiPart = body.split(boundary);
+
+        for (String s : multiPart) {
+            System.out.println("Target: " + s);
+            parseMultipartData(s);
+        }
+
         throw new UnsupportedOperationException();
     }
+
+    private static void parseMultipartData(String line) {
+        Map<String, String> multiPart = KeyValueParser.parseMultiPart(line);
+        System.out.println("헤더반환: " + multiPart);
+
+        // Header
+
+        // Body
+
+    }
+
+    private static void saveFile(byte[] content, String fileName) {
+        try (FileOutputStream fos = new FileOutputStream(new File(fileName))) {
+            fos.write(content);
+            System.out.println("File saved: " + fileName);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
 
     public static Map<String, String> pasreFormXwww(String[] lines, int contentLength) {
         String body = extractBody(lines, contentLength);
@@ -32,6 +64,36 @@ public class BodyParser {
 
         if (body.length() > contentLength) {
             body.setLength(contentLength);
+        }
+
+        return body.toString();
+    }
+
+    private static String extractBodyOnlyLength(String[] lines, int contentLength) {
+        StringBuilder body = new StringBuilder();
+
+        int bodyStartIndex = getBodyStartIndex(lines);
+        int currentLength = 0;
+
+        for (int i = bodyStartIndex; i < lines.length; i++) {
+            String line = lines[i];
+            int lineLength = line.length() + 1; // '\n' 문자를 고려하여 1을 더함
+
+            if (currentLength + lineLength > contentLength) {
+                int remainingLength = contentLength - currentLength;
+                body.append(line, 0, Math.min(remainingLength, line.length()));
+                if (remainingLength > line.length()) {
+                    body.append('\n');
+                }
+                break;
+            } else {
+                body.append(line).append('\n');
+                currentLength += lineLength;
+            }
+        }
+
+        if (body.length() > 0 && body.charAt(body.length() - 1) == '\n') {
+            body.deleteCharAt(body.length() - 1);
         }
 
         return body.toString();

--- a/src/main/java/codesquad/webserver/http/parser/HttpRequestParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/HttpRequestParser.java
@@ -11,7 +11,16 @@ import java.util.Map;
 public class HttpRequestParser {
     private HttpRequestParser() {}
 
-    public static HttpRequest parse(String message) {
+
+    public static HttpRequest parse(byte[] bytes) {
+        return parse(new String(bytes), bytes);
+    }
+
+    public static HttpRequest parse(String message) {  // TODO For TEST
+        return parse(message, new byte[1]);
+    }
+
+    public static HttpRequest parse(String message, byte[] bytes) {
         String[] lines = message.split("\n");
 
         StartLine startLine = StartLineParser.parse(lines);
@@ -23,7 +32,7 @@ public class HttpRequestParser {
 
         switch (getFormEnctype(headers)) {
             case X_WWW_FORM_URLENCODED -> body = BodyParser.pasreFormXwww(lines, contentLength);
-            case MULTIPART_FORM_DATA -> body = BodyParser.parseFormMultiPart(lines, contentLength, FormEnctype.getBoundary(headers.get("Content-Type")));
+            case MULTIPART_FORM_DATA -> body = MultiPartParser.parse(bytes, FormEnctype.getBoundary(headers.get("Content-Type")));
             case TEXT_PLAIN -> body.put("raw", BodyParser.parse(lines, contentLength));
             case NOT_FORM_DATA -> body.put("raw", BodyParser.parse(lines, contentLength));
         }

--- a/src/main/java/codesquad/webserver/http/parser/HttpRequestParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/HttpRequestParser.java
@@ -20,9 +20,10 @@ public class HttpRequestParser {
         // Body
         int contentLength = getContentLength(headers);
         Map<String, String> body = new HashMap<>();
+
         switch (getFormEnctype(headers)) {
             case X_WWW_FORM_URLENCODED -> body = BodyParser.pasreFormXwww(lines, contentLength);
-            case MULTIPART_FORM_DATA -> body = BodyParser.parseFormMultiPart(lines, contentLength);
+            case MULTIPART_FORM_DATA -> body = BodyParser.parseFormMultiPart(lines, contentLength, FormEnctype.getBoundary(headers.get("Content-Type")));
             case TEXT_PLAIN -> body.put("raw", BodyParser.parse(lines, contentLength));
             case NOT_FORM_DATA -> body.put("raw", BodyParser.parse(lines, contentLength));
         }

--- a/src/main/java/codesquad/webserver/http/parser/KeyValueParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/KeyValueParser.java
@@ -50,4 +50,23 @@ public class KeyValueParser {
 
         return cookies;
     }
+
+
+    public static Map<String, String> parseMultiPart(String multiPartHeader) {
+        Map<String, String> cookies = new HashMap<>();
+
+        if (multiPartHeader == null || multiPartHeader.isEmpty()) {
+            return cookies;
+        }
+
+        String[] pairs = multiPartHeader.split("; ");
+        for (String pair : pairs) {
+            String[] keyValue = pair.split("[=]|(: )", 2);
+            if (keyValue.length == 2) {
+                cookies.put(keyValue[0].trim(), keyValue[1].trim());
+            }
+        }
+
+        return cookies;
+    }
 }

--- a/src/main/java/codesquad/webserver/http/parser/MultiPartParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/MultiPartParser.java
@@ -1,0 +1,206 @@
+package codesquad.webserver.http.parser;
+
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultiPartParser {
+    private static final Logger logger = LoggerFactory.getLogger(MultiPartParser.class);
+
+    private MultiPartParser() {}
+
+    public static Map<String, String> parse(byte[] bytes, String boundary) {
+        final byte[] multiPartBody = extractBody(bytes);
+        List<byte[]> parts = splitMultiPartBody(multiPartBody, boundary);
+
+        Map<String, String> partContents = new HashMap<>();
+        for (byte[] part : parts) {
+            Map<String, String> partMap = parsePart(part);
+            partContents.putAll(partMap);
+        }
+
+        return partContents;
+    }
+
+    /**
+     * Bytes에서 Body 부분만 추출합니다.
+     * @param bytes 전체 HTTP Request 배열
+     * @return HTTP Request에서 Body만 추출한 부분
+     */
+    private static byte[] extractBody(final byte[] bytes) {
+        // Find the position of the empty line (CRLF 2 times)
+        int bodyStartIndex = findBodyStart(bytes);
+
+        if (bodyStartIndex == -1) {
+            throw new IllegalArgumentException("Invalid HTTP request format: body not found");
+        }
+
+        return Arrays.copyOfRange(bytes, bodyStartIndex, bytes.length);
+    }
+
+    private static int findBodyStart(byte[] bytes) {
+        for (int i = 0; i < bytes.length - 3; i++) {
+            if (bytes[i] == '\r' && bytes[i + 1] == '\n' && bytes[i + 2] == '\r' && bytes[i + 3] == '\n') {
+                return i + 4; // Body starts after "\r\n\r\n"
+            }
+        }
+        return -1; // Not found
+    }
+
+    /**
+     * MultiPart의 Body 부분들을 나눠서 반환합니다.
+     * @param multiPartBody MultiPart Body 부분 전체
+     * @param boundaryStr 구분자로 사용될 boundary 값
+     * @return 구분된 Body들
+     */
+    private static List<byte[]> splitMultiPartBody(byte[] multiPartBody, String boundaryStr) {
+        List<byte[]> parts = new ArrayList<>();
+
+        // Split multiPartBody by boundary
+        byte[] boundaryBytes = boundaryStr.getBytes();
+
+        int boundaryIndex = indexOf(multiPartBody, boundaryBytes, 0);
+        while (boundaryIndex != -1) {
+            int partStartIndex = boundaryIndex + boundaryBytes.length;
+            int nextBoundaryIndex = indexOf(multiPartBody, boundaryBytes, partStartIndex);
+
+            if (nextBoundaryIndex == -1) {
+                // Last part
+                parts.add(Arrays.copyOfRange(multiPartBody, partStartIndex, multiPartBody.length));
+                break;
+            } else {
+                parts.add(Arrays.copyOfRange(multiPartBody, partStartIndex, nextBoundaryIndex - 2)); // -2 to exclude CRLF after boundary
+            }
+
+            boundaryIndex = nextBoundaryIndex;
+        }
+
+        return parts;
+    }
+
+    private static int indexOf(byte[] source, byte[] target, int fromIndex) {
+        int max = source.length - target.length;
+        for (int i = fromIndex; i <= max; i++) {
+            int j;
+            for (j = 0; j < target.length; j++) {
+                if (source[i + j] != target[j]) {
+                    break;
+                }
+            }
+            if (j == target.length) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * MultiPart의 한 부분을 전달하여 Body값을 추출합니다. 전달된 것이 파일인 경우 내용으 저장하고 Path를 반환합니다.
+     * @param part MultiPart 중 한 부분
+     * @return Body값 (name과 value)
+     */
+    private static Map<String, String> parsePart(byte[] part) {
+        Map<String, String> partMap = new HashMap<>();
+
+        String partString = new String(part);
+        if (partString.trim().equals("--")) {
+            return partMap;
+        }
+
+        // Header와 Body로 구분
+        int headerEndIndex = indexOf(part, "\r\n\r\n".getBytes(), 0);
+        if (headerEndIndex == -1) {
+            throw new IllegalArgumentException("Invalid part format: headers not found");
+        }
+
+        byte[] headersBytes = Arrays.copyOfRange(part, 0, headerEndIndex);
+        String headers = new String(headersBytes);
+
+        Map<String, String> headersMap = parseHeaders(headers);
+
+        // 파일인 경우 저장하고 Path를 반환 또는 Body값을 반환
+        String contentDisposition = headersMap.get("Content-Disposition");
+        if (contentDisposition != null && contentDisposition.startsWith("form-data")) {
+            String[] dispositionParts = contentDisposition.split(";");
+
+            String name = null;
+            String filename = null;
+
+            for (String partHeader : dispositionParts) {
+                partHeader = partHeader.trim();
+                if (partHeader.startsWith("name=")) {
+                    name = partHeader.substring(5).replaceAll("\"", "");
+                } else if (partHeader.startsWith("filename=")) {
+                    filename = partHeader.substring(10).replaceAll("\"", "");
+                }
+            }
+
+            if (filename != null) {
+                // This part contains a file
+                String fileExtension = getFileExtension(filename);
+                String filePath = saveFile(Arrays.copyOfRange(part, headerEndIndex + 4, part.length), fileExtension);
+                partMap.put(name, filePath);
+            } else {
+                // Handle other form data
+                byte[] bodyBytes = Arrays.copyOfRange(part, headerEndIndex + 4, part.length); // +4 to skip "\r\n\r\n"
+                String body = new String(bodyBytes);
+                partMap.put(name, body);
+            }
+        }
+
+        return partMap;
+    }
+
+    private static String getFileExtension(String filename) {
+        int dotIndex = filename.lastIndexOf('.');
+        if (dotIndex > 0 && dotIndex < filename.length() - 1) {
+            return filename.substring(dotIndex);
+        }
+        return "";
+    }
+
+    private static String saveFile(byte[] content, String fileExtension) {
+        String uploadDir = "uploads/";
+        File dir = new File(uploadDir);
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+
+        String fileName = UUID.randomUUID().toString() + fileExtension;
+        String filePath = uploadDir + fileName;
+
+        try (FileOutputStream fos = new FileOutputStream(filePath);
+             BufferedOutputStream bos = new BufferedOutputStream(fos)) {
+            bos.write(content);
+            logger.debug("파일을 저장했습니다. 경로: {}", filePath);
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return filePath;
+    }
+
+    private static Map<String, String> parseHeaders(String headers) {
+        Map<String, String> headersMap = new HashMap<>();
+        String[] headerLines = headers.split("\r\n");
+
+        for (String headerLine : headerLines) {
+            int colonIndex = headerLine.indexOf(':');
+            if (colonIndex != -1) {
+                String key = headerLine.substring(0, colonIndex).trim();
+                String value = headerLine.substring(colonIndex + 1).trim();
+                headersMap.put(key, value);
+            }
+        }
+        return headersMap;
+    }
+}

--- a/src/main/java/codesquad/webserver/http/parser/MultiPartParser.java
+++ b/src/main/java/codesquad/webserver/http/parser/MultiPartParser.java
@@ -1,15 +1,11 @@
 package codesquad.webserver.http.parser;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
+import codesquad.webserver.file.StorageFileManager;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -147,7 +143,7 @@ public class MultiPartParser {
             if (filename != null) {
                 // This part contains a file
                 String fileExtension = getFileExtension(filename);
-                String filePath = saveFile(Arrays.copyOfRange(part, headerEndIndex + 4, part.length), fileExtension);
+                String filePath = StorageFileManager.saveFile(Arrays.copyOfRange(part, headerEndIndex + 4, part.length), fileExtension);
                 partMap.put(name, filePath);
             } else {
                 // Handle other form data
@@ -166,27 +162,6 @@ public class MultiPartParser {
             return filename.substring(dotIndex);
         }
         return "";
-    }
-
-    private static String saveFile(byte[] content, String fileExtension) {
-        String uploadDir = "uploads/";
-        File dir = new File(uploadDir);
-        if (!dir.exists()) {
-            dir.mkdirs();
-        }
-
-        String fileName = UUID.randomUUID().toString() + fileExtension;
-        String filePath = uploadDir + fileName;
-
-        try (FileOutputStream fos = new FileOutputStream(filePath);
-             BufferedOutputStream bos = new BufferedOutputStream(fos)) {
-            bos.write(content);
-            logger.debug("파일을 저장했습니다. 경로: {}", filePath);
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-
-        return filePath;
     }
 
     private static Map<String, String> parseHeaders(String headers) {

--- a/src/main/java/codesquad/webserver/http/type/FormEnctype.java
+++ b/src/main/java/codesquad/webserver/http/type/FormEnctype.java
@@ -1,0 +1,30 @@
+package codesquad.webserver.http.type;
+
+import java.util.Arrays;
+
+public enum FormEnctype {
+    X_WWW_FORM_URLENCODED("application/x-www-form-urlencoded"),
+    TEXT_PLAIN("text/plain"),
+    MULTIPART_FORM_DATA("multipart/form-data"),
+    NOT_FORM_DATA("");
+
+    private final String value;
+
+    FormEnctype(String value) {
+        this.value = value;
+    }
+
+    public static FormEnctype from(String value) {
+        if (value == null) {
+            return NOT_FORM_DATA;
+        }
+        return Arrays.stream(FormEnctype.values())
+                .filter(enctype -> value.contains(enctype.value))
+                .findFirst()
+                .orElse(NOT_FORM_DATA);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/codesquad/webserver/http/type/FormEnctype.java
+++ b/src/main/java/codesquad/webserver/http/type/FormEnctype.java
@@ -14,6 +14,14 @@ public enum FormEnctype {
         this.value = value;
     }
 
+    public String getValue() {
+        return value;
+    }
+
+    public boolean isMultipartForm() {
+        return this == MULTIPART_FORM_DATA;
+    }
+
     public static FormEnctype from(String value) {
         if (value == null) {
             return NOT_FORM_DATA;
@@ -24,7 +32,16 @@ public enum FormEnctype {
                 .orElse(NOT_FORM_DATA);
     }
 
-    public String getValue() {
-        return value;
+    public static String getBoundary(String value) {
+        if (!from(value).isMultipartForm()) {
+            throw new IllegalArgumentException("멀티파트 헤더가 아닙니다. header: " + value);
+        }
+
+        String[] split = value.split("boundary=");
+        if (split.length != 2) {
+            throw new IllegalArgumentException("값을 찾을 수 없습니다. split길이: " + split.length);
+        }
+
+        return "--" + split[1];
     }
 }

--- a/src/main/java/codesquad/webserver/http/type/HttpMethod.java
+++ b/src/main/java/codesquad/webserver/http/type/HttpMethod.java
@@ -12,6 +12,10 @@ public enum HttpMethod {
     PATCH,
     TRACE;
 
+    public boolean isGet() {
+        return this == GET;
+    }
+
     public static HttpMethod from(String name) {
         return Arrays.stream(HttpMethod.values())
                 .filter(v -> v.name().equals(name))

--- a/src/main/java/codesquad/webserver/socket/SocketReader.java
+++ b/src/main/java/codesquad/webserver/socket/SocketReader.java
@@ -1,6 +1,7 @@
 package codesquad.webserver.socket;
 
 import codesquad.webserver.exception.SocketIoException;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
@@ -15,26 +16,26 @@ public class SocketReader {
 
     /**
      * 전달된 Socket의 InputStream을 통해 값을 읽습니다.
-     * @return String 값
+     * @return byte 배열
      * @throws SocketIoException 소켓 IOException 발생시
      */
-    public String read() {
-        return getInputStream(socket);
+    public byte[] readBytes() {
+        return getInputStreamBytes(socket);
     }
 
-    private String getInputStream(Socket clientSocket) {
+    private byte[] getInputStreamBytes(Socket clientSocket) {
         try {
             InputStream input = clientSocket.getInputStream();
             byte[] buffer = new byte[BUFFER_SIZE];
 
-            StringBuilder sb = new StringBuilder();
+            ByteArrayOutputStream ba = new ByteArrayOutputStream();
             int length = 0;
             do {
                 length = input.read(buffer);
-                sb.append(new String(buffer, 0, length));
+                ba.write(buffer, 0, length);
             } while (length == BUFFER_SIZE);
 
-            return sb.toString();
+            return ba.toByteArray();
         } catch (IOException e) {
             e.printStackTrace();
             throw new SocketIoException("Socket 연결이 불안정합니다.");

--- a/src/main/resources/static/article/article.html
+++ b/src/main/resources/static/article/article.html
@@ -29,7 +29,7 @@
               ${title}
             </p>
           </div>
-          <img class="post__img" />
+          <img class="post__img" src="${imagePath}" />
           <div class="post__menu">
             <ul class="post__menu__personal">
               <li>

--- a/src/main/resources/static/article/index.html
+++ b/src/main/resources/static/article/index.html
@@ -23,7 +23,7 @@
       </header>
       <div class="page">
         <h2 class="page-title">게시글 작성</h2>
-        <form class="form" method="POST" action="/article/write">
+        <form class="form" method="POST" action="/article/write" enctype="multipart/form-data">
           <div class="textfield textfield_size_s">
             <p class="title_textfield">제목</p>
             <input
@@ -43,6 +43,10 @@
                     placeholder="글의 내용을 입력하세요"
                     autocomplete="content"
             ></textarea>
+          </div>
+          <div class="textfield textfield_size_s">
+          <label for="image">업로드할 이미지를 선택해주세요.</label>
+          <input type="file" id="image" name="image" accept="image/*" required>
           </div>
           <button
             id="registration-btn"

--- a/src/test/java/codesquad/application/HtmlPageHandlerTest.java
+++ b/src/test/java/codesquad/application/HtmlPageHandlerTest.java
@@ -51,8 +51,8 @@ class HtmlPageHandlerTest {
 
         HttpResponse response = htmlPageHandler.getHomepage(httpRequest);
 
-        assertEquals(HttpStatus.OK, response.status());
-        assertTrue(response.body().contains("로그인"));
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertTrue(response.getBody().contains("로그인"));
     }
 
     @Test
@@ -72,7 +72,7 @@ class HtmlPageHandlerTest {
 
         HttpResponse response = htmlPageHandler.getHomepage(httpRequest);
 
-        assertEquals(HttpStatus.OK, response.status());
-        assertTrue(response.body().contains(testUser.getName() + "님 환영합니다."));
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertTrue(response.getBody().contains(testUser.getName() + "님 환영합니다."));
     }
 }

--- a/src/test/java/codesquad/application/LoginHandlerTest.java
+++ b/src/test/java/codesquad/application/LoginHandlerTest.java
@@ -49,10 +49,10 @@ class LoginHandlerTest {
 
         HttpResponse response = loginHandler.login(httpRequest);
 
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/", response.headers().get("Location"));
-        assertTrue(response.headers().contains("Set-Cookie"));
-        assertEquals("로그인 완료!", response.body());
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/", response.getHeaders().get("Location"));
+        assertTrue(response.getHeaders().contains("Set-Cookie"));
+        assertEquals("로그인 완료!", response.getBody());
     }
 
     @Test
@@ -65,8 +65,8 @@ class LoginHandlerTest {
 
         HttpResponse response = loginHandler.login(httpRequest);
 
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/user/login_failed.html", response.headers().get("Location"));
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/user/login_failed.html", response.getHeaders().get("Location"));
     }
 
     @Test
@@ -86,8 +86,8 @@ class LoginHandlerTest {
 
         HttpResponse response = loginHandler.logout(httpRequest);
 
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/", response.headers().get("Location"));
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/", response.getHeaders().get("Location"));
         assertFalse(sessionManager.validSession(sessionId));
     }
 
@@ -110,8 +110,8 @@ class LoginHandlerTest {
 
         HttpResponse response = loginHandler.logout(httpRequest);
 
-        assertEquals(HttpStatus.UNAUTHORIZED, response.status());
-        assertEquals("세션이 존재하지 않습니다.", response.body());
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatus());
+        assertEquals("세션이 존재하지 않습니다.", response.getBody());
     }
 
     @Test
@@ -126,7 +126,7 @@ class LoginHandlerTest {
 
         HttpResponse response = loginHandler.logout(httpRequest);
 
-        assertEquals(HttpStatus.UNAUTHORIZED, response.status());
-        assertEquals("세션이 존재하지 않습니다.", response.body());
+        assertEquals(HttpStatus.UNAUTHORIZED, response.getStatus());
+        assertEquals("세션이 존재하지 않습니다.", response.getBody());
     }
 }

--- a/src/test/java/codesquad/application/UserHandlerTest.java
+++ b/src/test/java/codesquad/application/UserHandlerTest.java
@@ -55,9 +55,9 @@ class UserHandlerTest {
 
         HttpResponse response = userHandler.createUser(httpRequest);
 
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/", response.headers().get("Location"));
-        assertEquals("유저가 생성되었습니다.", response.body());
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/", response.getHeaders().get("Location"));
+        assertEquals("유저가 생성되었습니다.", response.getBody());
     }
 
     @Test
@@ -89,10 +89,10 @@ class UserHandlerTest {
 
         HttpResponse response = userHandler.getUserList(httpRequest);
 
-        assertEquals(HttpStatus.OK, response.status());
-        assertTrue(response.body().contains(testUser.getName()));
-        assertTrue(response.body().contains(testUser.getEmail()));
-        assertTrue(response.body().contains(testUser.getNickname()));
+        assertEquals(HttpStatus.OK, response.getStatus());
+        assertTrue(response.getBody().contains(testUser.getName()));
+        assertTrue(response.getBody().contains(testUser.getEmail()));
+        assertTrue(response.getBody().contains(testUser.getNickname()));
     }
 
     @Test
@@ -102,7 +102,7 @@ class UserHandlerTest {
 
         HttpResponse response = userHandler.getUserList(httpRequest);
 
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/user/login_failed.html", response.headers().get("Location"));
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/user/login_failed.html", response.getHeaders().get("Location"));
     }
 }

--- a/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
@@ -46,14 +46,14 @@ class ArticleHandlerTest {
     public void testGetFormWithAuthenticatedUser() {
         AuthenticationHolder.setContext(new User("testUser", "password", "Test User", "email@email.com"));
         HttpResponse response = articleHandler.getForm(null);
-        assertEquals(HttpStatus.OK, response.status());
+        assertEquals(HttpStatus.OK, response.getStatus());
     }
 
     @Test
     @DisplayName("인증 정보가 없다면 글쓰기 페이지로 접근할 수 없다. (FOUND)")
     public void testGetFormWithoutAuthenticatedUser() {
         HttpResponse response = articleHandler.getForm(null);
-        assertEquals(HttpStatus.FOUND, response.status());
+        assertEquals(HttpStatus.FOUND, response.getStatus());
     }
 
     @Test
@@ -67,12 +67,12 @@ class ArticleHandlerTest {
             Map.of(),
             HttpProtocol.HTTP_1_1,
             HttpHeader.createEmpty(),
-            Map.of("title", "제목입니다", "content", "글 내용입니다")
+            Map.of("title", "제목입니다", "content", "글 내용입니다", "image", "helloworld")
         );
 
         HttpResponse response = articleHandler.writeArticle(request);
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("글쓰기 성공!", response.body());
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("글쓰기 성공!", response.getBody());
         Article addedArticle = articleDao.get(1L).orElseThrow();
         assertEquals("제목입니다", addedArticle.title());
         assertEquals("글 내용입니다", addedArticle.content());
@@ -91,8 +91,8 @@ class ArticleHandlerTest {
         );
 
         HttpResponse response = articleHandler.writeArticle(request);
-        assertEquals(HttpStatus.FOUND, response.status());
-        assertEquals("/user/login_failed.html", response.headers().get("Location"));
+        assertEquals(HttpStatus.FOUND, response.getStatus());
+        assertEquals("/user/login_failed.html", response.getHeaders().get("Location"));
     }
 
     // TODO

--- a/src/test/java/codesquad/application/handler/CommentHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/CommentHandlerTest.java
@@ -44,7 +44,7 @@ class CommentHandlerTest {
     @DisplayName("게시글에 댓글을 추가한다.")
     public void add_comment() {
         AuthenticationHolder.setContext(createTestUser());
-        Article article = new Article(null, "정상조회제목", "정상조회내용");
+        Article article = new Article(null, "정상조회제목", "정상조회내용", "");
         articleDao.add(article);
 
         final Long id = articleDao.findAll().get(0).id();// TODO DB AUTO_INCREMENT CleanUp이 잘될때 제거..
@@ -58,8 +58,8 @@ class CommentHandlerTest {
         );
         final HttpResponse httpResponse = commentHandler.writeComment(request);
 
-        assertEquals(HttpStatus.FOUND, httpResponse.status());
-        assertThat(httpResponse.headers().get("Location")).startsWith("/article?");
+        assertEquals(HttpStatus.FOUND, httpResponse.getStatus());
+        assertThat(httpResponse.getHeaders().get("Location")).startsWith("/article?");
     }
 
     @Test
@@ -92,8 +92,8 @@ class CommentHandlerTest {
         );
 
         final HttpResponse httpResponse = commentHandler.writeComment(request);
-        assertThat(httpResponse.status()).isEqualTo(HttpStatus.FOUND);
-        assertThat(httpResponse.headers().get("Location")).startsWith("/user/login_failed.html");
+        assertThat(httpResponse.getStatus()).isEqualTo(HttpStatus.FOUND);
+        assertThat(httpResponse.getHeaders().get("Location")).startsWith("/user/login_failed.html");
     }
 
     private User createTestUser() {

--- a/src/test/java/codesquad/webserver/RequestHandlerTest.java
+++ b/src/test/java/codesquad/webserver/RequestHandlerTest.java
@@ -28,7 +28,7 @@ class RequestHandlerTest {
 
         HttpResponse httpResponse = requestHandler.handle(httpRequest);
 
-        assertEquals(HttpStatus.BAD_REQUEST, httpResponse.status());
+        assertEquals(HttpStatus.BAD_REQUEST, httpResponse.getStatus());
     }
 
     @Test
@@ -38,6 +38,6 @@ class RequestHandlerTest {
 
         HttpResponse httpResponse = requestHandler.handle(httpRequest);
 
-        assertEquals(HttpStatus.NOT_FOUND, httpResponse.status());
+        assertEquals(HttpStatus.NOT_FOUND, httpResponse.getStatus());
     }
 }

--- a/src/test/java/codesquad/webserver/http/parser/BodyParserTest.java
+++ b/src/test/java/codesquad/webserver/http/parser/BodyParserTest.java
@@ -28,7 +28,7 @@ class BodyParserTest {
 
     @Test
     @DisplayName("여러 Form값이 전달되어도 정상 파싱한다.")
-    public void testParseFormBody_multiplePairs() {
+    public void testPasreFormXwww_multiplePairs() {
         String[] lines = {
                 "POST / HTTP/1.1",
                 "Host: example.com",
@@ -38,7 +38,7 @@ class BodyParserTest {
         };
         int contentLength = 35;
 
-        Map<String, String> result = BodyParser.parseFormBody(lines, contentLength);
+        Map<String, String> result = BodyParser.pasreFormXwww(lines, contentLength);
         assertThat(result.get("key1")).isEqualTo("value1");
         assertThat(result.get("key2")).isEqualTo("value2");
         assertThat(result.get("key3")).isEqualTo("value3");

--- a/src/test/java/codesquad/webserver/http/parser/MultiPartParserTest.java
+++ b/src/test/java/codesquad/webserver/http/parser/MultiPartParserTest.java
@@ -1,0 +1,32 @@
+package codesquad.webserver.http.parser;
+
+import static codesquad.webserver.http.parser.MultiPartParser.parse;
+
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MultiPartParserTest {
+    @Test
+    @DisplayName("멀티파트 파싱을 정상적으로 수행한다.")
+    public void test_parse() {
+        byte[] bytes = ("POST /upload HTTP/1.1\r\n" +
+            "Host: example.com\r\n" +
+            "Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryABC123\r\n" +
+            "\r\n" +
+            "------WebKitFormBoundaryABC123\r\n" +
+            "Content-Disposition: form-data; name=\"file\"; filename=\"example.txt\"\r\n" +
+            "Content-Type: text/plain\r\n" +
+            "\r\n" +
+            "This is the content of the file.\r\n" +
+            "And here is the second line.\r\n" +
+            "------WebKitFormBoundaryABC123--\r\n").getBytes();
+
+        Map<String, String> parts = parse(bytes, "----WebKitFormBoundaryABC123");
+        for (Map.Entry<String, String> entry : parts.entrySet()) {
+            Assertions.assertThat(entry.getKey().toString()).isEqualTo("file");
+            Assertions.assertThat(entry.getValue().toString()).startsWith("uploads/");
+        }
+    }
+}


### PR DESCRIPTION

## 구현 내용
- 기능
  - 게시글 작성시 이미지 첨부하는 기능을 추가한다. 
  - 게시글 조회시 이미지를 조회하는 기능을 추가한다.
- 구조
  - 요청 FormEnctype에 따라 Body 파싱 로직을 분기처리한다.
  - MultiPart 타입을 파싱을 정상적으로 수행한다.
  - 저장소(local storage)에서 파일을 저장하고 읽어오는 `StorageFileManager`를 추가한다. (`./uploads` 경로에 저장)
    - 데이터베이스에서는 저장된 파일의 path를 기억합니다. 
    - 저장되는 파일은 UUID + 기존 파일 확장자로 처리됩니다. 
  - 저장소(local storage)에 저장된 파일을 읽어오는 `StorageFileHandler`를 추가한다.
    - 요청 경로가 `/uploads`로 시작하는 경우 해당 핸들러를 맵핑한다.
    - 저장소에서 파일을 불러와 반환한다. (`StorageFileManager`)  

## 고민 사항
- Bianry Data를 다루기 위해서는 기존 처럼 읽어들인 값을 String으로 인코딩/디코딩 하는 경우 손상이 발생했습니다. 이를 해결하기 위해 byte 배열 자체를 기반으로 데이터를 다루는 방식으로 작업 방식을 전환했습니다.
- 

## 기타

<img width="741" alt="image" src="https://github.com/user-attachments/assets/f681a130-3f13-4b09-a222-c83b08df66c3">


