### PR TITLE
[이호석] step-8 이미지 업로드 및 표시 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+/upload-image

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,25 +5,21 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
-      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartFile.java" afterDir="false" />
-      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/RequestHandlerMapping.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/RequestHandlerMapping.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestInputStreamReader.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestInputStreamReader.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestMessageBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestMessageBody.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/MimeType.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/MimeType.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/User.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/User.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/ImageRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/ImageRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/CommentInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/CommentInfo.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestMessageBodyTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestMessageBodyTest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -82,6 +78,8 @@
   <component name="HighlightingSettingsPerFile">
     <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/BufferedInputStream.java" root0="SKIP_INSPECTION" />
     <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/InputStream.java" root0="SKIP_INSPECTION" />
+    <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/lang/ArrayIndexOutOfBoundsException.java" root0="SKIP_INSPECTION" />
+    <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/util/Arrays.java" root0="SKIP_INSPECTION" />
   </component>
   <component name="JvmLoggingSettingsStorage">
     <option name="loggerId" value="Slf4j" />
@@ -206,7 +204,7 @@
       <recent name="codesquad.http.type" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.Tests in 'java-was.test'">
+  <component name="RunManager" selected="Application.Main">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="codesquad.Main" />
       <module name="java-was.main" />
@@ -391,23 +389,18 @@
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
           <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java</url>
-          <line>32</line>
+          <line>40</line>
           <option name="timeStamp" value="94" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
-          <line>70</line>
-          <option name="timeStamp" value="95" />
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/ImageRequestHandler.java</url>
+          <line>22</line>
+          <option name="timeStamp" value="109" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
-          <line>68</line>
-          <option name="timeStamp" value="97" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
-          <line>116</line>
-          <option name="timeStamp" value="100" />
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java</url>
+          <line>73</line>
+          <option name="timeStamp" value="110" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,10 @@
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/templates/post/form.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/templates/post/form.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/AbstractRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/AbstractRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/Headers.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/Headers.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpResponse.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -61,6 +64,10 @@
       </map>
     </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="HighlightingSettingsPerFile">
+    <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/BufferedInputStream.java" root0="SKIP_INSPECTION" />
+    <setting file="jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/InputStream.java" root0="SKIP_INSPECTION" />
   </component>
   <component name="JvmLoggingSettingsStorage">
     <option name="loggerId" value="Slf4j" />
@@ -291,8 +298,8 @@
   <component name="SharedIndexes">
     <attachedChunks>
       <set>
-        <option value="bundled-jdk-9f38398b9061-18abd8497189-intellij.indexing.shared.core-IU-241.14494.240" />
-        <option value="bundled-js-predefined-1d06a55b98c1-74d2a5396914-JavaScript-IU-241.14494.240" />
+        <option value="bundled-jdk-9f38398b9061-39b83d9b5494-intellij.indexing.shared.core-IU-241.18034.62" />
+        <option value="bundled-js-predefined-1d06a55b98c1-0b3e54e931b4-JavaScript-IU-241.18034.62" />
       </set>
     </attachedChunks>
   </component>
@@ -316,6 +323,7 @@
       <workItem from="1720623341419" duration="9949000" />
       <workItem from="1720746427540" duration="989000" />
       <workItem from="1721047714447" duration="4983000" />
+      <workItem from="1721263411715" duration="4906000" />
     </task>
     <servers />
   </component>
@@ -345,6 +353,25 @@
     </option>
   </component>
   <component name="XDebuggerManager">
+    <breakpoint-manager>
+      <breakpoints>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java</url>
+          <line>46</line>
+          <option name="timeStamp" value="74" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/ConnectionHandler.java</url>
+          <line>34</line>
+          <option name="timeStamp" value="75" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java</url>
+          <line>41</line>
+          <option name="timeStamp" value="78" />
+        </line-breakpoint>
+      </breakpoints>
+    </breakpoint-manager>
     <pin-to-top-manager>
       <pinned-members>
         <PinnedItemInfo parentTag="codesquad.web.infrastructure.JdbcPostRepository" memberName="jdbcTemplate" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,6 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/templates/post/form.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/templates/post/form.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -54,6 +55,11 @@
     </option>
   </component>
   <component name="Git.Settings">
+    <option name="RECENT_BRANCH_BY_REPOSITORY">
+      <map>
+        <entry key="$PROJECT_DIR$" value="was3-2" />
+      </map>
+    </option>
     <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
   </component>
   <component name="JvmLoggingSettingsStorage">
@@ -135,7 +141,7 @@
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
     "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "create.test.in.the.same.root": "true",
-    "git-widget-placeholder": "was3-1",
+    "git-widget-placeholder": "was3-2",
     "kotlin-language-version-configured": "true",
     "last_opened_file_path": "/Users/woowatech20/develop/wootacam/java-was/src/main/resources/static",
     "node.js.detected.package.eslint": "true",
@@ -175,7 +181,7 @@
       <recent name="codesquad.http.type" />
     </key>
   </component>
-  <component name="RunManager" selected="Gradle.Tests in 'java-was.test'">
+  <component name="RunManager" selected="Application.Main">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="codesquad.Main" />
       <module name="java-was.main" />
@@ -189,29 +195,18 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="ResourceSnippetTest.외부_템플릿_파일이_존재하지_않는다면_예외가_발생한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.web.snippet.ResourceSnippetTest.외부_템플릿_파일이_존재하지_않는다면_예외가_발생한다&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
+    <configuration name="Server2" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
+      <option name="MAIN_CLASS_NAME" value="codesquad.Server2" />
+      <module name="java-was.main" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="codesquad.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
     </configuration>
     <configuration name="Tests in 'java-was.test'" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
@@ -285,11 +280,11 @@
     </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Application.Server2" />
+        <item itemvalue="Application.Main" />
         <item itemvalue="Gradle.Tests in 'java-was.test'" />
         <item itemvalue="Application.Main" />
         <item itemvalue="Gradle.만약_로그인이_되어있다면.응답_코드로_200을_반환한다" />
-        <item itemvalue="Gradle.만약_로그인이_되어있다면.게시글을_저장하고_응답_코드로_200을_반환한다" />
-        <item itemvalue="Gradle.ResourceSnippetTest.외부_템플릿_파일이_존재하지_않는다면_예외가_발생한다" />
       </list>
     </recent_temporary>
   </component>
@@ -350,59 +345,6 @@
     </option>
   </component>
   <component name="XDebuggerManager">
-    <breakpoint-manager>
-      <breakpoints>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>jar://$USER_HOME$/.sdkman/candidates/java/17.0.11-tem/lib/src.zip!/java.base/java/io/OutputStream.java</url>
-          <line>47</line>
-          <option name="timeStamp" value="6" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/was/http/HttpRequestTest.java</url>
-          <line>105</line>
-          <option name="timeStamp" value="7" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpResponse.java</url>
-          <line>76</line>
-          <option name="timeStamp" value="17" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/LoginRequestHandlerTest.java</url>
-          <line>44</line>
-          <option name="timeStamp" value="43" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/LoginRequestHandlerTest.java</url>
-          <line>27</line>
-          <option name="timeStamp" value="44" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/PostRequestHandlerTest.java</url>
-          <line>136</line>
-          <option name="timeStamp" value="50" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/PostRequestHandlerTest.java</url>
-          <line>23</line>
-          <option name="timeStamp" value="54" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/fixture/RequestHandlerTest.java</url>
-          <line>45</line>
-          <option name="timeStamp" value="55" />
-        </line-breakpoint>
-        <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java</url>
-          <line>43</line>
-          <option name="timeStamp" value="58" />
-        </line-breakpoint>
-        <breakpoint enabled="true" type="java-exception">
-          <properties class="codesquad.web.exception.MethodNotAllowedException" package="codesquad.web.exception" />
-          <option name="timeStamp" value="9" />
-        </breakpoint>
-      </breakpoints>
-    </breakpoint-manager>
     <pin-to-top-manager>
       <pinned-members>
         <PinnedItemInfo parentTag="codesquad.web.infrastructure.JdbcPostRepository" memberName="jdbcTemplate" />
@@ -419,7 +361,7 @@
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__4_.ic" NAME="All in java-was.test (4) Coverage Results" MODIFIED="1720758549156" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__1_.ic" NAME="All in java-was.test (1) Coverage Results" MODIFIED="1721099385542" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__2_.ic" NAME="All in java-was.test (2) Coverage Results" MODIFIED="1720714876419" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
-    <SUITE FILE_PATH="coverage/java_was$Tests_in__java_was_test_.ic" NAME="Tests in 'java-was.test' Coverage Results" MODIFIED="1721127235895" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
+    <SUITE FILE_PATH="coverage/java_was$Tests_in__java_was_test_.ic" NAME="Tests in 'java-was.test' Coverage Results" MODIFIED="1721181962520" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__3_.ic" NAME="All in java-was.test (3) Coverage Results" MODIFIED="1721100069640" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test.ic" NAME="All in java-was.test Coverage Results" MODIFIED="1720761165739" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
   </component>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,20 +6,12 @@
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/User.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/User.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/ImageRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/ImageRequestHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/CommentInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/CommentInfo.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/UserRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/UserRequestHandler.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -132,6 +124,7 @@
     "Gradle.만약_로그인이_되어있다면.executor": "Run",
     "Gradle.만약_로그인이_되어있다면.게시글을_저장하고_응답_코드로_200을_반환한다.executor": "Debug",
     "Gradle.만약_로그인이_되어있다면.응답_코드로_200을_반환한다.executor": "Debug",
+    "Gradle.만약_로그인이_되어있으면.응답_코드로_200을_반환한다.executor": "Run",
     "Gradle.만약_로그인이_되어있지_않다면.응답_코드로_302를_반환한다 (1).executor": "Run",
     "Gradle.만약_로그인이_되어있지_않다면.응답_코드로_302를_반환한다.executor": "Run",
     "Gradle.잘못된_파일경로를_넘겨주면.예외가_발생한다.executor": "Run",
@@ -266,30 +259,6 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.was.http.RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
     <configuration name="Tests in 'java-was.test'" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
         <option name="executionName" />
@@ -312,13 +281,37 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
+    <configuration name="만약_로그인이_되어있으면.응답_코드로_200을_반환한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.web.handler.UserRequestHandlerTest$사용자_목록을_요청할때$만약_로그인이_되어있으면.응답_코드로_200을_반환한다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
     <recent_temporary>
       <list>
+        <item itemvalue="Gradle.만약_로그인이_되어있으면.응답_코드로_200을_반환한다" />
         <item itemvalue="Gradle.Tests in 'java-was.test'" />
         <item itemvalue="Gradle.RequestHandlerMappingTest.매핑된_핸들러를_찾지_못하면_null을_반환한다" />
         <item itemvalue="Application.Main" />
         <item itemvalue="Gradle.HeadersTest.헤더_OWS_여부에_관계없이_파싱_할_수_있다" />
-        <item itemvalue="Gradle.RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다" />
       </list>
     </recent_temporary>
   </component>
@@ -401,6 +394,16 @@
           <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java</url>
           <line>73</line>
           <option name="timeStamp" value="110" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/test/java/codesquad/web/handler/UserRequestHandlerTest.java</url>
+          <line>72</line>
+          <option name="timeStamp" value="117" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/UserRequestHandler.java</url>
+          <line>36</line>
+          <option name="timeStamp" value="118" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,11 +5,25 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="280b8feb-1974-426b-989d-56a186fab4bb" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartFile.java" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/AbstractRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/AbstractRequestHandler.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/Headers.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/Headers.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/RequestHandlerMapping.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/RequestHandlerMapping.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpResponse.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpResponse.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestInputStreamReader.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestInputStreamReader.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestMessageBody.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestMessageBody.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/MimeType.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/was/http/type/MimeType.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/Post.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/domain/vo/PostWithNickname.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/HomeRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/PostRequestHandler.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/handler/dto/PostsInfo.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/java/codesquad/web/snippet/SnippetFixture.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/src/main/resources/static/registration/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestMessageBodyTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/codesquad/was/http/RequestMessageBodyTest.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -52,8 +66,8 @@
         <option value="Enum" />
         <option value="Interface" />
         <option value="JUnit5 Test Class" />
-        <option value="Class" />
         <option value="Record" />
+        <option value="Class" />
       </list>
     </option>
   </component>
@@ -86,6 +100,7 @@
   "keyToString": {
     "Gradle.Build java-was.executor": "Run",
     "Gradle.HeadersTest.getHeader_헤더목록에_있는_헤더_값을_찾을_수_있다.executor": "Run",
+    "Gradle.HeadersTest.헤더_OWS_여부에_관계없이_파싱_할_수_있다.executor": "Run",
     "Gradle.HttpRequestTest.executor": "Run",
     "Gradle.HttpRequest가_들어오면.Request_Message_Body가_form_data_라면_파싱하여_저장한다.executor": "Run",
     "Gradle.HttpRequest가_들어오면.httpRequest_객체를_생성한다.executor": "Run",
@@ -100,7 +115,10 @@
     "Gradle.MimeTypeTest.일치하는_확장자의_mimeType이_없으면_예외가_발생한다.executor": "Run",
     "Gradle.PostRequestHandlerTest.executor": "Run",
     "Gradle.RawTest.test.executor": "Run",
+    "Gradle.RequestHandlerMappingTest.매핑된_핸들러를_찾지_못하면_null을_반환한다.executor": "Run",
     "Gradle.RequestLineTest.httpRequestLine을_받으면_각_메소드를_파싱하여_RequestLine을_생성한다.executor": "Run",
+    "Gradle.RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다.executor": "Run",
+    "Gradle.RequestMessageBodyTest.httpRequest의_요청_바디를_읽을_수_있다.executor": "Run",
     "Gradle.ResourceSnippetTest.외부_템플릿_파일이_존재하지_않는다면_예외가_발생한다.executor": "Run",
     "Gradle.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다 (1).executor": "Run",
     "Gradle.SignUpRequestHandlerTest.GET으로_회원가입을_시도하면_예외가_발생한다.executor": "Run",
@@ -188,7 +206,7 @@
       <recent name="codesquad.http.type" />
     </key>
   </component>
-  <component name="RunManager" selected="Application.Main">
+  <component name="RunManager" selected="Gradle.Tests in 'java-was.test'">
     <configuration name="Main" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
       <option name="MAIN_CLASS_NAME" value="codesquad.Main" />
       <module name="java-was.main" />
@@ -202,18 +220,77 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
-    <configuration name="Server2" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
-      <option name="MAIN_CLASS_NAME" value="codesquad.Server2" />
-      <module name="java-was.main" />
-      <extension name="coverage">
-        <pattern>
-          <option name="PATTERN" value="codesquad.*" />
-          <option name="ENABLED" value="true" />
-        </pattern>
-      </extension>
-      <method v="2">
-        <option name="Make" enabled="true" />
-      </method>
+    <configuration name="HeadersTest.헤더_OWS_여부에_관계없이_파싱_할_수_있다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.was.http.HeadersTest.헤더_OWS_여부에_관계없이_파싱_할_수_있다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="RequestHandlerMappingTest.매핑된_핸들러를_찾지_못하면_null을_반환한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.was.RequestHandlerMappingTest.매핑된_핸들러를_찾지_못하면_null을_반환한다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
+    </configuration>
+    <configuration name="RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
+      <ExternalSystemSettings>
+        <option name="executionName" />
+        <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="externalSystemIdString" value="GRADLE" />
+        <option name="scriptParameters" value="" />
+        <option name="taskDescriptions">
+          <list />
+        </option>
+        <option name="taskNames">
+          <list>
+            <option value=":test" />
+            <option value="--tests" />
+            <option value="&quot;codesquad.was.http.RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다&quot;" />
+          </list>
+        </option>
+        <option name="vmOptions" />
+      </ExternalSystemSettings>
+      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+      <DebugAllEnabled>false</DebugAllEnabled>
+      <RunAsTest>true</RunAsTest>
+      <method v="2" />
     </configuration>
     <configuration name="Tests in 'java-was.test'" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
       <ExternalSystemSettings>
@@ -237,61 +314,13 @@
       <RunAsTest>true</RunAsTest>
       <method v="2" />
     </configuration>
-    <configuration name="만약_로그인이_되어있다면.응답_코드로_200을_반환한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.web.handler.PostRequestHandlerTest$글쓰기_페이지에_GET요청을_할_때$만약_로그인이_되어있다면.응답_코드로_200을_반환한다&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
-    <configuration name="만약_로그인이_되어있다면.게시글을_저장하고_응답_코드로_200을_반환한다" type="GradleRunConfiguration" factoryName="Gradle" temporary="true">
-      <ExternalSystemSettings>
-        <option name="executionName" />
-        <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="externalSystemIdString" value="GRADLE" />
-        <option name="scriptParameters" value="" />
-        <option name="taskDescriptions">
-          <list />
-        </option>
-        <option name="taskNames">
-          <list>
-            <option value=":test" />
-            <option value="--tests" />
-            <option value="&quot;codesquad.web.handler.PostRequestHandlerTest$글쓰기를_완료하고_POST_요청을_보낼때$만약_로그인이_되어있다면.게시글을_저장하고_응답_코드로_200을_반환한다&quot;" />
-          </list>
-        </option>
-        <option name="vmOptions" />
-      </ExternalSystemSettings>
-      <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
-      <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
-      <DebugAllEnabled>false</DebugAllEnabled>
-      <RunAsTest>true</RunAsTest>
-      <method v="2" />
-    </configuration>
     <recent_temporary>
       <list>
-        <item itemvalue="Application.Server2" />
-        <item itemvalue="Application.Main" />
         <item itemvalue="Gradle.Tests in 'java-was.test'" />
+        <item itemvalue="Gradle.RequestHandlerMappingTest.매핑된_핸들러를_찾지_못하면_null을_반환한다" />
         <item itemvalue="Application.Main" />
-        <item itemvalue="Gradle.만약_로그인이_되어있다면.응답_코드로_200을_반환한다" />
+        <item itemvalue="Gradle.HeadersTest.헤더_OWS_여부에_관계없이_파싱_할_수_있다" />
+        <item itemvalue="Gradle.RequestMessageBodyTest.RequestMessageBody에서_form_parameter를_읽을_수_있다" />
       </list>
     </recent_temporary>
   </component>
@@ -323,7 +352,7 @@
       <workItem from="1720623341419" duration="9949000" />
       <workItem from="1720746427540" duration="989000" />
       <workItem from="1721047714447" duration="4983000" />
-      <workItem from="1721263411715" duration="4906000" />
+      <workItem from="1721263411715" duration="18656000" />
     </task>
     <servers />
   </component>
@@ -356,19 +385,29 @@
     <breakpoint-manager>
       <breakpoints>
         <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java</url>
-          <line>46</line>
-          <option name="timeStamp" value="74" />
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/RequestParameters.java</url>
+          <line>30</line>
+          <option name="timeStamp" value="90" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/ConnectionHandler.java</url>
-          <line>34</line>
-          <option name="timeStamp" value="75" />
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/web/handler/SignUpRequestHandler.java</url>
+          <line>32</line>
+          <option name="timeStamp" value="94" />
         </line-breakpoint>
         <line-breakpoint enabled="true" type="java-line">
-          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/HttpRequest.java</url>
-          <line>41</line>
-          <option name="timeStamp" value="78" />
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
+          <line>70</line>
+          <option name="timeStamp" value="95" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
+          <line>68</line>
+          <option name="timeStamp" value="97" />
+        </line-breakpoint>
+        <line-breakpoint enabled="true" type="java-line">
+          <url>file://$PROJECT_DIR$/src/main/java/codesquad/was/http/MultipartParser.java</url>
+          <line>116</line>
+          <option name="timeStamp" value="100" />
         </line-breakpoint>
       </breakpoints>
     </breakpoint-manager>
@@ -388,7 +427,7 @@
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__4_.ic" NAME="All in java-was.test (4) Coverage Results" MODIFIED="1720758549156" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__1_.ic" NAME="All in java-was.test (1) Coverage Results" MODIFIED="1721099385542" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__2_.ic" NAME="All in java-was.test (2) Coverage Results" MODIFIED="1720714876419" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
-    <SUITE FILE_PATH="coverage/java_was$Tests_in__java_was_test_.ic" NAME="Tests in 'java-was.test' Coverage Results" MODIFIED="1721181962520" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
+    <SUITE FILE_PATH="coverage/java_was$Tests_in__java_was_test_.ic" NAME="Tests in 'java-was.test' Coverage Results" MODIFIED="1721286364942" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test__3_.ic" NAME="All in java-was.test (3) Coverage Results" MODIFIED="1721100069640" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
     <SUITE FILE_PATH="coverage/java_was$All_in_java_was_test.ic" NAME="All in java-was.test Coverage Results" MODIFIED="1720761165739" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true" />
   </component>

--- a/src/main/java/codesquad/was/ConnectionHandler.java
+++ b/src/main/java/codesquad/was/ConnectionHandler.java
@@ -33,9 +33,8 @@ public class ConnectionHandler implements Runnable {
              OutputStream clientOutput = clientSocket.getOutputStream()
         ) {
             HttpRequest httpRequest = new HttpRequest(clientInput);
-            log.debug("Http Request = {}", httpRequest);
-
             HttpResponse httpResponse = new HttpResponse(clientOutput, httpRequest.getHttpVersion());
+            log.debug("Http Request = {}", httpRequest);
 
             RequestHandler requestHandler = requestHandlerMapping.read(httpRequest.getRequestPath());
             validateHandler(httpRequest, httpResponse, requestHandler);

--- a/src/main/java/codesquad/was/RequestHandlerMapping.java
+++ b/src/main/java/codesquad/was/RequestHandlerMapping.java
@@ -7,6 +7,7 @@ import codesquad.web.domain.PostRepository;
 import codesquad.web.domain.UserRepository;
 import codesquad.web.handler.CommentRequestHandler;
 import codesquad.web.handler.HomeRequestHandler;
+import codesquad.web.handler.ImageRequestHandler;
 import codesquad.web.handler.LoginRequestHandler;
 import codesquad.web.handler.LogoutRequestHandler;
 import codesquad.web.handler.PostRequestHandler;
@@ -15,6 +16,7 @@ import codesquad.web.handler.UserRequestHandler;
 import codesquad.web.infrastructure.JdbcCommentRepository;
 import codesquad.web.infrastructure.JdbcPostRepository;
 import codesquad.web.infrastructure.JdbcUserRepository;
+import java.util.HashMap;
 import java.util.Map;
 
 public class RequestHandlerMapping {
@@ -29,18 +31,18 @@ public class RequestHandlerMapping {
         PostRepository postRepository = new JdbcPostRepository(jdbcTemplate);
         CommentRepository commentRepository = new JdbcCommentRepository(jdbcTemplate);
 
-        handlerMappings = Map.of(
-                "static", (request, response) -> response.forward(request.getRequestPath()),
-                "/", new HomeRequestHandler(postRepository, commentRepository),
-                "/registration", (request, response) -> response.forward("/registration/index.html"),
-                "/user/login-failed", (request, response) -> response.forward("/login/failed.html"),
-                "/user/create", new SignUpRequestHandler(userRepository),
-                "/user/login", new LoginRequestHandler(userRepository),
-                "/user/logout", new LogoutRequestHandler(),
-                "/user/list", new UserRequestHandler(userRepository),
-                "/post", new PostRequestHandler(postRepository),
-                "/post/comment", new CommentRequestHandler(commentRepository)
-        );
+        handlerMappings = new HashMap<>();
+        handlerMappings.put("static", (request, response) -> response.forward(request.getRequestPath()));
+        handlerMappings.put("/", new HomeRequestHandler(postRepository, commentRepository));
+        handlerMappings.put("/registration", (request, response) -> response.forward("/registration/index.html"));
+        handlerMappings.put("/user/login-failed", (request, response) -> response.forward("/login/failed.html"));
+        handlerMappings.put("/user/create", new SignUpRequestHandler(userRepository));
+        handlerMappings.put("/user/login", new LoginRequestHandler(userRepository));
+        handlerMappings.put("/user/logout", new LogoutRequestHandler());
+        handlerMappings.put("/user/list", new UserRequestHandler(userRepository));
+        handlerMappings.put("/post", new PostRequestHandler(postRepository));
+        handlerMappings.put("/post/comment", new CommentRequestHandler(commentRepository));
+        handlerMappings.put("/image", new ImageRequestHandler());
     }
 
     public RequestHandler read(final String requestPath) {

--- a/src/main/java/codesquad/was/database/JdbcTemplate.java
+++ b/src/main/java/codesquad/was/database/JdbcTemplate.java
@@ -87,7 +87,7 @@ public class JdbcTemplate {
         }
     }
 
-    private static <T> List<T> getValues(final ResultSetMapper<T> mapper, final PreparedStatement ps)
+    private <T> List<T> getValues(final ResultSetMapper<T> mapper, final PreparedStatement ps)
             throws SQLException {
         try (ResultSet resultSet = ps.executeQuery()) {
             List<T> results = new ArrayList<>();

--- a/src/main/java/codesquad/was/http/HttpRequest.java
+++ b/src/main/java/codesquad/was/http/HttpRequest.java
@@ -5,10 +5,9 @@ import static codesquad.was.http.type.CharsetType.UTF_8;
 import codesquad.was.http.type.HeaderType;
 import codesquad.was.http.type.HttpMethod;
 import codesquad.was.http.type.MimeType;
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.util.Collections;
@@ -17,6 +16,7 @@ import java.util.Objects;
 
 public class HttpRequest {
 
+    private static final int TWO_MB = 2 * 1024 * 1024;
     private static final String ONE_SPACE = " ";
     private static final int METHOD_INDEX = 0;
     private static final int URI_INDEX = 1;
@@ -28,7 +28,7 @@ public class HttpRequest {
 
     private final RequestLine requestLine;
     private final Headers headers;
-    private final RequestParameters parameters = new RequestParameters();
+    private final RequestParameters queryParameters = new RequestParameters();
     private final RequestMessageBody requestBody;
 
     public HttpRequest(final RequestLine requestLine, final Headers headers, final RequestMessageBody requestBody) {
@@ -38,26 +38,29 @@ public class HttpRequest {
     }
 
     public HttpRequest(final InputStream clientInput) throws IOException {
-        BufferedReader requestReader = new BufferedReader(new InputStreamReader(clientInput));
-        requestLine = createRequestLine(requestReader.readLine());
-        headers = new Headers(requestReader);
-        String contentLengthValue = parseContentLength();
-        requestBody = new RequestMessageBody(requestReader, contentLengthValue);
+        BufferedInputStream bufferedInputStream = new BufferedInputStream(clientInput, TWO_MB);
+        RequestInputStreamReader reader = new RequestInputStreamReader(bufferedInputStream);
+        String requestLineValue = reader.readRequestLine();
+        requestLine = createRequestLine(requestLineValue);
 
-        if (isFormData()) {
-            String bodyData = requestBody.getBodyData();
-            parameters.putParameters(bodyData);
-        }
+        List<String> headerValues = reader.readHeaders();
+        headers = new Headers(headerValues);
+
+        String contentLengthValue = parseContentLength();
+        byte[] bodyBytes = reader.readBody(Integer.parseInt(contentLengthValue));
+
+        MimeType mimeType = headers.getMimeType();
+        requestBody = new RequestMessageBody(bodyBytes, mimeType);
     }
 
-    private RequestLine createRequestLine(final String requestLine) throws UnsupportedEncodingException {
-        String[] splitLines = requestLine.split(ONE_SPACE);
+    private RequestLine createRequestLine(final String requestLineValue) throws UnsupportedEncodingException {
+        String[] splitLines = requestLineValue.split(ONE_SPACE);
         HttpMethod method = HttpMethod.find(splitLines[METHOD_INDEX].toUpperCase());
         String[] pathWithQueryString = splitDecodedQueryString(splitLines[URI_INDEX]);
         String requestPath = pathWithQueryString[PATH_INDEX];
 
         if (pathWithQueryString.length == RequestParameters.KEY_VALUE_LENGTH) {
-            parameters.putParameters(pathWithQueryString[QUERY_STRING_INDEX]);
+            queryParameters.putParameters(pathWithQueryString[QUERY_STRING_INDEX]);
         }
         String httpVersion = splitLines[VERSION_INDEX];
 
@@ -67,19 +70,9 @@ public class HttpRequest {
     private String parseContentLength() {
         List<String> headerValues = headers.getHeader(HeaderType.CONTENT_LENGTH);
         if (Objects.isNull(headerValues) || headerValues.isEmpty()) {
-            return null;
+            return "0";
         }
-        return String.join("; ", headerValues);
-    }
-
-    private boolean isFormData() {
-        List<String> headerValues = headers.getHeader(HeaderType.CONTENT_TYPE);
-        if (Objects.isNull(headerValues) || headerValues.isEmpty()) {
-            return false;
-        }
-        String contentType = headerValues.get(0);
-
-        return contentType.contains(MimeType.APPLICATION_X_WWW_FORM_ENCODED.getValue());
+        return headerValues.get(0);
     }
 
     private String[] splitDecodedQueryString(final String queryString) throws UnsupportedEncodingException {
@@ -88,20 +81,14 @@ public class HttpRequest {
         return decodedQueryString.split("\\?");
     }
 
-    public String getRequestPath() {
-        return requestLine.getRequestPath();
-    }
-
-    public String getHttpVersion() {
-        return requestLine.getHttpVersion();
-    }
-
-    public HttpMethod getHttpMethod() {
-        return requestLine.getMethod();
-    }
-
     public String getParameter(final String name) {
-        return parameters.get(name);
+        if (queryParameters.contains(name)) {
+            return queryParameters.get(name);
+        }
+        if (requestBody.containsParameter(name)) {
+            return requestBody.getParameter(name);
+        }
+        return null;
     }
 
     public List<Cookie> getCookies() {
@@ -131,12 +118,24 @@ public class HttpRequest {
         return httpSession;
     }
 
+    public String getRequestPath() {
+        return requestLine.getRequestPath();
+    }
+
+    public String getHttpVersion() {
+        return requestLine.getHttpVersion();
+    }
+
+    public HttpMethod getHttpMethod() {
+        return requestLine.getMethod();
+    }
+
     @Override
     public String toString() {
         return "HttpRequest{" +
                 "requestLine=" + requestLine +
                 ", headers=" + headers +
-                ", parameters=" + parameters +
+                ", parameters=" + queryParameters +
                 ", requestBody=" + requestBody +
                 '}';
     }

--- a/src/main/java/codesquad/was/http/HttpRequest.java
+++ b/src/main/java/codesquad/was/http/HttpRequest.java
@@ -50,7 +50,7 @@ public class HttpRequest {
         byte[] bodyBytes = reader.readBody(Integer.parseInt(contentLengthValue));
 
         MimeType mimeType = headers.getMimeType();
-        requestBody = new RequestMessageBody(bodyBytes, mimeType);
+        requestBody = new RequestMessageBody(bodyBytes, mimeType, () -> headers.getHeader(HeaderType.CONTENT_TYPE));
     }
 
     private RequestLine createRequestLine(final String requestLineValue) throws UnsupportedEncodingException {
@@ -128,6 +128,10 @@ public class HttpRequest {
 
     public HttpMethod getHttpMethod() {
         return requestLine.getMethod();
+    }
+
+    public MultipartFile getMultipartFile() {
+        return requestBody.getMultipartFile();
     }
 
     @Override

--- a/src/main/java/codesquad/was/http/HttpResponse.java
+++ b/src/main/java/codesquad/was/http/HttpResponse.java
@@ -38,7 +38,7 @@ public class HttpResponse {
 
         try (InputStream inputStream = fileUrl.openStream()) {
             byte[] fileBytes = inputStream.readAllBytes();
-            headers.add(HeaderType.CONTENT_TYPE, MimeType.findMimeValue(StringUtils.getFilenameExtension(requestPath)));
+            headers.add(HeaderType.CONTENT_TYPE, MimeType.findValue(StringUtils.getFilenameExtension(requestPath)));
             statusLine.setResponseStatus(StatusCodeType.OK);
 
             sendResponse(fileBytes);

--- a/src/main/java/codesquad/was/http/MultipartFile.java
+++ b/src/main/java/codesquad/was/http/MultipartFile.java
@@ -1,0 +1,52 @@
+package codesquad.was.http;
+
+import codesquad.was.http.type.MimeType;
+import java.util.UUID;
+
+public class MultipartFile {
+
+    private final String originalFilename;
+    private final String extension;
+    private final byte[] bytes;
+    private final MimeType mimeType;
+
+    public MultipartFile(final String originalFilename,
+                         final String extension,
+                         final byte[] bytes,
+                         final MimeType mimeType) {
+        this.originalFilename = originalFilename;
+        this.extension = extension;
+        this.bytes = bytes;
+        this.mimeType = mimeType;
+    }
+
+    public String randomName() {
+        return UUID.randomUUID() + "." + extension;
+    }
+
+    public String getOriginalFilename() {
+        return originalFilename;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public byte[] getBytes() {
+        return bytes;
+    }
+
+    public MimeType getMimeType() {
+        return mimeType;
+    }
+
+    @Override
+    public String toString() {
+        return "MultipartFile{" +
+                "originalFilename='" + originalFilename + '\'' +
+                ", extension='" + extension + '\'' +
+                ", bytesLength=" + bytes.length +
+                ", mimeType=" + mimeType +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/was/http/MultipartParser.java
+++ b/src/main/java/codesquad/was/http/MultipartParser.java
@@ -34,7 +34,6 @@ public class MultipartParser {
     private MultipartFile multipartFile;
 
     public MultipartParser(final byte[] bodyData, final List<String> mimeTypeValues) throws IOException {
-        // boundary 만들기
         String boundarySymbol = getBoundarySymbol(mimeTypeValues);
         splitBoundary = DASH + boundarySymbol;
         endBoundary = DASH + boundarySymbol + DASH;
@@ -45,24 +44,20 @@ public class MultipartParser {
             Map<String, String> contentDispositionValues = getContentDispositions(
                     new String(readUntilSymbol(CR, inputStream), UTF_8.getCharset()));
 
-            // 그냥 form데이터
             if (contentDispositionValues.size() == ONLY_FORM_DATA_SIZE) {
                 inputStream.skip(2);
                 String formKey = contentDispositionValues.get("name");
                 String formValue = new String(readUntilSymbol(CR, inputStream));
                 formParameters.put(formKey, formValue);
             }
-            // byte 데이터가 입력되면 filename,
             if (contentDispositionValues.size() == MIME_DATA_SIZE) {
                 MimeType mimeType = getMimeType(new String(readUntilSymbol(CR, inputStream), UTF_8.getCharset()));
 
-                // application/octet-stream이거나 filename이 비어있다면 스킵
                 if (mimeType == MimeType.APPLICATION_OCTET_STREAM || contentDispositionValues.get("filename")
                         .isEmpty()) {
                     inputStream.skip(4);
                     continue;
                 }
-                // filename에서 확장자를 가져와서 mime type을 찾는다.
                 String filename = contentDispositionValues.get("filename");
                 inputStream.skip(2);
 

--- a/src/main/java/codesquad/was/http/MultipartParser.java
+++ b/src/main/java/codesquad/was/http/MultipartParser.java
@@ -1,0 +1,170 @@
+package codesquad.was.http;
+
+import static codesquad.was.http.type.CharsetType.UTF_8;
+
+import codesquad.utils.StringUtils;
+import codesquad.was.http.type.MimeType;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class MultipartParser {
+
+
+    private static final String CRLF = "\r\n";
+    private static final byte CR = 13;
+    private static final String DASH = "--";
+    private static final int ONLY_FORM_DATA_SIZE = 1;
+    private static final int MIME_DATA_SIZE = 2;
+
+    private final Logger log = LoggerFactory.getLogger(MultipartParser.class);
+
+    private final String splitBoundary;
+    private final String endBoundary;
+    private final Map<String, String> formParameters = new HashMap<>();
+    private MultipartFile multipartFile;
+
+    public MultipartParser(final byte[] bodyData, final List<String> mimeTypeValues) throws IOException {
+        // boundary 만들기
+        String boundarySymbol = getBoundarySymbol(mimeTypeValues);
+        splitBoundary = DASH + boundarySymbol;
+        endBoundary = DASH + boundarySymbol + DASH;
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(bodyData);
+
+        while (!(new String(readUntilSymbol(CR, inputStream), UTF_8.getCharset())).equals(endBoundary)) {
+            Map<String, String> contentDispositionValues = getContentDispositions(
+                    new String(readUntilSymbol(CR, inputStream), UTF_8.getCharset()));
+
+            // 그냥 form데이터
+            if (contentDispositionValues.size() == ONLY_FORM_DATA_SIZE) {
+                inputStream.skip(2);
+                String formKey = contentDispositionValues.get("name");
+                String formValue = new String(readUntilSymbol(CR, inputStream));
+                formParameters.put(formKey, formValue);
+            }
+            // byte 데이터가 입력되면 filename,
+            if (contentDispositionValues.size() == MIME_DATA_SIZE) {
+                MimeType mimeType = getMimeType(new String(readUntilSymbol(CR, inputStream), UTF_8.getCharset()));
+
+                // application/octet-stream이거나 filename이 비어있다면 스킵
+                if (mimeType == MimeType.APPLICATION_OCTET_STREAM || contentDispositionValues.get("filename")
+                        .isEmpty()) {
+                    inputStream.skip(4);
+                    continue;
+                }
+                // filename에서 확장자를 가져와서 mime type을 찾는다.
+                String filename = contentDispositionValues.get("filename");
+                inputStream.skip(2);
+
+                byte[] multipartBytes = readUntilSymbol((CRLF + splitBoundary).getBytes(UTF_8.getCharset()),
+                        inputStream);
+                log.debug("read multipart file byte = {}", multipartBytes.length);
+
+                multipartFile = new MultipartFile(filename, StringUtils.getFilenameExtension(filename), multipartBytes,
+                        mimeType);
+            }
+        }
+    }
+
+    private String getBoundarySymbol(final List<String> mimeTypeValues) {
+        return mimeTypeValues.get(1).split("=")[1];
+    }
+
+    private byte[] readUntilSymbol(final byte symbol, final InputStream inputStream) throws IOException {
+        byte[] bytes;
+        inputStream.mark(0);
+        int count = countLine(inputStream, symbol);
+        inputStream.reset();
+
+        bytes = new byte[count];
+        inputStream.read(bytes);
+        skipByte(inputStream, 2);
+
+        return bytes;
+    }
+
+    private Map<String, String> getContentDispositions(final String header) {
+        String wholeValue = header.split(":")[1];
+        String[] values = wholeValue.split(";");
+        String[] onlyValues = Arrays.copyOfRange(values, 1, values.length);
+
+        return Arrays.stream(onlyValues)
+                .map(onlyValue -> onlyValue.split("="))
+                .collect(Collectors.toMap(
+                        split -> split[0].trim(),
+                        split -> split[1].trim().substring(1, split[1].trim().length() - 1)
+                ));
+    }
+
+    private MimeType getMimeType(final String contentAndMimeType) {
+        String[] contentAndMimeTypes = contentAndMimeType.split(":");
+
+        return MimeType.findMimeType(contentAndMimeTypes[1].trim());
+    }
+
+    private byte[] readUntilSymbol(final byte[] bytes, final ByteArrayInputStream inputStream) {
+        List<Byte> byteStore = new ArrayList<>();
+        inputStream.mark(0);
+        while (!isEndOfBoundary(byteStore, bytes)) {
+            byteStore.add((byte) inputStream.read());
+        }
+        List<Byte> findBytes = byteStore.subList(0, byteStore.size() - bytes.length);
+        inputStream.reset();
+        inputStream.skip(findBytes.size());
+        inputStream.skip(2);
+
+        return toArray(findBytes);
+    }
+
+    private byte[] toArray(final List<Byte> bytes) {
+        byte[] convertedBytes = new byte[bytes.size()];
+        for (int i = 0; i < bytes.size(); i++) {
+            convertedBytes[i] = bytes.get(i);
+        }
+
+        return convertedBytes;
+    }
+
+    private boolean isEndOfBoundary(final List<Byte> byteStore, final byte[] bytes) {
+        if (byteStore.size() < bytes.length) {
+            return false;
+        }
+        List<Byte> compareBytes = byteStore.subList(byteStore.size() - bytes.length, byteStore.size());
+        return IntStream.range(0, compareBytes.size())
+                .allMatch(i -> compareBytes.get(i) == bytes[i]);
+    }
+
+    private int countLine(final InputStream inputStream, final byte specificByte) throws IOException {
+        int count = 0;
+        int value;
+        while ((value = inputStream.read()) != specificByte) {
+            if (value == -1) {
+                break;
+            }
+            count++;
+        }
+        return count;
+    }
+
+    private void skipByte(final InputStream inputStream, int count) throws IOException {
+        inputStream.skip(count);
+    }
+
+    public Map<String, String> getFormParameters() {
+        return formParameters;
+    }
+
+    public MultipartFile getMultipartFile() {
+        return multipartFile;
+    }
+}

--- a/src/main/java/codesquad/was/http/RequestInputStreamReader.java
+++ b/src/main/java/codesquad/was/http/RequestInputStreamReader.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 public class RequestInputStreamReader {
 
     private static final byte CR = 13;
-    private static final byte LF = 10;
     private static final int START_POSITION = 0;
 
     private final Logger log = LoggerFactory.getLogger(RequestInputStreamReader.class);
@@ -26,12 +25,12 @@ public class RequestInputStreamReader {
     public RequestInputStreamReader(final BufferedInputStream bufferedInputStream) throws IOException {
         this.requestInputStream = new BufferedInputStream(bufferedInputStream);
 
-        requestLineBytes = readBytesUntilSymbol(LF);
+        requestLineBytes = readBytesUntilSymbol(CR);
 
         byte[] currentHeaderBytes;
         do {
             skipByte(2);
-            currentHeaderBytes = readBytesUntilSymbol(LF);
+            currentHeaderBytes = readBytesUntilSymbol(CR);
             headerBytes.add(currentHeaderBytes);
         } while (currentHeaderBytes.length > 1);
 
@@ -44,7 +43,7 @@ public class RequestInputStreamReader {
         int count = countLine(requestInputStream, symbol);
         requestInputStream.reset();
 
-        readBytes = new byte[count - 1];
+        readBytes = new byte[count];
         requestInputStream.read(readBytes);
 
         return readBytes;

--- a/src/main/java/codesquad/was/http/RequestInputStreamReader.java
+++ b/src/main/java/codesquad/was/http/RequestInputStreamReader.java
@@ -1,0 +1,89 @@
+package codesquad.was.http;
+
+import static codesquad.was.http.type.CharsetType.UTF_8;
+
+import codesquad.was.exception.InternalServerException;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RequestInputStreamReader {
+
+    private static final byte CR = 13;
+    private static final byte LF = 10;
+    private static final int START_POSITION = 0;
+
+    private final Logger log = LoggerFactory.getLogger(RequestInputStreamReader.class);
+
+    private final BufferedInputStream requestInputStream;
+    private final byte[] requestLineBytes;
+    private final List<byte[]> headerBytes = new ArrayList<>();
+
+    public RequestInputStreamReader(final BufferedInputStream bufferedInputStream) throws IOException {
+        this.requestInputStream = new BufferedInputStream(bufferedInputStream);
+
+        requestLineBytes = readBytesUntilSymbol(LF);
+
+        byte[] currentHeaderBytes;
+        do {
+            skipByte(2);
+            currentHeaderBytes = readBytesUntilSymbol(LF);
+            headerBytes.add(currentHeaderBytes);
+        } while (currentHeaderBytes.length > 1);
+
+        skipByte(2);
+    }
+
+    private byte[] readBytesUntilSymbol(final byte symbol) throws IOException {
+        byte[] readBytes;
+        requestInputStream.mark(START_POSITION);
+        int count = countLine(requestInputStream, symbol);
+        requestInputStream.reset();
+
+        readBytes = new byte[count - 1];
+        requestInputStream.read(readBytes);
+
+        return readBytes;
+    }
+
+    private int countLine(final BufferedInputStream bufferedInputStream, final byte specificByte) throws IOException {
+        int count = 0;
+        while ((bufferedInputStream.read()) != specificByte) {
+            count++;
+        }
+        return count;
+    }
+
+    private void skipByte(final int count) throws IOException {
+        requestInputStream.skip(count);
+    }
+
+    public String readRequestLine() throws UnsupportedEncodingException {
+        return new String(requestLineBytes, UTF_8.getCharset());
+    }
+
+    public List<String> readHeaders() {
+        return headerBytes.stream()
+                .map(header -> {
+                    try {
+                        return new String(header, UTF_8.getCharset());
+                    } catch (UnsupportedEncodingException e) {
+                        log.error(e.getMessage(), e);
+                        throw new InternalServerException();
+                    }
+                })
+                .toList();
+    }
+
+    public byte[] readBody(final int contentLength) throws IOException {
+        byte[] bytes = new byte[contentLength];
+        requestInputStream.read(bytes);
+
+        return bytes;
+    }
+}
+

--- a/src/main/java/codesquad/was/http/RequestMessageBody.java
+++ b/src/main/java/codesquad/was/http/RequestMessageBody.java
@@ -4,11 +4,8 @@ import static codesquad.was.http.type.CharsetType.UTF_8;
 
 import codesquad.was.http.type.MimeType;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.List;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class RequestMessageBody {
 

--- a/src/main/java/codesquad/was/http/RequestParameters.java
+++ b/src/main/java/codesquad/was/http/RequestParameters.java
@@ -27,6 +27,10 @@ public class RequestParameters {
                 .collect(Collectors.toMap(splitParams -> splitParams[0].trim(), splitParams -> splitParams[1].trim()));
     }
 
+    public void putAll(final Map<String, String> parameters) {
+        requestParameters.putAll(parameters);
+    }
+
     public boolean contains(final String key) {
         return requestParameters.containsKey(key);
     }

--- a/src/main/java/codesquad/was/http/RequestParameters.java
+++ b/src/main/java/codesquad/was/http/RequestParameters.java
@@ -27,8 +27,12 @@ public class RequestParameters {
                 .collect(Collectors.toMap(splitParams -> splitParams[0].trim(), splitParams -> splitParams[1].trim()));
     }
 
-    public String get(final String name) {
-        return requestParameters.get(name);
+    public boolean contains(final String key) {
+        return requestParameters.containsKey(key);
+    }
+
+    public String get(final String key) {
+        return requestParameters.get(key);
     }
 
     @Override

--- a/src/main/java/codesquad/was/http/type/MimeType.java
+++ b/src/main/java/codesquad/was/http/type/MimeType.java
@@ -1,6 +1,7 @@
 package codesquad.was.http.type;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Set;
 
 public enum MimeType {
@@ -12,8 +13,8 @@ public enum MimeType {
     PNG(Set.of("png"), "image/png"),
     JPG(Set.of("jpg", "jpeg"), "image/jpeg"),
     SVG(Set.of("svg"), "image/svg+xml"),
-    APPLICATION_X_WWW_FORM_ENCODED(Set.of("application/x-www-form-urlencoded"), "application/x-www-form-urlencoded"),
-    APPLICATION_OCTET_STREAM(Set.of("application/octet-stream"), "application/octet-stream");
+    APPLICATION_X_WWW_FORM_ENCODED(Collections.emptySet(), "application/x-www-form-urlencoded"),
+    APPLICATION_OCTET_STREAM(Collections.emptySet(), "application/octet-stream");
 
     private final Set<String> extensions;
     private final String value;
@@ -23,12 +24,19 @@ public enum MimeType {
         this.value = value;
     }
 
-    public static String findMimeValue(final String extension) {
+    public static String findValue(final String extension) {
         return Arrays.stream(values())
                 .filter(type -> type.extensions.contains(extension))
                 .map(type -> type.value)
                 .findAny()
                 .orElse(APPLICATION_OCTET_STREAM.value);
+    }
+
+    public static MimeType findMimeType(final String extension) {
+        return Arrays.stream(values())
+                .filter(type -> type.value.contains(extension))
+                .findAny()
+                .orElse(APPLICATION_OCTET_STREAM);
     }
 
     public String getValue() {

--- a/src/main/java/codesquad/was/http/type/MimeType.java
+++ b/src/main/java/codesquad/was/http/type/MimeType.java
@@ -13,7 +13,9 @@ public enum MimeType {
     PNG(Set.of("png"), "image/png"),
     JPG(Set.of("jpg", "jpeg"), "image/jpeg"),
     SVG(Set.of("svg"), "image/svg+xml"),
+    GIF(Set.of("gif"), "image/gif"),
     APPLICATION_X_WWW_FORM_ENCODED(Collections.emptySet(), "application/x-www-form-urlencoded"),
+    MULTIPART_FORM_DATA(Collections.emptySet(), "multipart/form-data"),
     APPLICATION_OCTET_STREAM(Collections.emptySet(), "application/octet-stream");
 
     private final Set<String> extensions;

--- a/src/main/java/codesquad/web/domain/Post.java
+++ b/src/main/java/codesquad/web/domain/Post.java
@@ -5,18 +5,22 @@ public class Post {
     private Long id;
     private final String title;
     private final String content;
+    private final String imageName;
     private final Long userPrimaryId;
 
-    public Post(final String title, final String content, final long userPrimaryId) {
+    public Post(final String title, final String content, final String imageName, final long userPrimaryId) {
         this.title = title;
         this.content = content;
+        this.imageName = imageName;
         this.userPrimaryId = userPrimaryId;
     }
 
-    public Post(final Long id, final String title, final String content, final Long userPrimaryId) {
+    public Post(final Long id, final String title, final String content, final String imageName,
+                final Long userPrimaryId) {
         this.id = id;
         this.title = title;
         this.content = content;
+        this.imageName = imageName;
         this.userPrimaryId = userPrimaryId;
     }
 
@@ -30,6 +34,10 @@ public class Post {
 
     public String getContent() {
         return content;
+    }
+
+    public String getImageName() {
+        return imageName;
     }
 
     public Long getUserPrimaryId() {

--- a/src/main/java/codesquad/web/domain/Post.java
+++ b/src/main/java/codesquad/web/domain/Post.java
@@ -1,5 +1,7 @@
 package codesquad.web.domain;
 
+import java.util.Objects;
+
 public class Post {
 
     private Long id;
@@ -37,6 +39,9 @@ public class Post {
     }
 
     public String getImageName() {
+        if (Objects.isNull(imageName)) {
+            return "";
+        }
         return imageName;
     }
 

--- a/src/main/java/codesquad/web/domain/User.java
+++ b/src/main/java/codesquad/web/domain/User.java
@@ -7,20 +7,25 @@ public class User {
     private final String nickname;
     private final String password;
     private final String email;
+    private final String imageName;
 
-    public User(final String userId, final String nickname, final String password, final String email) {
+    public User(final String userId, final String nickname, final String password, final String email,
+                final String imageName) {
         this.userId = userId;
         this.nickname = nickname;
         this.password = password;
         this.email = email;
+        this.imageName = imageName;
     }
 
-    public User(final Long id, final String userId, final String nickname, final String password, final String email) {
+    public User(final Long id, final String userId, final String nickname, final String password, final String email,
+                final String imageName) {
         this.id = id;
         this.userId = userId;
         this.nickname = nickname;
         this.password = password;
         this.email = email;
+        this.imageName = imageName;
     }
 
     public Long getId() {
@@ -41,6 +46,10 @@ public class User {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getImageName() {
+        return imageName;
     }
 
     public boolean isValidPassword(final String password) {

--- a/src/main/java/codesquad/web/domain/User.java
+++ b/src/main/java/codesquad/web/domain/User.java
@@ -1,5 +1,7 @@
 package codesquad.web.domain;
 
+import java.util.Objects;
+
 public class User {
 
     private Long id;
@@ -49,6 +51,9 @@ public class User {
     }
 
     public String getImageName() {
+        if (Objects.isNull(imageName)) {
+            return "";
+        }
         return imageName;
     }
 

--- a/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java
+++ b/src/main/java/codesquad/web/domain/vo/CommentWithNickname.java
@@ -2,6 +2,7 @@ package codesquad.web.domain.vo;
 
 public record CommentWithNickname(
         String nickname,
+        String imageName,
         String content
 ) {
 }

--- a/src/main/java/codesquad/web/domain/vo/PostWithNickname.java
+++ b/src/main/java/codesquad/web/domain/vo/PostWithNickname.java
@@ -4,8 +4,9 @@ public record PostWithNickname(
         Long id,
         String title,
         String content,
-        String imageName,
+        String postImageName,
         Long userPrimaryId,
-        String nickname
+        String nickname,
+        String userImageName
 ) {
 }

--- a/src/main/java/codesquad/web/domain/vo/PostWithNickname.java
+++ b/src/main/java/codesquad/web/domain/vo/PostWithNickname.java
@@ -4,6 +4,7 @@ public record PostWithNickname(
         Long id,
         String title,
         String content,
+        String imageName,
         Long userPrimaryId,
         String nickname
 ) {

--- a/src/main/java/codesquad/web/handler/HomeRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/HomeRequestHandler.java
@@ -80,11 +80,11 @@ public class HomeRequestHandler extends AbstractRequestHandler {
     private static Snippet createPostInfoSnippet(final PostsInfo post) {
         return SnippetBuilder.builder()
                 .snippet(SnippetFixture.POST_INFO)
-                .attributes(List.of(post.writerNickname(), post.title(), post.content()))
+                .attributes(List.of(post.writerNickname(), post.title(), post.imageName(), post.content()))
                 .build();
     }
 
-    private static Snippet createCommentInfoSnippet(final List<CommentInfo> commentInfos) {
+    private Snippet createCommentInfoSnippet(final List<CommentInfo> commentInfos) {
         List<Snippet> postPerCommentSnippets = commentInfos.stream()
                 .map(comment -> SnippetBuilder.builder()
                         .attributes(List.of(comment.commentWriterNickname(), comment.content()))

--- a/src/main/java/codesquad/web/handler/HomeRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/HomeRequestHandler.java
@@ -80,14 +80,15 @@ public class HomeRequestHandler extends AbstractRequestHandler {
     private static Snippet createPostInfoSnippet(final PostsInfo post) {
         return SnippetBuilder.builder()
                 .snippet(SnippetFixture.POST_INFO)
-                .attributes(List.of(post.writerNickname(), post.title(), post.imageName(), post.content()))
+                .attributes(List.of(post.writerImageName(), post.writerNickname(), post.title(), post.postImageName(),
+                        post.content()))
                 .build();
     }
 
     private Snippet createCommentInfoSnippet(final List<CommentInfo> commentInfos) {
         List<Snippet> postPerCommentSnippets = commentInfos.stream()
                 .map(comment -> SnippetBuilder.builder()
-                        .attributes(List.of(comment.commentWriterNickname(), comment.content()))
+                        .attributes(List.of(comment.writerImageName(), comment.writerNickname(), comment.content()))
                         .snippet(SnippetFixture.COMMENT_INFO)
                         .build())
                 .toList();

--- a/src/main/java/codesquad/web/handler/ImageRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/ImageRequestHandler.java
@@ -25,6 +25,10 @@ public class ImageRequestHandler extends AbstractRequestHandler {
             log.debug("이미지를 찾을 수 없습니다.");
             return;
         }
+        if (imageName.equals("NONE")) {
+            response.dynamicForward(new byte[0], MimeType.APPLICATION_OCTET_STREAM);
+            return;
+        }
         File imageFile = new File(UPLOAD_PATH + "/", imageName);
         FileInputStream fileInputStream = new FileInputStream(imageFile);
         byte[] bytes = fileInputStream.readAllBytes();

--- a/src/main/java/codesquad/web/handler/ImageRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/ImageRequestHandler.java
@@ -25,10 +25,6 @@ public class ImageRequestHandler extends AbstractRequestHandler {
             log.debug("이미지를 찾을 수 없습니다.");
             return;
         }
-        if (imageName.equals("NONE")) {
-            response.dynamicForward(new byte[0], MimeType.APPLICATION_OCTET_STREAM);
-            return;
-        }
         File imageFile = new File(UPLOAD_PATH + "/", imageName);
         FileInputStream fileInputStream = new FileInputStream(imageFile);
         byte[] bytes = fileInputStream.readAllBytes();

--- a/src/main/java/codesquad/web/handler/ImageRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/ImageRequestHandler.java
@@ -1,0 +1,35 @@
+package codesquad.web.handler;
+
+import codesquad.utils.StringUtils;
+import codesquad.was.AbstractRequestHandler;
+import codesquad.was.http.HttpRequest;
+import codesquad.was.http.HttpResponse;
+import codesquad.was.http.type.MimeType;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ImageRequestHandler extends AbstractRequestHandler {
+
+    public static final String UPLOAD_PATH = "./upload-image";
+
+    private final Logger log = LoggerFactory.getLogger(ImageRequestHandler.class);
+
+    @Override
+    public void handleGet(final HttpRequest request, final HttpResponse response) throws IOException {
+        String imageName = request.getParameter("imageName");
+        if (Objects.isNull(imageName)) {
+            log.debug("이미지를 찾을 수 없습니다.");
+            return;
+        }
+        File imageFile = new File(UPLOAD_PATH + "/", imageName);
+        FileInputStream fileInputStream = new FileInputStream(imageFile);
+        byte[] bytes = fileInputStream.readAllBytes();
+        String extension = StringUtils.getFilenameExtension(imageName);
+
+        response.dynamicForward(bytes, MimeType.findMimeType(extension));
+    }
+}

--- a/src/main/java/codesquad/web/handler/PostRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/PostRequestHandler.java
@@ -1,11 +1,14 @@
 package codesquad.web.handler;
 
+import static codesquad.web.handler.ImageRequestHandler.UPLOAD_PATH;
+
 import codesquad.was.AbstractRequestHandler;
 import codesquad.was.ContextHolder;
 import codesquad.was.exception.BadRequestException;
 import codesquad.was.http.HttpRequest;
 import codesquad.was.http.HttpResponse;
 import codesquad.was.http.HttpSession;
+import codesquad.was.http.MultipartFile;
 import codesquad.was.http.type.MimeType;
 import codesquad.web.domain.Post;
 import codesquad.web.domain.PostRepository;
@@ -14,6 +17,8 @@ import codesquad.web.snippet.ResourceSnippetBuilder;
 import codesquad.web.snippet.Snippet;
 import codesquad.web.snippet.SnippetBuilder;
 import codesquad.web.snippet.SnippetFixture;
+import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
@@ -66,10 +71,12 @@ public class PostRequestHandler extends AbstractRequestHandler {
 
         String title = request.getParameter("title");
         String content = request.getParameter("content");
+        MultipartFile multipartFile = request.getMultipartFile();
 
         validatePost(title, content);
+        String imageName = uploadFile(multipartFile);
 
-        Post post = new Post(title, content, loginedUser.getId());
+        Post post = new Post(title, content, imageName, loginedUser.getId());
         postRepository.save(post);
 
         response.sendRedirect("/");
@@ -79,5 +86,28 @@ public class PostRequestHandler extends AbstractRequestHandler {
         if (Objects.isNull(title) || Objects.isNull(content)) {
             throw new BadRequestException("제목과 본문은 반드시 입력해야 합니다.");
         }
+    }
+
+    private String uploadFile(final MultipartFile multipartFile) throws IOException {
+        if (Objects.isNull(multipartFile)) {
+            return null;
+        }
+        createDirectory();
+        return writeBytes(multipartFile);
+    }
+
+    private void createDirectory() {
+        File file = new File(UPLOAD_PATH);
+        file.mkdirs();
+    }
+
+    private String writeBytes(final MultipartFile multipartFile) throws IOException {
+        String randomName = multipartFile.randomName();
+        File file = new File(UPLOAD_PATH + "/" + randomName);
+        FileOutputStream fileOutputStream = new FileOutputStream(file);
+        fileOutputStream.write(multipartFile.getBytes());
+        fileOutputStream.close();
+
+        return randomName;
     }
 }

--- a/src/main/java/codesquad/web/handler/UserRequestHandler.java
+++ b/src/main/java/codesquad/web/handler/UserRequestHandler.java
@@ -57,7 +57,7 @@ public class UserRequestHandler extends AbstractRequestHandler {
         List<Snippet> snippets = users.stream()
                 .map(user -> SnippetBuilder.builder()
                         .snippet(SnippetFixture.USER_INFO)
-                        .attributes(List.of(user.getNickname(), user.getUserId(), user.getEmail()))
+                        .attributes(List.of(user.getImageName(), user.getNickname(), user.getUserId(), user.getEmail()))
                         .build())
                 .toList();
 

--- a/src/main/java/codesquad/web/handler/dto/CommentInfo.java
+++ b/src/main/java/codesquad/web/handler/dto/CommentInfo.java
@@ -1,7 +1,8 @@
 package codesquad.web.handler.dto;
 
 public record CommentInfo(
-        String commentWriterNickname,
+        String writerNickname,
+        String writerImageName,
         String content
 ) {
 }

--- a/src/main/java/codesquad/web/handler/dto/PostsInfo.java
+++ b/src/main/java/codesquad/web/handler/dto/PostsInfo.java
@@ -18,15 +18,7 @@ public record PostsInfo(
                 .map(comment -> new CommentInfo(comment.nickname(), comment.imageName(), comment.content()))
                 .toList();
 
-        String userImageName = post.userImageName();
-        String postImageName = post.postImageName();
-        if (post.userImageName() == null) {
-            userImageName = "NONE";
-        }
-        if (post.postImageName() == null) {
-            postImageName = "NONE";
-        }
-        return new PostsInfo(post.id(), userImageName, post.nickname(), post.title(), post.content(), postImageName,
-                commentInfos);
+        return new PostsInfo(post.id(), post.userImageName(), post.nickname(), post.title(), post.content(),
+                post.postImageName(), commentInfos);
     }
 }

--- a/src/main/java/codesquad/web/handler/dto/PostsInfo.java
+++ b/src/main/java/codesquad/web/handler/dto/PostsInfo.java
@@ -9,6 +9,7 @@ public record PostsInfo(
         String writerNickname,
         String title,
         String content,
+        String imageName,
         List<CommentInfo> commentInfos
 ) {
     public static PostsInfo from(final PostWithNickname post, final List<CommentWithNickname> commentWithNicknames) {
@@ -16,6 +17,6 @@ public record PostsInfo(
                 .map(comment -> new CommentInfo(comment.nickname(), comment.content()))
                 .toList();
 
-        return new PostsInfo(post.id(), post.nickname(), post.title(), post.content(), commentInfos);
+        return new PostsInfo(post.id(), post.nickname(), post.title(), post.content(), post.imageName(), commentInfos);
     }
 }

--- a/src/main/java/codesquad/web/handler/dto/PostsInfo.java
+++ b/src/main/java/codesquad/web/handler/dto/PostsInfo.java
@@ -6,17 +6,27 @@ import java.util.List;
 
 public record PostsInfo(
         Long id,
+        String writerImageName,
         String writerNickname,
         String title,
         String content,
-        String imageName,
+        String postImageName,
         List<CommentInfo> commentInfos
 ) {
     public static PostsInfo from(final PostWithNickname post, final List<CommentWithNickname> commentWithNicknames) {
         List<CommentInfo> commentInfos = commentWithNicknames.stream()
-                .map(comment -> new CommentInfo(comment.nickname(), comment.content()))
+                .map(comment -> new CommentInfo(comment.nickname(), comment.imageName(), comment.content()))
                 .toList();
 
-        return new PostsInfo(post.id(), post.nickname(), post.title(), post.content(), post.imageName(), commentInfos);
+        String userImageName = post.userImageName();
+        String postImageName = post.postImageName();
+        if (post.userImageName() == null) {
+            userImageName = "NONE";
+        }
+        if (post.postImageName() == null) {
+            postImageName = "NONE";
+        }
+        return new PostsInfo(post.id(), userImageName, post.nickname(), post.title(), post.content(), postImageName,
+                commentInfos);
     }
 }

--- a/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java
+++ b/src/main/java/codesquad/web/infrastructure/JdbcCommentRepository.java
@@ -26,12 +26,13 @@ public class JdbcCommentRepository implements CommentRepository {
 
     @Override
     public List<CommentWithNickname> findAllByPostIdWithJoinUser(final Long postId) {
-        String sql = "SELECT u.user_id, c.content FROM comment c join users u on u.id=c.users_primary_id where c.post_primary_id=?";
+        String sql = "SELECT u.user_id, u.image_name, c.content FROM comment c join users u on u.id=c.users_primary_id where c.post_primary_id=?";
         return jdbcTemplate.selectAll(
                 sql,
                 ps -> ps.setLong(1, postId),
                 rs -> new CommentWithNickname(
                         rs.getString("user_id"),
+                        rs.getString("image_name"),
                         rs.getString("content")
                 )
         );

--- a/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java
+++ b/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java
@@ -18,6 +18,7 @@ public class JdbcPostRepository implements PostRepository {
                         + "    id BIGINT AUTO_INCREMENT PRIMARY KEY,\n"
                         + "    title VARCHAR(255),\n"
                         + "    content TEXT,\n"
+                        + "    image_name VARCHAR(255),\n"
                         + "    user_primary_id BIGINT,\n"
                         + "    FOREIGN KEY (user_primary_id) REFERENCES users(id)\n"
                         + ");"
@@ -26,27 +27,29 @@ public class JdbcPostRepository implements PostRepository {
 
     @Override
     public void save(final Post post) {
-        String sql = "INSERT INTO post (title, content, user_primary_id) VALUES (?, ?, ?)";
+        String sql = "INSERT INTO post (title, content, image_name, user_primary_id) VALUES (?, ?, ?, ?)";
         jdbcTemplate.insert(
                 sql,
                 ps -> {
                     ps.setString(1, post.getTitle());
                     ps.setString(2, post.getContent());
-                    ps.setLong(3, post.getUserPrimaryId());
+                    ps.setString(3, post.getImageName());
+                    ps.setLong(4, post.getUserPrimaryId());
                 }
         );
     }
 
     @Override
     public Optional<Post> findById(final long id) {
-        String sql = "SELECT id, title, content, user_primary_id FROM post WHERE id = ?";
+        String sql = "SELECT id, title, content, image_name, user_primary_id FROM post WHERE id = ?";
         Post post = jdbcTemplate.selectOne(
                 sql,
                 ps -> ps.setLong(1, id),
                 rs -> new Post(
-                        rs.getLong(1),
+                        rs.getLong("id"),
                         rs.getString("title"),
                         rs.getString("content"),
+                        rs.getString("image_name"),
                         rs.getLong("user_primary_id")
                 )
         );
@@ -56,13 +59,14 @@ public class JdbcPostRepository implements PostRepository {
 
     @Override
     public List<PostWithNickname> findAllWithJoinUser() {
-        String sql = "SELECT p.id, p.title, p.content, p.user_primary_id, u.user_id FROM post p join users u on p.user_primary_id = u.id ORDER BY p.id DESC";
+        String sql = "SELECT p.id, p.title, p.content, p.image_name, p.user_primary_id, u.user_id FROM post p join users u on p.user_primary_id = u.id ORDER BY p.id DESC";
         return jdbcTemplate.selectAll(
                 sql,
                 rs -> new PostWithNickname(
                         rs.getLong("id"),
                         rs.getString("title"),
                         rs.getString("content"),
+                        rs.getString("image_name"),
                         rs.getLong("user_primary_id"),
                         rs.getString("user_id")
                 )

--- a/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java
+++ b/src/main/java/codesquad/web/infrastructure/JdbcPostRepository.java
@@ -59,16 +59,17 @@ public class JdbcPostRepository implements PostRepository {
 
     @Override
     public List<PostWithNickname> findAllWithJoinUser() {
-        String sql = "SELECT p.id, p.title, p.content, p.image_name, p.user_primary_id, u.user_id FROM post p join users u on p.user_primary_id = u.id ORDER BY p.id DESC";
+        String sql = "SELECT p.id, p.title, p.content, p.image_name post_image_name, p.user_primary_id, u.user_id, u.image_name user_image_name FROM post p join users u on p.user_primary_id = u.id ORDER BY p.id DESC";
         return jdbcTemplate.selectAll(
                 sql,
                 rs -> new PostWithNickname(
                         rs.getLong("id"),
                         rs.getString("title"),
                         rs.getString("content"),
-                        rs.getString("image_name"),
+                        rs.getString("post_image_name"),
                         rs.getLong("user_primary_id"),
-                        rs.getString("user_id")
+                        rs.getString("user_id"),
+                        rs.getString("user_image_name")
                 )
         );
 

--- a/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java
+++ b/src/main/java/codesquad/web/infrastructure/JdbcUserRepository.java
@@ -19,24 +19,26 @@ public class JdbcUserRepository implements UserRepository {
                         + "    user_id VARCHAR(255),\n"
                         + "    nickname VARCHAR(255),\n"
                         + "    password VARCHAR(255),\n"
+                        + "    image_name VARCHAR(255),\n"
                         + "    email VARCHAR(255)\n"
                         + ")");
     }
 
     @Override
     public void save(final User user) {
-        String sql = "INSERT INTO users (user_id, nickname, password, email) VALUES (?, ?, ?, ?)";
+        String sql = "INSERT INTO users (user_id, nickname, password, email, image_name) VALUES (?, ?, ?, ?, ?)";
         jdbcTemplate.insert(sql, ps -> {
             ps.setString(1, user.getUserId());
             ps.setString(2, user.getNickname());
             ps.setString(3, user.getPassword());
             ps.setString(4, user.getEmail());
+            ps.setString(5, user.getImageName());
         });
     }
 
     @Override
     public Optional<User> findByUserId(final String userId) {
-        String sql = "SELECT id, user_id, nickname, password, email FROM users where user_id = ?";
+        String sql = "SELECT id, user_id, nickname, password, email, image_name FROM users where user_id = ?";
         User findUser = jdbcTemplate.selectOne(
                 sql,
                 ps -> ps.setString(1, userId),
@@ -45,7 +47,8 @@ public class JdbcUserRepository implements UserRepository {
                         rs.getString("user_id"),
                         rs.getString("nickname"),
                         rs.getString("password"),
-                        rs.getString("email")
+                        rs.getString("email"),
+                        rs.getString("image_name")
                 )
         );
 
@@ -54,7 +57,7 @@ public class JdbcUserRepository implements UserRepository {
 
     @Override
     public List<User> findAll() {
-        String sql = "SELECT id, user_id, nickname, password, email FROM users";
+        String sql = "SELECT id, user_id, nickname, password, email, image_name FROM users";
         return jdbcTemplate.selectAll(
                 sql,
                 rs -> new User(
@@ -62,7 +65,8 @@ public class JdbcUserRepository implements UserRepository {
                         rs.getString("user_id"),
                         rs.getString("nickname"),
                         rs.getString("password"),
-                        rs.getString("email")
+                        rs.getString("email"),
+                        rs.getString("image_name")
                 )
         );
     }

--- a/src/main/java/codesquad/web/snippet/SnippetFixture.java
+++ b/src/main/java/codesquad/web/snippet/SnippetFixture.java
@@ -42,7 +42,7 @@ public class SnippetFixture {
     public static final String POST_INFO = """
             <div class="post">
                 <div class="post__account">
-                    <img class="post__account__img"/>
+                    <img src="/image?imageName=%s" class="post__account__img"/>
                     <p class="post__account__nickname">%s</p>
                     <h1>%s</h1>
                 </div>
@@ -96,7 +96,7 @@ public class SnippetFixture {
     public static final String COMMENT_INFO = """
             <li class="comment__item">
                 <div class="comment__item__user">
-                    <img class="comment__item__user__img"/>
+                    <img src="/image?imageName=%s"class="comment__item__user__img"/>
                     <p class="comment__item__user__nickname">%s</p>
                 </div>
                 <p class="comment__item__article">

--- a/src/main/java/codesquad/web/snippet/SnippetFixture.java
+++ b/src/main/java/codesquad/web/snippet/SnippetFixture.java
@@ -46,7 +46,7 @@ public class SnippetFixture {
                     <p class="post__account__nickname">%s</p>
                     <h1>%s</h1>
                 </div>
-                <img class="post__img"/>
+                <img src="/image?imageName=%s" class="post__img"/>
                 <div class="post__menu">
                     <ul class="post__menu__personal">
                         <li>

--- a/src/main/java/codesquad/web/snippet/SnippetFixture.java
+++ b/src/main/java/codesquad/web/snippet/SnippetFixture.java
@@ -31,7 +31,7 @@ public class SnippetFixture {
     public static final String USER_INFO = """
             <div class="user-card">
                 <div class="user-header"></div>
-                <div class="user-avatar"></div>
+                <img src="/image?imageName=%s" class="user-avatar">
                 <div class="user-info">
                     <div class="user-name">%s</div>
                     <div class="user-id">%s</div>

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <link href="../reset.css" rel="stylesheet"/>
     <link href="../global.css" rel="stylesheet"/>
+    <style>
+        .form-group label {
+            display: block;
+            margin-bottom: 5px;
+        }
+
+    </style>
 </head>
 <body>
 <div class="container">
@@ -23,7 +30,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">회원가입</h2>
-        <form class="form" method="post" action="/user/create">
+        <form class="form" method="post" action="/user/create" enctype="multipart/form-data">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input
@@ -60,6 +67,11 @@
                         autocomplete="email"
                         name="email"
                 />
+            </div>
+            <div class="form-group">
+                <label for="post-file">프로필 사진</label>
+                <input type="file" id="post-file" name="file" class="form-control">
+                <img id="preview"/>
             </div>
             <button
                     id="registration-btn"

--- a/src/main/resources/static/registration/index.html
+++ b/src/main/resources/static/registration/index.html
@@ -31,6 +31,11 @@
     <div class="page">
         <h2 class="page-title">회원가입</h2>
         <form class="form" method="post" action="/user/create" enctype="multipart/form-data">
+            <div class="form-group">
+                <label for="post-file">프로필 사진</label>
+                <input type="file" id="post-file" name="file" class="form-control">
+                <img id="preview"/>
+            </div>
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">아이디</p>
                 <input
@@ -67,11 +72,6 @@
                         autocomplete="email"
                         name="email"
                 />
-            </div>
-            <div class="form-group">
-                <label for="post-file">프로필 사진</label>
-                <input type="file" id="post-file" name="file" class="form-control">
-                <img id="preview"/>
             </div>
             <button
                     id="registration-btn"

--- a/src/main/resources/templates/post/form.html
+++ b/src/main/resources/templates/post/form.html
@@ -46,7 +46,7 @@
     function readURL(input) {
         if (input.files && input.files[0]) {
             var reader = new FileReader();
-            reader.onload = function(e) {
+            reader.onload = function (e) {
                 document.getElementById('preview').src = e.target.result;
             };
             reader.readAsDataURL(input.files[0]);

--- a/src/main/resources/templates/post/form.html
+++ b/src/main/resources/templates/post/form.html
@@ -7,6 +7,7 @@
     <link href="../global.css" rel="stylesheet"/>
     <link href="../main.css" rel="stylesheet"/>
     <link href="../post-form.css" rel="stylesheet"/>
+
 </head>
 <body>
 <div class="container">
@@ -18,10 +19,15 @@
     </header>
     <div class="wrapper">
         <div class="post">
-            <form class="post-form" method="post" action="/post">
+            <form class="post-form" method="post" action="/post" enctype="multipart/form-data">
                 <div class="form-group">
                     <label for="post-title">제목</label>
                     <input type="text" id="post-title" name="title" class="form-control" required>
+                </div>
+                <div class="form-group">
+                    <label for="post-file">파일 첨부</label>
+                    <input type="file" id="post-file" name="file" class="form-control" onchange="readURL(this);">
+                    <img id="preview"/>
                 </div>
                 <div class="form-group">
                     <label for="post-content">본문</label>
@@ -32,6 +38,21 @@
                     <a type="button" class="btn btn-secondary" href="/">취소</a>
                 </div>
             </form>
+
         </div>
     </div>
 </div>
+<script>
+    function readURL(input) {
+        if (input.files && input.files[0]) {
+            var reader = new FileReader();
+            reader.onload = function(e) {
+                document.getElementById('preview').src = e.target.result;
+            };
+            reader.readAsDataURL(input.files[0]);
+        } else {
+            document.getElementById('preview').src = "";
+        }
+    }
+</script>
+</body>

--- a/src/test/java/codesquad/was/http/HeadersTest.java
+++ b/src/test/java/codesquad/was/http/HeadersTest.java
@@ -4,9 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import codesquad.was.http.type.HeaderType;
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.StringReader;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -15,12 +13,7 @@ class HeadersTest {
     @Test
     void getHeader_헤더목록에_있는_헤더_값을_찾을_수_있다() throws IOException {
         // given
-        String httpRequestHeaders = "Host: localhost\r\n" +
-                "Connection: keep-alive\r\n" +
-                "Accept: text/html\r\n" +
-                "\r\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(httpRequestHeaders));
-        Headers headers = new Headers(bufferedReader);
+        Headers headers = new Headers(List.of("Host: localhost", "Connection: keep-alive", "Accept: text/html"));
 
         // when
         String headerValue = headers.getHeader(HeaderType.HOST).get(0);
@@ -48,13 +41,8 @@ class HeadersTest {
     @Test
     void 헤더_OWS_여부에_관계없이_파싱_할_수_있다() throws IOException {
         // given
-        String httpRequestHeaders = "Host:localhost\r\n" +
-                "Connection: keep-alive\r\n" +
-                "Accept : text/html\r\n" +
-                "Content-Type :text/html\r\n" +
-                "\r\n";
-        BufferedReader bufferedReader = new BufferedReader(new StringReader(httpRequestHeaders));
-        Headers headers = new Headers(bufferedReader);
+        Headers headers = new Headers(
+                List.of("Host:localhost", "Connection :keep-alive", "Accept: text/html", "Content-Type :text/html"));
 
         // when
         String value1 = headers.getHeader(HeaderType.HOST).get(0);

--- a/src/test/java/codesquad/was/http/RequestMessageBodyTest.java
+++ b/src/test/java/codesquad/was/http/RequestMessageBodyTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import codesquad.was.http.type.MimeType;
 import java.io.IOException;
+import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class RequestMessageBodyTest {
@@ -13,7 +14,7 @@ class RequestMessageBodyTest {
         // given
         byte[] bodyBytes = "name=사람이름".getBytes();
         RequestMessageBody requestMessageBody = new RequestMessageBody(bodyBytes,
-                MimeType.APPLICATION_X_WWW_FORM_ENCODED);
+                MimeType.APPLICATION_X_WWW_FORM_ENCODED, Collections::emptyList);
 
         // when
         String name = requestMessageBody.getParameter("name");

--- a/src/test/java/codesquad/was/http/RequestMessageBodyTest.java
+++ b/src/test/java/codesquad/was/http/RequestMessageBodyTest.java
@@ -1,41 +1,24 @@
 package codesquad.was.http;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.io.BufferedReader;
+import codesquad.was.http.type.MimeType;
 import java.io.IOException;
-import java.io.StringReader;
 import org.junit.jupiter.api.Test;
 
 class RequestMessageBodyTest {
 
     @Test
-    void httpRequest의_요청_바디를_읽을_수_있다() throws IOException {
+    void RequestMessageBody에서_form_parameter를_읽을_수_있다() throws IOException {
         // given
-        String input = "name=사람이름";
-        BufferedReader requestReader = new BufferedReader(new StringReader(input));
+        byte[] bodyBytes = "name=사람이름".getBytes();
+        RequestMessageBody requestMessageBody = new RequestMessageBody(bodyBytes,
+                MimeType.APPLICATION_X_WWW_FORM_ENCODED);
 
         // when
-        RequestMessageBody requestMessageBody = new RequestMessageBody(requestReader, String.valueOf(input.length()));
+        String name = requestMessageBody.getParameter("name");
 
         // then
-        assertAll(
-                () -> assertThat(requestMessageBody.getBodyData()).isEqualTo(new String(input.getBytes("UTF-8"))),
-                () -> assertThat(requestMessageBody.getBodyData().getBytes("UTF-8")).isEqualTo(input.getBytes("UTF-8"))
-        );
-    }
-
-    @Test
-    void httpRequest의_요청바디가_비어있다면_바디는_비어있다() throws IOException {
-        // given
-        String input = " ";
-        BufferedReader requestReader = new BufferedReader(new StringReader(input));
-
-        // when
-        RequestMessageBody requestMessageBody = new RequestMessageBody(requestReader, "0");
-
-        // then
-        assertThat(requestMessageBody.getBodyData()).isEqualTo("");
+        assertThat(name).isEqualTo("사람이름");
     }
 }

--- a/src/test/java/codesquad/was/http/type/MimeTypeTest.java
+++ b/src/test/java/codesquad/was/http/type/MimeTypeTest.java
@@ -12,7 +12,7 @@ class MimeTypeTest {
         String extension = "html";
 
         // when
-        String mimeValue = MimeType.findMimeValue(extension);
+        String mimeValue = MimeType.findValue(extension);
 
         // then
         assertThat(mimeValue).isEqualTo("text/html");
@@ -21,6 +21,6 @@ class MimeTypeTest {
     @Test
     void 알_수_없는_mimeType이라면_octet_stream이_반환된다() {
         // expect
-        assertThat(MimeType.findMimeValue("undefined-type")).isEqualTo("application/octet-stream");
+        assertThat(MimeType.findValue("undefined-type")).isEqualTo("application/octet-stream");
     }
 }

--- a/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java
+++ b/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java
@@ -20,6 +20,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Collections;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -33,7 +34,7 @@ class SignUpRequestHandlerTest extends RequestHandlerTest {
         // expect
         assertThatThrownBy(() -> signUpRequestHandler.handleGet(
                 new HttpRequest(new RequestLine(HttpMethod.GET, "/path", "HTTP/1.1"), new Headers(),
-                        new RequestMessageBody(new byte[0], MimeType.APPLICATION_OCTET_STREAM)),
+                        new RequestMessageBody(new byte[0], MimeType.APPLICATION_OCTET_STREAM, Collections::emptyList)),
                 new HttpResponse(new DataOutputStream(OutputStream.nullOutputStream()), "HTTP/1.1")))
                 .isInstanceOf(MethodNotAllowedException.class)
                 .hasMessage("Method Not Allowed");

--- a/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java
+++ b/src/test/java/codesquad/web/handler/SignUpRequestHandlerTest.java
@@ -12,6 +12,7 @@ import codesquad.was.http.HttpResponse;
 import codesquad.was.http.RequestLine;
 import codesquad.was.http.RequestMessageBody;
 import codesquad.was.http.type.HttpMethod;
+import codesquad.was.http.type.MimeType;
 import codesquad.web.domain.User;
 import codesquad.web.handler.fixture.RequestHandlerTest;
 import java.io.ByteArrayInputStream;
@@ -32,7 +33,7 @@ class SignUpRequestHandlerTest extends RequestHandlerTest {
         // expect
         assertThatThrownBy(() -> signUpRequestHandler.handleGet(
                 new HttpRequest(new RequestLine(HttpMethod.GET, "/path", "HTTP/1.1"), new Headers(),
-                        new RequestMessageBody("data")),
+                        new RequestMessageBody(new byte[0], MimeType.APPLICATION_OCTET_STREAM)),
                 new HttpResponse(new DataOutputStream(OutputStream.nullOutputStream()), "HTTP/1.1")))
                 .isInstanceOf(MethodNotAllowedException.class)
                 .hasMessage("Method Not Allowed");


### PR DESCRIPTION
## 구현 내용
### 1. BufferedReader 기반 request읽기에서 Byte기반 request읽기로 변경

`HTTP Request`를 이루고 있는 `Request Line`, `Header`는 `String`으로 저장해도 무관합니다. 
오로지 `message body` 데이터만 `multipart form data`로 들어왔을때의 처리가 필요합니다.
따라서 기존 `BufferedReader`로 읽어오던 `Request` 정보들을 `InputStream`을 감싼 `BufferedInputStream`을 사용해 읽었습니다.

1. `RequestInputStreamReader`를 만들기
    
    기존 `HttpRequest` 객체의 구조를 최대한 변경하지 않고 싶었습니다. 따라서 `HTTP Request`를 전용으로 읽는 `reader`를 만들어서 해당 객체가 `Request Line`, `Header`, `Body`를 파싱하는 책임을 주었습니다.
    
    
2. `Message Body` 데이터는 바이트로 관리하기
    
    `RequestINputStreamReader`는 `MessageBody` 데이터를 `byte[]`로 가지고 있습니다. `RequestMessageBody`는 해당 데이터와 `HTTP Request`의 `Content-Type`을 넘겨받아 적절하게 파싱할 수 있도록 합니다.
    이때 `x-www-form-urlencoded` 혹은 `multipart/form-data MimeType`을 여기서 구분하여 파싱하기 위한 기반 코드를 작성했습니다.

- 이미지 저장 및 조회는 노가다성의 파싱이라서, 이렇다 할 설명을 하기가 어렵습니다, ,그냥 열심히 구현했습니다 ㅠ

## 고민 사항
- 이미지를 파싱할때 많은 객체들을 중복하여 생성(new String, List 등)하는 경우가 있는데 이로인해 조금 용량이 높은 이미지들을 업로드하면 OOM이 발생합니다. 좀 더 최적화가 필요하다고 느껴집니다 ㅠ

- 전반적으로 파싱 로직과, 새로 변경된 request 로직, 과거 작성했던 몇몇 로직들이 상당히 가독성이 좋지 못하고, 클래스 하나의 볼륨이 크다고 느껴집니다. 리팩토링을 어떻게 할지에 대한 고민이 있습니다.

## 기타
- 힘들다,, 4주차 ㅠ