### PR TITLE
[박혜성] step8 이미지 업로드 및 표시 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
+/images/

--- a/src/main/java/codesquad/application/DatabaseInit.java
+++ b/src/main/java/codesquad/application/DatabaseInit.java
@@ -24,6 +24,7 @@ public class DatabaseInit {
                 + "title varchar(100) not null,"
                 + "content varchar(100) not null,"
                 + "user_id varchar(100),"
+                + "image_filename varchar(255),"
                 + " foreign key (user_id) references users (user_id))";
         String createSessionStorageSQL = "create table if not exists sessions ("
                 + "session_id varchar(100) primary key,"

--- a/src/main/java/codesquad/application/config/DatabaseConfig.java
+++ b/src/main/java/codesquad/application/config/DatabaseConfig.java
@@ -3,6 +3,7 @@ package codesquad.application.config;
 import codesquad.application.bean.Bean;
 import codesquad.application.database.ArticleDatabase;
 import codesquad.application.database.ArticleJdbcDatabase;
+import codesquad.application.file.ImageStore;
 import codesquad.application.database.SessionJdbcStorage;
 import codesquad.application.database.SessionStorage;
 import codesquad.application.database.UserDatabase;
@@ -23,5 +24,10 @@ public class DatabaseConfig {
     @Bean
     public ArticleDatabase articleDatabase() {
         return new ArticleJdbcDatabase();
+    }
+
+    @Bean
+    public ImageStore imageDatabase() {
+        return new ImageStore();
     }
 }

--- a/src/main/java/codesquad/application/config/HandlerConfig.java
+++ b/src/main/java/codesquad/application/config/HandlerConfig.java
@@ -29,8 +29,8 @@ public class HandlerConfig {
     }
 
     @Bean
-    public StaticResourceHandler staticResourceHandler() {
-        return new StaticResourceHandler();
+    public StaticResourceHandler staticResourceHandler(ImageStore imageStore) {
+        return new StaticResourceHandler(imageStore);
     }
 
     @Bean

--- a/src/main/java/codesquad/application/config/HandlerConfig.java
+++ b/src/main/java/codesquad/application/config/HandlerConfig.java
@@ -2,6 +2,7 @@ package codesquad.application.config;
 
 import codesquad.application.bean.Bean;
 import codesquad.application.database.ArticleDatabase;
+import codesquad.application.file.ImageStore;
 import codesquad.application.database.SessionStorage;
 import codesquad.application.database.UserDatabase;
 import codesquad.application.handler.ArticleHandler;
@@ -34,7 +35,7 @@ public class HandlerConfig {
 
     @Bean
     public ArticleHandler articleHandler(SessionStorage sessionStorage, ArticleDatabase articleDatabase,
-                                         UserDatabase userDatabase) {
-        return new ArticleHandler(articleDatabase, sessionStorage, userDatabase);
+                                         UserDatabase userDatabase, ImageStore imageStore) {
+        return new ArticleHandler(articleDatabase, sessionStorage, userDatabase, imageStore);
     }
 }

--- a/src/main/java/codesquad/application/config/HandlerConfig.java
+++ b/src/main/java/codesquad/application/config/HandlerConfig.java
@@ -19,8 +19,8 @@ public class HandlerConfig {
     }
 
     @Bean
-    public MainHandler mainHandler(UserDatabase userDatabase, SessionStorage sessionStorage) {
-        return new MainHandler(userDatabase, sessionStorage);
+    public MainHandler mainHandler(UserDatabase userDatabase, SessionStorage sessionStorage, ArticleDatabase articleDatabase) {
+        return new MainHandler(userDatabase, sessionStorage, articleDatabase);
     }
 
     @Bean

--- a/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
+++ b/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
@@ -122,6 +122,7 @@ public class ArticleJdbcDatabase implements ArticleDatabase {
                                 rs.getString("name")
                         )
                 );
+                article.setImage(rs.getString("image_filename"));
                 articles.add(article);
             }
             return articles;

--- a/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
+++ b/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
@@ -88,6 +88,7 @@ public class ArticleJdbcDatabase implements ArticleDatabase {
                                 rs.getString("name")
                         )
                 );
+                article.setImage(rs.getString("image_filename"));
                 return Optional.of(article);
             }
             return Optional.empty();

--- a/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
+++ b/src/main/java/codesquad/application/database/ArticleJdbcDatabase.java
@@ -19,7 +19,7 @@ public class ArticleJdbcDatabase implements ArticleDatabase {
 
     @Override
     public Long save(Article article) {
-        String sql = "insert into article(article_id, title, content, user_id) values(?, ?, ?, ?)";
+        String sql = "insert into article(article_id, title, content, user_id, image_filename) values(?, ?, ?, ?, ?)";
 
         Connection con = null;
         PreparedStatement pstmt = null;
@@ -30,6 +30,7 @@ public class ArticleJdbcDatabase implements ArticleDatabase {
             pstmt.setString(2, article.getTitle());
             pstmt.setString(3, article.getContent());
             pstmt.setString(4, article.getAuthor().getUserId());
+            pstmt.setString(5, article.getImageFilename());
             pstmt.executeUpdate();
             return article.getArticleId();
         } catch (SQLException e) {

--- a/src/main/java/codesquad/application/file/ImageStore.java
+++ b/src/main/java/codesquad/application/file/ImageStore.java
@@ -2,8 +2,10 @@ package codesquad.application.file;
 
 import codesquad.server.message.HttpFile;
 import codesquad.server.message.RuntimeIOException;
+import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.UUID;
@@ -30,6 +32,17 @@ public class ImageStore {
         } catch (IOException e) {
             throw new RuntimeIOException("파일 쓰기 실패", e);
         }
-        return storeFilename;
+        return file.getPath();
+    }
+
+    public byte[] getImage(String storeFilename) {
+        File file = new File(PATH + "/" + storeFilename);
+        try {
+            FileInputStream fis = new FileInputStream(file);
+            BufferedInputStream bis = new BufferedInputStream(fis);
+            return bis.readAllBytes();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/src/main/java/codesquad/application/file/ImageStore.java
+++ b/src/main/java/codesquad/application/file/ImageStore.java
@@ -1,0 +1,35 @@
+package codesquad.application.file;
+
+import codesquad.server.message.HttpFile;
+import codesquad.server.message.RuntimeIOException;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.UUID;
+
+public class ImageStore {
+
+    private static final String PATH = "images";
+
+    public String store(HttpFile httpFile) {
+        File dir = new File(PATH);
+        if(!dir.exists()) {
+            if(!dir.mkdir()) {
+                throw new RuntimeIOException("디렉터리 생성 불가");
+            }
+        }
+        String extension = httpFile.getFileName().split("\\.")[1];
+        String storeFilename = UUID.randomUUID() + "." + extension;
+        File file = new File(dir, storeFilename);
+        try (
+                FileOutputStream fos = new FileOutputStream(file);
+                BufferedOutputStream bos = new BufferedOutputStream(fos);
+        ) {
+            bos.write(httpFile.getContent());
+        } catch (IOException e) {
+            throw new RuntimeIOException("파일 쓰기 실패", e);
+        }
+        return storeFilename;
+    }
+}

--- a/src/main/java/codesquad/application/handler/ArticleHandler.java
+++ b/src/main/java/codesquad/application/handler/ArticleHandler.java
@@ -112,6 +112,7 @@ public class ArticleHandler {
         modelAndView.add("content", article.getContent());
         modelAndView.add("userId", article.getAuthor().getUserId());
         modelAndView.add("username", article.getAuthor().getName());
+        modelAndView.add("imageFilename", article.getImageFilename());
         return modelAndView;
     }
 

--- a/src/main/java/codesquad/application/handler/ArticleHandler.java
+++ b/src/main/java/codesquad/application/handler/ArticleHandler.java
@@ -63,7 +63,7 @@ public class ArticleHandler {
         Article article = Article.create(articleDatabase.getNextId(), data.title, data.content, user);
         articleDatabase.save(article);
 
-        ModelAndView modelAndView = new ModelAndView(HttpStatusCode.MOVED_PERMANENTLY);
+        ModelAndView modelAndView = new ModelAndView(HttpStatusCode.FOUND);
         modelAndView.addHeader("Location", "/article?articleId=" + article.getArticleId());
         modelAndView.add("articleId", String.valueOf(article.getArticleId()));
         return modelAndView;
@@ -74,7 +74,7 @@ public class ArticleHandler {
     }
 
     private ModelAndView redirectToLogin() {
-        ModelAndView modelAndView = new ModelAndView(HttpStatusCode.MOVED_PERMANENTLY);
+        ModelAndView modelAndView = new ModelAndView(HttpStatusCode.FOUND);
         modelAndView.addHeader("Location", "/login");
         return modelAndView;
     }

--- a/src/main/java/codesquad/application/handler/ArticleHandler.java
+++ b/src/main/java/codesquad/application/handler/ArticleHandler.java
@@ -107,6 +107,17 @@ public class ArticleHandler {
                 .orElseThrow(() -> new NoSuchElementException("존재하지 않는 게시글입니다."));
         ModelAndView modelAndView = new ModelAndView(ResourceUtils.getStaticFile("/article/index.html"),
                 HttpStatusCode.OK);
+
+        String sessionId = request.httpCookies().cookies().get("SID");
+        if(sessionId != null) {
+            String userId = sessionStorage.findLoginUser(sessionId)
+                    .orElseThrow(() -> new NoSuchElementException("세션이 유효하지 않습니다."));
+            User user = userDatabase.findUserByUserId(userId)
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 유저입니다."));
+            modelAndView.add("userId", user.getUserId());
+            modelAndView.add("name", user.getName());
+            modelAndView.add("email", user.getEmail());
+        }
         modelAndView.add("articleId", article.getArticleId());
         modelAndView.add("title", article.getTitle());
         modelAndView.add("content", article.getContent());
@@ -118,8 +129,19 @@ public class ArticleHandler {
 
     @RequestMapping(path = "/articles", method = HttpMethod.GET)
     public ModelAndView getArticles(HttpRequest request) {
-        List<Article> articles = articleDatabase.findAll();
         ModelAndView modelAndView = new ModelAndView(ResourceUtils.getStaticFile("/article/articleList.html"));
+        String sessionId = request.httpCookies().cookies().get("SID");
+        if(sessionId != null) {
+            String userId = sessionStorage.findLoginUser(sessionId)
+                    .orElseThrow(() -> new NoSuchElementException("세션이 유효하지 않습니다."));
+            User user = userDatabase.findUserByUserId(userId)
+                    .orElseThrow(() -> new NoSuchElementException("존재하지 않는 유저입니다."));
+            modelAndView.add("userId", user.getUserId());
+            modelAndView.add("name", user.getName());
+            modelAndView.add("email", user.getEmail());
+        }
+
+        List<Article> articles = articleDatabase.findAll();
         modelAndView.add("articles", articles);
         return modelAndView;
     }

--- a/src/main/java/codesquad/application/handler/MainHandler.java
+++ b/src/main/java/codesquad/application/handler/MainHandler.java
@@ -1,30 +1,34 @@
 package codesquad.application.handler;
 
+import codesquad.application.database.ArticleDatabase;
 import codesquad.application.database.SessionStorage;
 import codesquad.application.database.UserDatabase;
+import codesquad.application.model.Article;
 import codesquad.application.model.User;
 import codesquad.application.util.ResourceUtils;
 import codesquad.application.web.ModelAndView;
 import codesquad.application.web.RequestMapping;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
-import codesquad.server.message.HttpStatusCode;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 public class MainHandler {
 
     private final UserDatabase userDatabase;
     private final SessionStorage sessionStorage;
+    private final ArticleDatabase articleDatabase;
 
-    public MainHandler(UserDatabase userDatabase, SessionStorage sessionStorage) {
+    public MainHandler(UserDatabase userDatabase, SessionStorage sessionStorage, ArticleDatabase articleDatabase) {
         this.userDatabase = userDatabase;
         this.sessionStorage = sessionStorage;
+        this.articleDatabase = articleDatabase;
     }
 
-    @RequestMapping(method = HttpMethod.GET, path = "/")
-    public ModelAndView mainPage(HttpRequest httpRequest) {
-        String sessionId = httpRequest.cookies().get("SID");
-        ModelAndView modelAndView = new ModelAndView(ResourceUtils.getStaticFile("/index.html"), HttpStatusCode.OK);
+    @RequestMapping(path = "/", method = HttpMethod.GET)
+    public ModelAndView getArticles(HttpRequest request) {
+        String sessionId = request.cookies().get("SID");
+        ModelAndView modelAndView = new ModelAndView(ResourceUtils.getStaticFile("/article/articleList.html"));
         if(sessionId != null) {
             String userId = sessionStorage.findLoginUser(sessionId)
                     .orElseThrow(() -> new NoSuchElementException("세션이 유효하지 않습니다."));
@@ -34,6 +38,9 @@ public class MainHandler {
             modelAndView.add("name", user.getName());
             modelAndView.add("email", user.getEmail());
         }
+
+        List<Article> articles = articleDatabase.findAll();
+        modelAndView.add("articles", articles);
         return modelAndView;
     }
 }

--- a/src/main/java/codesquad/application/model/Article.java
+++ b/src/main/java/codesquad/application/model/Article.java
@@ -5,6 +5,7 @@ public class Article {
     private final String title;
     private final String content;
     private final Author author;
+    private String imageFilename;
 
     private Article(Long articleId, String title, String content, Author author) {
         this.articleId = articleId;
@@ -35,5 +36,13 @@ public class Article {
 
     public Author getAuthor() {
         return author;
+    }
+
+    public String getImageFilename() {
+        return imageFilename;
+    }
+
+    public void setImage(String storeFilename) {
+        this.imageFilename = storeFilename;
     }
 }

--- a/src/main/java/codesquad/application/model/Article.java
+++ b/src/main/java/codesquad/application/model/Article.java
@@ -38,6 +38,10 @@ public class Article {
         return author;
     }
 
+    public String getUsername() {
+        return author.getName();
+    }
+
     public String getImageFilename() {
         return imageFilename;
     }

--- a/src/main/java/codesquad/application/web/HttpResponseFactory.java
+++ b/src/main/java/codesquad/application/web/HttpResponseFactory.java
@@ -41,7 +41,7 @@ public final class HttpResponseFactory {
     }
 
     public static HttpResponse invalidateSession() {
-        HttpResponse httpResponse = new HttpResponse(HTTP1_1, HttpStatusCode.MOVED_PERMANENTLY, "");
+        HttpResponse httpResponse = new HttpResponse(HTTP1_1, HttpStatusCode.FOUND, "");
         httpResponse.addHeader("Location", "/login");
         httpResponse.addHeader("Set-Cookie", "SID=-1; Max-Age=0");
         return httpResponse;

--- a/src/main/java/codesquad/application/web/StaticResourceHandler.java
+++ b/src/main/java/codesquad/application/web/StaticResourceHandler.java
@@ -1,5 +1,6 @@
 package codesquad.application.web;
 
+import codesquad.application.file.ImageStore;
 import codesquad.server.message.HttpRequest;
 import codesquad.application.util.ResourceUtils;
 import org.slf4j.Logger;
@@ -8,9 +9,23 @@ import org.slf4j.LoggerFactory;
 public class StaticResourceHandler implements Handler {
     private static final Logger log = LoggerFactory.getLogger(StaticResourceHandler.class);
 
+    private final ImageStore imageStore;
+
+    public StaticResourceHandler(ImageStore imageStore) {
+        this.imageStore = imageStore;
+    }
+
     @Override
     public ModelAndView handle(HttpRequest httpRequest) {
         String viewPath = addIndexPath(httpRequest.requestUrl());
+        if(viewPath.contains("/images")) {
+            String filename = viewPath.replace("/images/", "");
+            byte[] image = imageStore.getImage(filename);
+            ModelAndView modelAndView = new ModelAndView(image);
+            modelAndView.addHeader("Content-Length", String.valueOf(image.length));
+            modelAndView.addHeader("Content-Type", "image/png");
+            return modelAndView;
+        }
         byte[] view = ResourceUtils.getStaticFile(viewPath);
         ModelAndView modelAndView = new ModelAndView(view);
         modelAndView.addHeader("Content-Length", String.valueOf(view.length));

--- a/src/main/java/codesquad/server/ClientRequest.java
+++ b/src/main/java/codesquad/server/ClientRequest.java
@@ -2,10 +2,8 @@ package codesquad.server;
 
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpResponse;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.net.Socket;
 import org.slf4j.Logger;
@@ -38,14 +36,13 @@ public class ClientRequest implements Runnable {
     private void process(InputStream clientInput, OutputStream clientOutput) throws IOException {
         log.debug("Client connected");
 
-        BufferedReader br = new BufferedReader(new InputStreamReader(clientInput));
-        HttpRequest httpRequest = HttpRequest.parse(br);
-        log.debug("HTTP 요청 메시지 해석={}", httpRequest);
+        HttpRequest httpRequest = HttpRequest.parse(clientInput);
+        log.debug("HTTP 요청={}", httpRequest.requestUrl());
 
         HttpResponse httpResponse = serverHandler.handle(httpRequest);
         httpResponse.write(clientOutput);
         clientOutput.flush();
-        log.debug("HTTP 응답 메시지 출력={}", httpRequest);
+        log.debug("HTTP 응답 메시지 출력");
 
         clientSocket.close();
         log.debug("Client disconnected");

--- a/src/main/java/codesquad/server/message/HttpBody.java
+++ b/src/main/java/codesquad/server/message/HttpBody.java
@@ -17,6 +17,7 @@ public record HttpBody(Map<String, String> data, Map<String, HttpFile> files) {
 
     public static HttpBody parse(BufferedReader br, InputStream clientInput, HttpHeaders httpHeaders) throws IOException {
         Map<String, String> data = new HashMap<>();
+        Map<String, HttpFile> files = new HashMap<>();
 
         if (httpHeaders.isMultiPart()) {
             HttpBody parse = MultiPartParser.parse(httpHeaders, clientInput);
@@ -25,7 +26,7 @@ public record HttpBody(Map<String, String> data, Map<String, HttpFile> files) {
         }
 
         if (!httpHeaders.isFormData()) {
-            return new HttpBody(data, null);
+            return new HttpBody(data, files);
         }
 
         String body = getRawBodyUsing(br, httpHeaders);
@@ -35,7 +36,7 @@ public record HttpBody(Map<String, String> data, Map<String, HttpFile> files) {
             keyValue = changeValueToEmptyString(keyValue);
             data.put(decode(keyValue[0]), decode(keyValue[1]));
         }
-        return new HttpBody(data, null);
+        return new HttpBody(data, files);
     }
 
     private static String getRawBodyUsing(BufferedReader br, HttpHeaders httpHeaders) throws IOException {

--- a/src/main/java/codesquad/server/message/HttpBody.java
+++ b/src/main/java/codesquad/server/message/HttpBody.java
@@ -1,18 +1,31 @@
 package codesquad.server.message;
 
+import codesquad.server.utils.MultiPartParser;
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.HashMap;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public record HttpBody(Map<String, String> data) {
+public record HttpBody(Map<String, String> data, Map<String, HttpFile> files) {
 
-    public static HttpBody parse(BufferedReader br, HttpHeaders httpHeaders) throws IOException {
+    private static final Logger log = LoggerFactory.getLogger(HttpBody.class);
+
+    public static HttpBody parse(BufferedReader br, InputStream clientInput, HttpHeaders httpHeaders) throws IOException {
         Map<String, String> data = new HashMap<>();
+
+        if (httpHeaders.isMultiPart()) {
+            HttpBody parse = MultiPartParser.parse(httpHeaders, clientInput);
+            log.debug("폼 데이터={}", parse);
+            return parse;
+        }
+
         if (!httpHeaders.isFormData()) {
-            return new HttpBody(data);
+            return new HttpBody(data, null);
         }
 
         String body = getRawBodyUsing(br, httpHeaders);
@@ -22,7 +35,7 @@ public record HttpBody(Map<String, String> data) {
             keyValue = changeValueToEmptyString(keyValue);
             data.put(decode(keyValue[0]), decode(keyValue[1]));
         }
-        return new HttpBody(data);
+        return new HttpBody(data, null);
     }
 
     private static String getRawBodyUsing(BufferedReader br, HttpHeaders httpHeaders) throws IOException {
@@ -36,7 +49,7 @@ public record HttpBody(Map<String, String> data) {
     }
 
     private static String[] changeValueToEmptyString(String[] keyValue) {
-        if(keyValue.length == 2) {
+        if (keyValue.length == 2) {
             return keyValue;
         }
         return new String[]{keyValue[0], ""};

--- a/src/main/java/codesquad/server/message/HttpFile.java
+++ b/src/main/java/codesquad/server/message/HttpFile.java
@@ -1,0 +1,25 @@
+package codesquad.server.message;
+
+public class HttpFile {
+    private final String fileName;
+    private final String contentType;
+    private final byte[] content;
+
+    public HttpFile(String fileName, String contentType, byte[] content) {
+        this.fileName = fileName;
+        this.contentType = contentType;
+        this.content = content;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public byte[] getContent() {
+        return content;
+    }
+}

--- a/src/main/java/codesquad/server/message/HttpHeaders.java
+++ b/src/main/java/codesquad/server/message/HttpHeaders.java
@@ -1,7 +1,8 @@
 package codesquad.server.message;
 
-import java.io.BufferedReader;
+import codesquad.server.utils.ByteUtils;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -11,10 +12,10 @@ public record HttpHeaders(Map<String, String> headers) {
 
     private static final String LINE_SEPARATOR = "\n";
 
-    public static HttpHeaders parse(BufferedReader br) throws IOException {
+    public static HttpHeaders parse(InputStream clientInput) throws IOException {
         Map<String, String> headers = new HashMap<>();
         String header;
-        while (!(header = br.readLine()).isEmpty()) {
+        while (!(header = new String(ByteUtils.readLine(clientInput))).isEmpty()) {
             String[] keyValue = header.split(": ");
             validateHeader(keyValue);
             headers.put(keyValue[0], keyValue[1]);

--- a/src/main/java/codesquad/server/message/HttpHeaders.java
+++ b/src/main/java/codesquad/server/message/HttpHeaders.java
@@ -47,4 +47,9 @@ public record HttpHeaders(Map<String, String> headers) {
         String contentType = headers.get("Content-Type");
         return contentType != null && contentType.equals("application/x-www-form-urlencoded");
     }
+
+    public boolean isMultiPart() {
+        String contentType = headers.get("Content-Type");
+        return contentType != null && contentType.contains("multipart/form-data");
+    }
 }

--- a/src/main/java/codesquad/server/message/HttpRequest.java
+++ b/src/main/java/codesquad/server/message/HttpRequest.java
@@ -1,10 +1,8 @@
 package codesquad.server.message;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedReader;
+import codesquad.server.utils.ByteUtils;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +24,14 @@ public record HttpRequest(
     }
 
     private static HttpRequest parseInner(InputStream clientInput) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(clientInput));
-        HttpStartLine httpStartLine = HttpStartLine.parse(br.readLine());
-        HttpHeaders httpHeaders = HttpHeaders.parse(br);
+        HttpStartLine httpStartLine = HttpStartLine.parse(new String(ByteUtils.readLine(clientInput)));
+        HttpHeaders httpHeaders = HttpHeaders.parse(clientInput);
         HttpCookies httpCookies = HttpCookies.parse(httpHeaders);
 
-        HttpBody httpBody = HttpBody.parse(br, clientInput, httpHeaders);
+        HttpBody httpBody = HttpBody.parse(clientInput, httpHeaders);
         return new HttpRequest(httpStartLine, httpHeaders, httpCookies, httpBody);
     }
+
 
     public HttpMethod method() {
         return httpStartLine.method();

--- a/src/main/java/codesquad/server/utils/ByteUtils.java
+++ b/src/main/java/codesquad/server/utils/ByteUtils.java
@@ -1,0 +1,38 @@
+package codesquad.server.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ByteUtils {
+
+    public static byte[] readLine(InputStream inputStream) {
+        List<Byte> result = new ArrayList<>();
+        int count = 0;
+        try {
+            int b = 0;
+            while ((b = inputStream.read()) != -1) {
+                byte bytes = (byte) b;
+                result.add(bytes);
+                if (bytes == '\r') {
+                    count = 1;
+                }
+                if (count == 1 && bytes == '\n') {
+                    return toByteArray(result.subList(0, result.size() - 2));
+                }
+            }
+            return toByteArray(result);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] toByteArray(List<Byte> bytes) {
+        byte[] result = new byte[bytes.size()];
+        for (int i = 0; i < bytes.size(); i++) {
+            result[i] = bytes.get(i);
+        }
+        return result;
+    }
+}

--- a/src/main/java/codesquad/server/utils/MultiPartParser.java
+++ b/src/main/java/codesquad/server/utils/MultiPartParser.java
@@ -53,16 +53,7 @@ public class MultiPartParser {
 
     private static byte[] readBytes(HttpHeaders httpHeaders, InputStream clientInput) throws IOException {
         int contentLength = Integer.parseInt(httpHeaders.get("Content-Length").get());
-        byte[] buffer = new byte[contentLength];
-        int bytesRead = 0;
-        while (bytesRead < contentLength) {
-            int result = clientInput.read(buffer, bytesRead, contentLength - bytesRead);
-            if (result == -1) {
-                break;
-            }
-            bytesRead += result;
-        }
-        return buffer;
+        return clientInput.readNBytes(contentLength);
     }
 
     private static int indexOf(byte[] body, byte[] target, int start) {

--- a/src/main/java/codesquad/server/utils/MultiPartParser.java
+++ b/src/main/java/codesquad/server/utils/MultiPartParser.java
@@ -1,0 +1,118 @@
+package codesquad.server.utils;
+
+import codesquad.server.message.HttpBody;
+import codesquad.server.message.HttpFile;
+import codesquad.server.message.HttpHeaders;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultiPartParser {
+
+    private static final byte[] NEW_LINE = ("\r\n").getBytes();
+    private static final Logger log = LoggerFactory.getLogger(MultiPartParser.class);
+
+    public static HttpBody parse(HttpHeaders httpHeaders, InputStream clientInput)
+            throws IOException {
+        Map<String, HttpFile> files = new HashMap<>();
+        Map<String, String> params = new HashMap<>();
+        log.debug("multipart 파싱 시작");
+
+        byte[] bodyBytes = readBytes(httpHeaders, clientInput);
+        String contentType = httpHeaders.get("Content-Type").get();
+
+        String boundary = contentType.split("boundary=", 2)[1].trim();
+        log.debug("bounday={}", boundary);
+        byte[] delimiter = ("--" + boundary).getBytes();
+        byte[] endDelimiter = ("--" + boundary + "--").getBytes();
+
+        int start = 0;
+        int delimiterPos = indexOf(bodyBytes, delimiter, start);
+        int endDelimiterPos = indexOf(bodyBytes, endDelimiter, start);
+        while (delimiterPos != endDelimiterPos) {
+            start = delimiterPos + delimiter.length + NEW_LINE.length; // part의 시작점
+            delimiterPos = indexOf(bodyBytes, delimiter, start); // part의 경계
+
+            int partHeaderEnd = indexOf(bodyBytes, NEW_LINE, start); // part header의 CRLF 위치
+            String contentDisposition = new String(Arrays.copyOfRange(bodyBytes, start, partHeaderEnd));
+            log.debug("Content-Disposition={}", contentDisposition);
+
+            if (contentDisposition.contains("filename=")) {
+                processFilePart(contentDisposition, bodyBytes, partHeaderEnd, delimiterPos, files);
+            } else {
+                processParameterPart(contentDisposition, bodyBytes, partHeaderEnd, delimiterPos, params);
+            }
+        }
+
+        return new HttpBody(params, files);
+    }
+
+    private static byte[] readBytes(HttpHeaders httpHeaders, InputStream clientInput) throws IOException {
+        int contentLength = Integer.parseInt(httpHeaders.get("Content-Length").get());
+        byte[] buffer = new byte[contentLength];
+        int bytesRead = 0;
+        while (bytesRead < contentLength) {
+            int result = clientInput.read(buffer, bytesRead, contentLength - bytesRead);
+            if (result == -1) {
+                break;
+            }
+            bytesRead += result;
+        }
+        return buffer;
+    }
+
+    private static int indexOf(byte[] body, byte[] target, int start) {
+        for (int i = start; i < body.length - target.length; i++) {
+            boolean found = true;
+            for (int j = 0; j < target.length; j++) {
+                if (body[i + j] != target[j]) {
+                    found = false;
+                    break;
+                }
+            }
+            if (found) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    private static void processParameterPart(String contentDisposition, byte[] body, int partHeaderEnd,
+                                             int delimiterPos, Map<String, String> params) {
+        String name = getFieldName(contentDisposition.split(";")[1]);
+        String data = new String(
+                Arrays.copyOfRange(body, partHeaderEnd + NEW_LINE.length * 2, delimiterPos - NEW_LINE.length));
+        log.debug("name={}, data={}", name, data);
+        params.put(name, data);
+    }
+
+    private static void processFilePart(String contentDisposition, byte[] body, int partHeaderEnd,
+                                        int delimiterPos, Map<String, HttpFile> files) {
+        String name = getFieldName(contentDisposition.split(";")[1]);
+        String filename = getFileName(contentDisposition.split(";")[2]);
+        int contentTypeNewLinePos = indexOf(body, NEW_LINE,
+                partHeaderEnd + NEW_LINE.length); // content-type \r\n 첫 위치
+        String partContentType = new String(
+                Arrays.copyOfRange(body, partHeaderEnd + NEW_LINE.length, contentTypeNewLinePos));
+        byte[] fileBytes = Arrays.copyOfRange(
+                body, contentTypeNewLinePos + NEW_LINE.length * 2, delimiterPos - NEW_LINE.length);
+        log.debug("content-type={}, filename={}, length={}", partContentType, filename, fileBytes.length);
+        files.put(name, new HttpFile(filename, partContentType, fileBytes));
+    }
+
+    private static String getFieldName(String contentDisposition) {
+        return contentDisposition.substring(contentDisposition.indexOf("name=") + "name=".length())
+                .replaceAll("\"", "")
+                .trim();
+    }
+
+    private static String getFileName(String contentDisposition) {
+        return contentDisposition.substring(contentDisposition.indexOf("filename=") + "filename=".length())
+                .replaceAll("\"", "")
+                .trim();
+    }
+}

--- a/src/main/java/codesquad/server/utils/MultiPartParser.java
+++ b/src/main/java/codesquad/server/utils/MultiPartParser.java
@@ -98,6 +98,7 @@ public class MultiPartParser {
                 partHeaderEnd + NEW_LINE.length); // content-type \r\n 첫 위치
         String partContentType = new String(
                 Arrays.copyOfRange(body, partHeaderEnd + NEW_LINE.length, contentTypeNewLinePos));
+        partContentType = partContentType.split(":")[1].trim();
         byte[] fileBytes = Arrays.copyOfRange(
                 body, contentTypeNewLinePos + NEW_LINE.length * 2, delimiterPos - NEW_LINE.length);
         log.debug("content-type={}, filename={}, length={}", partContentType, filename, fileBytes.length);

--- a/src/main/resources/static/article/articleList.html
+++ b/src/main/resources/static/article/articleList.html
@@ -28,14 +28,14 @@
     </header>
     <div class="wrapper">
         <div class="post">
-            <div class="post__account">
-                <img class="post__account__img"/>
-                <p class="post__account__nickname">{{username}}</p>
-            </div>
             <div class="post__list">
                 {{for article in articles}}
                 <div class="post__title__content">
-                    <img class="post__img_small"/>
+                    <img src="{{article.getImageFilename}}" class="post__img_small"/>
+                    <div class="post__account">
+                        <img class="post__account__img"/>
+                        <p class="post__account__nickname">{{article.getUsername}}</p>
+                    </div>
                     <p>
                         {{article.getTitle}}
                     </p>

--- a/src/main/resources/static/article/articleList.html
+++ b/src/main/resources/static/article/articleList.html
@@ -10,11 +10,19 @@
 <body>
 <div class="container">
     <header class="header">
-        <a href="/"><img src="../img/signiture.svg"/></a>
-        {{#if userId}}
-        <p>{{userId}}</p>
-        {{else}}
+        <a href="/"><img src="./img/signiture.svg" /></a>
         <ul class="header__menu">
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/articles">글 목록</a>
+            </li>
+            {{#if userId}}
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/article/write">글쓰기</a>
+            </li>
+            <li class="header__menu__item">
+                <p>{{userId}}</p>
+            </li>
+            {{else}}
             <li class="header__menu__item">
                 <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
             </li>
@@ -23,8 +31,8 @@
                     회원 가입
                 </a>
             </li>
+            {{/if}}
         </ul>
-        {{/if}}
     </header>
     <div class="wrapper">
         <div class="post">

--- a/src/main/resources/static/article/index.html
+++ b/src/main/resources/static/article/index.html
@@ -10,11 +10,19 @@
   <body>
     <div class="container">
       <header class="header">
-        <a href="/"><img src="../img/signiture.svg" /></a>
-        {{#if userId}}
-        <p>{{userId}}</p>
-        {{else}}
+        <a href="/"><img src="./img/signiture.svg" /></a>
         <ul class="header__menu">
+          <li class="header__menu__item">
+            <a class="btn btn_contained btn_size_s" href="/articles">글 목록</a>
+          </li>
+          {{#if userId}}
+          <li class="header__menu__item">
+            <a class="btn btn_contained btn_size_s" href="/article/write">글쓰기</a>
+          </li>
+          <li class="header__menu__item">
+            <p>{{userId}}</p>
+          </li>
+          {{else}}
           <li class="header__menu__item">
             <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
           </li>
@@ -23,8 +31,8 @@
               회원 가입
             </a>
           </li>
+          {{/if}}
         </ul>
-        {{/if}}
       </header>
       <div class="wrapper">
         <div class="post">

--- a/src/main/resources/static/article/index.html
+++ b/src/main/resources/static/article/index.html
@@ -32,7 +32,7 @@
             <img class="post__account__img" />
             <p class="post__account__nickname">{{username}}</p>
           </div>
-          <img class="post__img" />
+          <img src="{{imageFilename}}" class="post__img" />
           <div class="post__menu">
             <ul class="post__menu__personal">
               <li>

--- a/src/main/resources/static/article/write.html
+++ b/src/main/resources/static/article/write.html
@@ -48,7 +48,8 @@
                 <input type="file"
                        id="image"
                        name="image"
-                       accept="image/png, image/jpeg">
+                       accept="image/png, image/jpeg"
+                       required/>
             </div>
             <button
                     id="registration-btn"

--- a/src/main/resources/static/article/write.html
+++ b/src/main/resources/static/article/write.html
@@ -12,7 +12,7 @@
         <a href="/main"><img src="../img/signiture.svg"/></a>
         <ul class="header__menu">
             <li class="header__menu__item">
-                <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
+                <a class="btn btn_contained btn_size_s" href="/article/write">글쓰기</a>
             </li>
             <li class="header__menu__item">
                 <button id="logout-btn" class="btn btn_ghost btn_size_s">

--- a/src/main/resources/static/article/write.html
+++ b/src/main/resources/static/article/write.html
@@ -1,59 +1,65 @@
 <!DOCTYPE html>
 <html>
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link href="../reset.css" rel="stylesheet" />
-    <link href="../global.css" rel="stylesheet" />
-  </head>
-  <body>
-    <div class="container">
-      <header class="header">
-        <a href="/main"><img src="../img/signiture.svg" /></a>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <link href="../reset.css" rel="stylesheet"/>
+    <link href="../global.css" rel="stylesheet"/>
+</head>
+<body>
+<div class="container">
+    <header class="header">
+        <a href="/main"><img src="../img/signiture.svg"/></a>
         <ul class="header__menu">
-          <li class="header__menu__item">
-            <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
-          </li>
-          <li class="header__menu__item">
-            <button id="logout-btn" class="btn btn_ghost btn_size_s">
-              로그아웃
-            </button>
-          </li>
+            <li class="header__menu__item">
+                <a class="btn btn_contained btn_size_s" href="/article">글쓰기</a>
+            </li>
+            <li class="header__menu__item">
+                <button id="logout-btn" class="btn btn_ghost btn_size_s">
+                    로그아웃
+                </button>
+            </li>
         </ul>
-      </header>
-      <div class="page">
+    </header>
+    <div class="page">
         <h2 class="page-title">게시글 작성</h2>
-        <form class="form" action="/article" method="post">
-          <div class="textfield textfield_size_s_full">
-            <p class="title_textfield">제목</p>
-            <input
-                    type="text"
-                    class="input_textfield"
-                    name="title"
-                    placeholder="글의 제목을 입력하세요."
-                    autocomplete="username"
-            />
-          </div>
-          <div class="textfield textfield_size_m">
-            <p class="title_textfield">내용</p>
-            <textarea
-              class="input_textfield"
-              placeholder="글의 내용을 입력하세요"
-              autocomplete="username"
-              name="content"
-              id="content"
-            ></textarea>
-          </div>
-          <button
-            id="registration-btn"
-            class="btn btn_contained btn_size_m"
-            style="margin-top: 24px"
-            type="submit"
-          >
-            작성 완료
-          </button>
+        <form class="form" action="/article" method="post" enctype="multipart/form-data">
+            <div class="textfield textfield_size_s_full">
+                <p class="title_textfield">제목</p>
+                <input
+                        type="text"
+                        class="input_textfield"
+                        name="title"
+                        placeholder="글의 제목을 입력하세요."
+                        autocomplete="username"
+                />
+            </div>
+            <div class="textfield textfield_size_m">
+                <p class="title_textfield">내용</p>
+                <textarea
+                        class="input_textfield"
+                        placeholder="글의 내용을 입력하세요"
+                        autocomplete="username"
+                        name="content"
+                        id="content"
+                ></textarea>
+            </div>
+            <div>
+                <input type="file"
+                       id="image"
+                       name="image"
+                       accept="image/png, image/jpeg">
+            </div>
+            <button
+                    id="registration-btn"
+                    class="btn btn_contained btn_size_m"
+                    style="margin-top: 24px"
+                    type="submit"
+            >
+                작성 완료
+            </button>
         </form>
-      </div>
     </div>
-  </body>
+</div>
+</body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -11,10 +11,15 @@
     <div class="container">
       <header class="header">
         <a href="/"><img src="./img/signiture.svg" /></a>
-        {{#if userId}}
-        <p>{{userId}}</p>
-        {{else}}
         <ul class="header__menu">
+          <li class="header__menu__item">
+            <a class="btn btn_contained btn_size_s" href="/articles">글 목록</a>
+          </li>
+          {{#if userId}}
+          <li class="header__menu__item">
+            <p>{{userId}}</p>
+          </li>
+          {{else}}
           <li class="header__menu__item">
             <a class="btn btn_contained btn_size_s" href="/login">로그인</a>
           </li>

--- a/src/test/java/codesquad/application/handler/AnnotationHandlerMappingTest.java
+++ b/src/test/java/codesquad/application/handler/AnnotationHandlerMappingTest.java
@@ -10,8 +10,8 @@ import codesquad.base.ApplicationTest;
 import codesquad.fixture.HttpFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,7 +30,8 @@ class AnnotationHandlerMappingTest extends ApplicationTest {
                     .method(HttpMethod.GET)
                     .path("/asdf")
                     .buildToRawHttpMessage();
-            HttpRequest httpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             handlerMapping.init(beanFactory);
@@ -47,7 +48,8 @@ class AnnotationHandlerMappingTest extends ApplicationTest {
             String rawHttpMessage = HttpFixture.builder()
                     .method(HttpMethod.GET).path("/article")
                     .buildToRawHttpMessage();
-            HttpRequest httpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             handlerMapping.init(beanFactory);

--- a/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
@@ -81,7 +81,7 @@ class ArticleHandlerTest {
 
             //then
             assertThat(mav.getView()).isEmpty();
-            assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.MOVED_PERMANENTLY);
+            assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
             assertThat(mav.getHeaders().get("Location")).isNotEmpty().isEqualTo("/login");
         }
     }
@@ -131,7 +131,7 @@ class ArticleHandlerTest {
 
             //then
             assertThat(mav.getView()).isEmpty();
-            assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.MOVED_PERMANENTLY);
+            assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.FOUND);
             assertThat(mav.getHeaders().get("Location")).isNotEmpty().isEqualTo("/login");
         }
 

--- a/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/ArticleHandlerTest.java
@@ -15,8 +15,8 @@ import codesquad.fixture.UserFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpStatusCode;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -54,8 +54,8 @@ class ArticleHandlerTest {
                     .method(HttpMethod.GET).path("/article/write")
                     .cookie("SID", sessionId)
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             ModelAndView mav = articleHandler.getArticleForm(httpRequest);
@@ -73,8 +73,8 @@ class ArticleHandlerTest {
             String rawHttpMessage = HttpFixture.builder()
                     .method(HttpMethod.GET).path("/article/write")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             ModelAndView mav = articleHandler.getArticleForm(httpRequest);

--- a/src/test/java/codesquad/application/handler/LoginHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/LoginHandlerTest.java
@@ -2,17 +2,17 @@ package codesquad.application.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import codesquad.application.database.UserMemoryDatabase;
 import codesquad.application.database.SessionMemoryStorage;
+import codesquad.application.database.UserMemoryDatabase;
+import codesquad.application.model.User;
 import codesquad.application.util.ResourceUtils;
+import codesquad.application.web.ModelAndView;
 import codesquad.fixture.HttpFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpStatusCode;
-import codesquad.application.model.User;
-import codesquad.application.web.ModelAndView;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -109,8 +109,8 @@ class LoginHandlerTest {
                     .path("/login")
                     .body("userId=nope&password=nope")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             ModelAndView mav = loginHandler.login(httpRequest);
@@ -131,8 +131,8 @@ class LoginHandlerTest {
                     .path("/login")
                     .body("userId=userId&password=nope")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             ModelAndView mav = loginHandler.login(httpRequest);

--- a/src/test/java/codesquad/application/handler/MainHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/MainHandlerTest.java
@@ -2,6 +2,8 @@ package codesquad.application.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import codesquad.application.database.ArticleDatabase;
+import codesquad.application.database.ArticleMemoryDatabase;
 import codesquad.application.database.SessionMemoryStorage;
 import codesquad.application.database.UserMemoryDatabase;
 import codesquad.application.model.User;
@@ -23,6 +25,7 @@ class MainHandlerTest {
     private MainHandler mainHandler;
     private UserMemoryDatabase userMemoryDatabase;
     private SessionMemoryStorage sessionStorage;
+    private ArticleDatabase articleDatabase;
     private HttpRequest httpRequest;
     private User user;
 
@@ -30,7 +33,8 @@ class MainHandlerTest {
     void setUp() {
         userMemoryDatabase = new UserMemoryDatabase();
         sessionStorage = new SessionMemoryStorage();
-        mainHandler = new MainHandler(userMemoryDatabase, sessionStorage);
+        articleDatabase = new ArticleMemoryDatabase();
+        mainHandler = new MainHandler(userMemoryDatabase, sessionStorage, articleDatabase);
         user = UserFixture.user();
         userMemoryDatabase.addUser(user);
         String sessionId = sessionStorage.store(user);
@@ -51,7 +55,7 @@ class MainHandlerTest {
             //given
 
             //when
-            ModelAndView mav = mainHandler.mainPage(httpRequest);
+            ModelAndView mav = mainHandler.getArticles(httpRequest);
 
             //then
             assertThat(mav.getStatusCode()).isEqualTo(HttpStatusCode.OK);
@@ -64,7 +68,7 @@ class MainHandlerTest {
             //given
 
             //when
-            ModelAndView mav = mainHandler.mainPage(httpRequest);
+            ModelAndView mav = mainHandler.getArticles(httpRequest);
 
             //then
             assertThat(mav.getModelValue("userId")).isEqualTo(user.getUserId());
@@ -82,7 +86,7 @@ class MainHandlerTest {
                     new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes())));
 
             //when
-            ModelAndView mav = mainHandler.mainPage(httpRequest);
+            ModelAndView mav = mainHandler.getArticles(httpRequest);
 
             //then
             assertThat(mav.getModelValue("userId")).isNull();

--- a/src/test/java/codesquad/application/handler/MainHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/MainHandlerTest.java
@@ -2,17 +2,17 @@ package codesquad.application.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import codesquad.application.database.UserMemoryDatabase;
 import codesquad.application.database.SessionMemoryStorage;
+import codesquad.application.database.UserMemoryDatabase;
+import codesquad.application.model.User;
+import codesquad.application.web.ModelAndView;
 import codesquad.fixture.HttpFixture;
 import codesquad.fixture.UserFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpStatusCode;
-import codesquad.application.model.User;
-import codesquad.application.web.ModelAndView;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -38,7 +38,7 @@ class MainHandlerTest {
                 .method(HttpMethod.GET).path("/")
                 .cookie("SID", sessionId)
                 .buildToRawHttpMessage();
-        httpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+        httpRequest = HttpRequest.parse(new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes())));
     }
 
     @Nested
@@ -78,7 +78,8 @@ class MainHandlerTest {
             String rawHttpMessage = HttpFixture.builder()
                     .method(HttpMethod.GET).path("/")
                     .buildToRawHttpMessage();
-            HttpRequest httpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+            HttpRequest httpRequest = HttpRequest.parse(
+                    new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes())));
 
             //when
             ModelAndView mav = mainHandler.mainPage(httpRequest);

--- a/src/test/java/codesquad/application/handler/UserHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/UserHandlerTest.java
@@ -2,16 +2,16 @@ package codesquad.application.handler;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import codesquad.application.database.UserMemoryDatabase;
 import codesquad.application.database.SessionMemoryStorage;
+import codesquad.application.database.UserMemoryDatabase;
+import codesquad.application.model.User;
+import codesquad.application.web.ModelAndView;
 import codesquad.fixture.HttpFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpStatusCode;
-import codesquad.application.model.User;
-import codesquad.application.web.ModelAndView;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -43,8 +43,8 @@ class UserHandlerTest {
                     .method(HttpMethod.POST).path("/user/create")
                     .body("userId=userId&password=password&name=name&email=email")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            httpRequest = HttpRequest.parse(bis);
         }
 
         @Test
@@ -96,7 +96,8 @@ class UserHandlerTest {
                     .method(HttpMethod.GET).path("/user/list")
                     .cookie("SID", sessionId)
                     .buildToRawHttpMessage();
-            loginUserHttpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            loginUserHttpRequest = HttpRequest.parse(bis);
         }
 
         @Test
@@ -119,7 +120,8 @@ class UserHandlerTest {
             String rawHttpMessage = HttpFixture.builder()
                     .method(HttpMethod.GET).path("/user/list")
                     .buildToRawHttpMessage();
-            HttpRequest httpRequest = HttpRequest.parse(new BufferedReader(new StringReader(rawHttpMessage)));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             ModelAndView mav = userHandler.listUser(httpRequest);

--- a/src/test/java/codesquad/application/web/RequestDispatcherTest.java
+++ b/src/test/java/codesquad/application/web/RequestDispatcherTest.java
@@ -7,8 +7,8 @@ import codesquad.fixture.HttpFixture;
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
 import codesquad.server.message.HttpResponse;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,8 +29,8 @@ class RequestDispatcherTest extends ApplicationTest {
                     .method(HttpMethod.POST).path("/user/create")
                     .body("userId=userId&password=password&name=name&email=email@email.com")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //when
             HttpResponse httpResponse = requestDispatcher.handle(httpRequest);

--- a/src/test/java/codesquad/base/ApplicationTest.java
+++ b/src/test/java/codesquad/base/ApplicationTest.java
@@ -1,6 +1,8 @@
 package codesquad.base;
 
 import codesquad.application.bean.BeanFactory;
+import codesquad.application.database.SessionMemoryStorage;
+import codesquad.application.database.SessionStorage;
 import codesquad.application.web.AnnotationHandlerMapping;
 import codesquad.application.web.RequestDispatcher;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +12,7 @@ public abstract class ApplicationTest {
     protected BeanFactory beanFactory;
     protected AnnotationHandlerMapping handlerMapping;
     protected RequestDispatcher requestDispatcher;
+    protected SessionStorage sessionStorage;
 
     @BeforeEach
     void setUp() {
@@ -19,6 +22,8 @@ public abstract class ApplicationTest {
         handlerMapping = new AnnotationHandlerMapping();
         handlerMapping.init(beanFactory);
 
-        requestDispatcher = new RequestDispatcher(handlerMapping);
+        sessionStorage = new SessionMemoryStorage();
+
+        requestDispatcher = new RequestDispatcher(handlerMapping, sessionStorage);
     }
 }

--- a/src/test/java/codesquad/fixture/HttpFixture.java
+++ b/src/test/java/codesquad/fixture/HttpFixture.java
@@ -2,8 +2,8 @@ package codesquad.fixture;
 
 import codesquad.server.message.HttpMethod;
 import codesquad.server.message.HttpRequest;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -81,8 +81,8 @@ public class HttpFixture {
 
         public HttpRequest buildToHttpRequest() {
             String rawHttpMessage = buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
-            return HttpRequest.parse(br);
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
+            return HttpRequest.parse(bis);
         }
     }
 }

--- a/src/test/java/codesquad/fixture/HttpFixture.java
+++ b/src/test/java/codesquad/fixture/HttpFixture.java
@@ -53,9 +53,9 @@ public class HttpFixture {
 
         public String buildToRawHttpMessage() {
             return  """
-                    {method} {path} HTTP/1.1
-                    {header}
-                    {body}"""
+                    {method} {path} HTTP/1.1\r
+                    {header}\r
+                    {body}\r"""
                     .replace("{method}", method.name())
                     .replace("{path}", path)
                     .replace("{header}", toRequestHeader())
@@ -65,7 +65,7 @@ public class HttpFixture {
         private String toRequestHeader() {
             StringBuilder sb = new StringBuilder();
             headers.forEach((key, value) -> {
-                sb.append(key).append(": ").append(value).append("\n");
+                sb.append(key).append(": ").append(value).append("\r\n");
             });
             if (cookies.isEmpty()) {
                 return sb.toString();
@@ -75,7 +75,7 @@ public class HttpFixture {
             cookies.forEach((key, value) -> {
                 sb.append(key).append("=").append(value).append("; ");
             });
-            sb.append("\n");
+            sb.append("\r\n");
             return sb.toString();
         }
 

--- a/src/test/java/codesquad/server/message/HttpBodyTest.java
+++ b/src/test/java/codesquad/server/message/HttpBodyTest.java
@@ -32,7 +32,7 @@ class HttpBodyTest {
             BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawBody.getBytes()));
 
             //when
-            HttpBody httpBody = HttpBody.parse(br, bis, httpHeaders);
+            HttpBody httpBody = HttpBody.parse(bis, httpHeaders);
 
             //then
             assertThat(httpBody.data().get("data")).isNotNull().isBlank();

--- a/src/test/java/codesquad/server/message/HttpBodyTest.java
+++ b/src/test/java/codesquad/server/message/HttpBodyTest.java
@@ -50,16 +50,16 @@ class HttpBodyTest {
                 body = """
                     ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
                     Content-Disposition: form-data; name="title"\r
-                                        \r
+                    \r
                     qwer\r
                     ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
                     Content-Disposition: form-data; name="content"\r
-                                        \r
+                    \r
                     qwer\r
                     ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
                     Content-Disposition: form-data; name="image"; filename="carbon.png"\r
                     Content-Type: image/png\r
-                                        \r
+                    \r
                     asdf\r
                     ------WebKitFormBoundaryCxwg8SiBWAa9oImg--\r""";
                 httpHeaders.headers().put("Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryCxwg8SiBWAa9oImg");
@@ -70,11 +70,10 @@ class HttpBodyTest {
             @DisplayName("파일 데이터를 파싱한다.")
             void parseFileData() throws IOException {
                 //given
-                BufferedReader br = new BufferedReader(new StringReader(body));
                 BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(body.getBytes()));
 
                 //when
-                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis, br);
+                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis);
 
                 //then
                 assertThat(httpBody.files()).satisfies(files -> {
@@ -91,11 +90,10 @@ class HttpBodyTest {
             @DisplayName("파라미터를 파싱한다.")
             void parseParameters() throws IOException {
                 //given
-                BufferedReader br = new BufferedReader(new StringReader(body));
                 BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(body.getBytes()));
 
                 //when
-                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis, br);
+                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis);
 
                 //then
                 assertThat(httpBody.data()).satisfies(data -> {

--- a/src/test/java/codesquad/server/message/HttpBodyTest.java
+++ b/src/test/java/codesquad/server/message/HttpBodyTest.java
@@ -2,10 +2,14 @@ package codesquad.server.message;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import codesquad.server.utils.MultiPartParser;
+import java.io.BufferedInputStream;
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.HashMap;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,12 +29,82 @@ class HttpBodyTest {
             HttpHeaders httpHeaders = new HttpHeaders(new HashMap<>());
             httpHeaders.headers().put("Content-Length", String.valueOf(rawBody.getBytes().length));
             httpHeaders.headers().put("Content-Type", "application/x-www-form-urlencoded");
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawBody.getBytes()));
 
             //when
-            HttpBody httpBody = HttpBody.parse(br, httpHeaders);
+            HttpBody httpBody = HttpBody.parse(br, bis, httpHeaders);
 
             //then
             assertThat(httpBody.data().get("data")).isNotNull().isBlank();
         }
+
+        @Nested
+        @DisplayName("컨텐츠 타입이 multipart/form-data 인 경우")
+        class MultiPartTest {
+
+            private String body;
+            private HttpHeaders httpHeaders = new HttpHeaders(new HashMap<>());
+
+            @BeforeEach
+            void setUp() {
+                body = """
+                    ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
+                    Content-Disposition: form-data; name="title"\r
+                                        \r
+                    qwer\r
+                    ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
+                    Content-Disposition: form-data; name="content"\r
+                                        \r
+                    qwer\r
+                    ------WebKitFormBoundaryCxwg8SiBWAa9oImg\r
+                    Content-Disposition: form-data; name="image"; filename="carbon.png"\r
+                    Content-Type: image/png\r
+                                        \r
+                    asdf\r
+                    ------WebKitFormBoundaryCxwg8SiBWAa9oImg--\r""";
+                httpHeaders.headers().put("Content-Type", "multipart/form-data; boundary=----WebKitFormBoundaryCxwg8SiBWAa9oImg");
+                httpHeaders.headers().put("Content-Length", String.valueOf(body.getBytes().length));
+            }
+
+            @Test
+            @DisplayName("파일 데이터를 파싱한다.")
+            void parseFileData() throws IOException {
+                //given
+                BufferedReader br = new BufferedReader(new StringReader(body));
+                BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(body.getBytes()));
+
+                //when
+                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis, br);
+
+                //then
+                assertThat(httpBody.files()).satisfies(files -> {
+                    assertThat(files).containsKey("image");
+                    assertThat(files.get("image")).satisfies(httpFile -> {
+                        assertThat(httpFile.getContent()).isEqualTo("asdf".getBytes());
+                        assertThat(httpFile.getContentType()).isEqualTo("image/png");
+                        assertThat(httpFile.getFileName()).isEqualTo("carbon.png");
+                    });
+                });
+            }
+
+            @Test
+            @DisplayName("파라미터를 파싱한다.")
+            void parseParameters() throws IOException {
+                //given
+                BufferedReader br = new BufferedReader(new StringReader(body));
+                BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(body.getBytes()));
+
+                //when
+                HttpBody httpBody = MultiPartParser.parse(httpHeaders, bis, br);
+
+                //then
+                assertThat(httpBody.data()).satisfies(data -> {
+                    assertThat(data.get("title")).isNotNull().isEqualTo("qwer");
+                    assertThat(data.get("content")).isNotNull().isEqualTo("qwer");
+                });
+            }
+        }
+
+
     }
 }

--- a/src/test/java/codesquad/server/message/HttpHeadersTest.java
+++ b/src/test/java/codesquad/server/message/HttpHeadersTest.java
@@ -3,10 +3,8 @@ package codesquad.server.message;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
-import codesquad.server.message.HttpHeaders;
-import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.StringReader;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -24,18 +22,18 @@ class HttpHeadersTest {
         void parseRawHttpHeaders() throws IOException {
             //given
             String rawHeaders = """
-                    Accept: application/json
-                    Authorization: Bearer accessToken
-                    Host: localhost:8080
-                    Connection: keep-alive
-                    Accept-Language: en-US,en;q=0.5
-                    Accept-Encoding: gzip, deflate
-                    
+                    Accept: application/json\r
+                    Authorization: Bearer accessToken\r
+                    Host: localhost:8080\r
+                    Connection: keep-alive\r
+                    Accept-Language: en-US,en;q=0.5\r
+                    Accept-Encoding: gzip, deflate\r
+                    \r\n
                     """;
-            BufferedReader br = new BufferedReader(new StringReader(rawHeaders));
+            ByteArrayInputStream clientInput = new ByteArrayInputStream(rawHeaders.getBytes());
 
             //when
-            HttpHeaders httpHeaders = HttpHeaders.parse(br);
+            HttpHeaders httpHeaders = HttpHeaders.parse(clientInput);
 
             //then
             assertThat(httpHeaders.headers()).satisfies(headers -> {
@@ -58,10 +56,10 @@ class HttpHeadersTest {
         @DisplayName("예외(IllegalArgument): 형식이 올바르지 않으면")
         void illegalArgument_WhenInvalidFormat(String rawHeaders) {
             //given
-            BufferedReader br = new BufferedReader(new StringReader(rawHeaders));
+            ByteArrayInputStream clientInput = new ByteArrayInputStream(rawHeaders.getBytes());
 
             //whenrr
-            Exception exception = catchException(() -> HttpHeaders.parse(br));
+            Exception exception = catchException(() -> HttpHeaders.parse(clientInput));
 
             //then
             assertThat(exception).isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/codesquad/server/message/HttpRequestTest.java
+++ b/src/test/java/codesquad/server/message/HttpRequestTest.java
@@ -4,8 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchException;
 
 import codesquad.fixture.HttpFixture;
-import java.io.BufferedReader;
-import java.io.StringReader;
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -28,10 +28,10 @@ class HttpRequestTest {
                     .header("Connection", "keep-alive")
                     .header("Cache-Control", "max-age=0")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
 
             //when
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //then
             assertThat(httpRequest.method()).isEqualTo(HttpMethod.GET);
@@ -53,10 +53,10 @@ class HttpRequestTest {
                     .header("Connection", "keep-alive")
                     .header("Cache-Control", "max-age=0")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
 
             //when
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //then
             assertThat(httpRequest.method()).isEqualTo(HttpMethod.GET);
@@ -83,10 +83,10 @@ class HttpRequestTest {
                     .header("Connection", "keep-alive")
                     .header("Cache-Control", "max-age=0")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
 
             //when
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //then
             assertThat(httpRequest.method()).isEqualTo(HttpMethod.GET);
@@ -108,10 +108,10 @@ class HttpRequestTest {
                     .header("Connection", "keep-alive")
                     .header("Cache-Control", "max-age=0")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
 
             //when
-            Exception exception = catchException(() -> HttpRequest.parse(br));
+            Exception exception = catchException(() -> HttpRequest.parse(bis));
 
             //then
             assertThat(exception).isInstanceOf(IllegalArgumentException.class);
@@ -127,10 +127,10 @@ class HttpRequestTest {
                     .header("Host", "localhost:8080")
                     .body("userId=userId&nickname=nickname")
                     .buildToRawHttpMessage();
-            BufferedReader br = new BufferedReader(new StringReader(rawHttpMessage));
+            BufferedInputStream bis = new BufferedInputStream(new ByteArrayInputStream(rawHttpMessage.getBytes()));
 
             //when
-            HttpRequest httpRequest = HttpRequest.parse(br);
+            HttpRequest httpRequest = HttpRequest.parse(bis);
 
             //then
             assertThat(httpRequest.httpBody().data()).satisfies(data -> {


### PR DESCRIPTION
## 구현 내용
- multipart/form-data 파싱을 담당할 `MultipartParser`를 구현하였습니다.
  - 파일을 올바르게 읽어들이지 못하는 문제가 있어 기존 http 요청 메시지 파싱에 문자열 스트림을 사용하던 것에서 바이트 스트림을 사용하는 것으로 변경하였습니다.
- 게시글 작성 시 이미지 파일을 첨부할 수 있도록 변경하였습니다.
  - 업로드 된 이미지는 로컬에 저장되고 db에는 이미지 경로가 저장됩니다.
- 게시글 단일, 목록 조회시 이미지 출력을 구현하였습니다.
  - 이미지 경로에 해당되는 이미지를 정적 리소스 핸들러가 찾아서 반환합니다.

## 고민 사항

## 기타
