### PR TITLE
[고동훤] step-8 이미지 업로드 및 표시 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM openjdk:17-slim
+
+VOLUME /mnt/service
+COPY build/libs/*.jar app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,18 @@ services:
     volumes:
       - h2-data:/h2-data  # Persistent storage for database files
       - ./initdb:/docker-entrypoint-initdb.d  # Initialization scripts
-
+    networks:
+      - network
+  app:
+    build:
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - h2database
+    networks:
+      - network
 volumes:
   h2-data:
+networks:
+  network:

--- a/server/src/main/java/server/connection/ConnectionManager.java
+++ b/server/src/main/java/server/connection/ConnectionManager.java
@@ -3,6 +3,8 @@ package server.connection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import server.exception.ConnectedSocketException;
+import server.exception.ResponseException;
+import server.http.model.startline.StatusCode;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -62,14 +64,12 @@ public abstract class ConnectionManager {
 
     public byte[] readNBytes(int bytes) {
         try {
-            byte[] buffer = new byte[bytes];
-            int bytesRead = getInputStream().read(buffer, 0, bytes);
-            if (bytesRead < bytes) {
-                byte[] bytesReadArray = new byte[bytesRead];
-                System.arraycopy(buffer, 0, bytesReadArray, 0, bytesRead);
-                return bytesReadArray;
+            byte[] result = new byte[bytes];
+            int read = getInputStream().readNBytes(result, 0, bytes);
+            if (read != bytes) {
+                throw new ResponseException("not read", StatusCode.INTERNAL_SERVER_ERROR);
             }
-            return buffer;
+            return result;
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/server/src/main/java/server/http/handler/HttpRequestHandler.java
+++ b/server/src/main/java/server/http/handler/HttpRequestHandler.java
@@ -49,12 +49,12 @@ public class HttpRequestHandler implements Runnable {
                 logger.info("exception", e);
                 responseHttp(new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.BAD_REQUEST)));
             } catch (ResponseException e) {
-                logger.info("exception", e);
+                logger.info("exception for request {}", httpRequest.getRequestPath(), e);
                 httpRequest = httpRequest.forward(Method.GET, new Target("/error?" + "code=" + e.getStatusCode().getCode() + "&message=" + e.getMessage()));
                 HttpResponse response = processor.process(httpRequest);
                 responseHttp(response);
             } catch (Exception e) {
-                logger.info("exception", e);
+                logger.info("uncaught exception for request {}", httpRequest.getRequestPath(), e);
                 responseHttp(new HttpResponse(new StatusLine(Version.HTTP_1_1, StatusCode.INTERNAL_SERVER_ERROR)));
             } finally {
                 connectionManager.incrementRequestCounter();

--- a/server/src/main/java/server/http/model/header/ContentType.java
+++ b/server/src/main/java/server/http/model/header/ContentType.java
@@ -9,6 +9,7 @@ public enum ContentType {
     JPG("jpg", "image/jpeg"),
     SVG("svg", "image/svg+xml"),
     FORM_DATA("form-data", "application/x-www-form-urlencoded"),
+    MULTIPART_FORM_DATA("multi-part", "multipart/form-data"),
     DEFAULT("", "text/plain");
 
     private final String extension;
@@ -29,8 +30,11 @@ public enum ContentType {
     }
 
     public static ContentType of(String value) {
+        if (value == null || value.isEmpty()) {
+            return null;
+        }
         for (ContentType contentType : ContentType.values()) {
-            if (contentType.contentType.equals(value)) {
+            if (value.contains(contentType.contentType)) {
                 return contentType;
             }
         }

--- a/server/src/main/java/server/http/model/header/Headers.java
+++ b/server/src/main/java/server/http/model/header/Headers.java
@@ -26,11 +26,4 @@ public class Headers {
         }
         return sb.toString();
     }
-
-    public void sout() {
-        for (String key : headers.keySet()) {
-            headers.put(key, headers.get(key));
-            System.out.println(key + ": " + headers.get(key));
-        }
-    }
 }

--- a/server/src/main/java/server/http/model/header/Headers.java
+++ b/server/src/main/java/server/http/model/header/Headers.java
@@ -26,4 +26,11 @@ public class Headers {
         }
         return sb.toString();
     }
+
+    public void sout() {
+        for (String key : headers.keySet()) {
+            headers.put(key, headers.get(key));
+            System.out.println(key + ": " + headers.get(key));
+        }
+    }
 }

--- a/src/main/java/codesquad/annotation/api/parameter/Multipart.java
+++ b/src/main/java/codesquad/annotation/api/parameter/Multipart.java
@@ -1,0 +1,11 @@
+package codesquad.annotation.api.parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Multipart {
+}

--- a/src/main/java/codesquad/application/ApplicationInitializer.java
+++ b/src/main/java/codesquad/application/ApplicationInitializer.java
@@ -37,6 +37,8 @@ public class ApplicationInitializer {
         logger.info("Initializing DelegatingProcessor");
         DelegatingProcessor.getInstance().addRequestMappings(processors);
         logger.info("Initializing done");
+
+        H2Initializer.initialize();
     }
 
     private static void processAnnotation(Annotation annotation, java.lang.reflect.Method method,

--- a/src/main/java/codesquad/application/H2Initializer.java
+++ b/src/main/java/codesquad/application/H2Initializer.java
@@ -1,0 +1,51 @@
+package codesquad.application;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.stream.Collectors;
+
+public class H2Initializer {
+    private static final Logger logger = LoggerFactory.getLogger(H2Initializer.class);
+
+    public static void initialize() {
+        logger.info("Initializing H2 database...");
+        // 데이터베이스 URL
+        String jdbcUrl = "jdbc:h2:file:./xtagram";
+
+        // 초기화 스크립트 파일 경로
+        InputStream inputStream = H2Initializer.class.getResourceAsStream("/xtagram.sql");
+
+        if (inputStream == null) {
+            logger.error("Resource not found: xtagram.sql");
+            return;
+        }
+
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, "", "")) {
+            // 초기화 스크립트 읽기
+            String sql;
+            try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+                sql = reader.lines().collect(Collectors.joining("\n"));
+            } catch (IOException e) {
+                logger.error("Error reading the SQL script file.", e);
+                return;
+            }
+
+            // SQL 문 실행
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(sql);
+                logger.info("Database initialized successfully.");
+            }
+        } catch (SQLException e) {
+            logger.error("Error connecting to the database or executing SQL.", e);
+        }
+    }
+}

--- a/src/main/java/codesquad/application/SingletonContainer.java
+++ b/src/main/java/codesquad/application/SingletonContainer.java
@@ -1,16 +1,15 @@
 package codesquad.application;
 
 import codesquad.application.adapter.RequestHandlerAdapter;
-import codesquad.application.argumentresolver.ArgumentResolver;
-import codesquad.application.argumentresolver.FormUrlEncodedResolver;
-import codesquad.application.argumentresolver.NoOpArgumentResolver;
-import codesquad.application.argumentresolver.SessionArgumentResolver;
+import codesquad.application.argumentresolver.*;
 import codesquad.application.handler.RequestHandler;
 import codesquad.application.handler.SessionStorage;
 import codesquad.application.returnvaluehandler.ModelViewHandler;
 import codesquad.application.returnvaluehandler.NoOpViewHandler;
 import codesquad.application.returnvaluehandler.ReturnValueHandler;
-import codesquad.infra.*;
+import codesquad.infra.JdbcArticleStorage;
+import codesquad.infra.JdbcUserStorage;
+import codesquad.infra.MemorySessionStorage;
 
 import java.util.List;
 
@@ -49,7 +48,7 @@ public class SingletonContainer {
 
     public List<ArgumentResolver<?>> argumentResolvers() {
         if (argumentResolvers == null) {
-            argumentResolvers = List.of(new NoOpArgumentResolver(), new FormUrlEncodedResolver(), new SessionArgumentResolver(sessionStorage()));
+            argumentResolvers = List.of(new NoOpArgumentResolver(), new FormUrlEncodedResolver(), new MultipartArgumentResolver(), new SessionArgumentResolver(sessionStorage()));
         }
         return argumentResolvers;
     }

--- a/src/main/java/codesquad/application/argumentresolver/MultipartArgumentResolver.java
+++ b/src/main/java/codesquad/application/argumentresolver/MultipartArgumentResolver.java
@@ -63,17 +63,21 @@ public class MultipartArgumentResolver implements ArgumentResolver<Map<String, b
 
     private byte[] readContent(InputStream inputStream, String boundary) throws IOException {
         ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-        int prev = 0, current;
+        int prev = -1, current;
         while ((current = inputStream.read()) != -1) {
             if (prev == '\r' && current == '\n') {
                 if (checkBoundary(inputStream, boundary)) {
                     break;
                 }
             }
-            buffer.write(prev);
+            if (prev != -1) {
+                buffer.write(prev);
+            }
             prev = current;
         }
-        buffer.write(prev); // Write the last character
+        if (prev != -1) {
+            buffer.write(prev);
+        }
         return buffer.toByteArray();
     }
 

--- a/src/main/java/codesquad/application/argumentresolver/MultipartArgumentResolver.java
+++ b/src/main/java/codesquad/application/argumentresolver/MultipartArgumentResolver.java
@@ -1,0 +1,130 @@
+package codesquad.application.argumentresolver;
+
+import codesquad.annotation.api.parameter.Multipart;
+import server.http.model.HttpRequest;
+import server.http.model.header.Header;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Parameter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class MultipartArgumentResolver implements ArgumentResolver<Map<String, byte[]>> {
+    @Override
+    public Map<String, byte[]> resolve(Parameter parameter, HttpRequest request) {
+        // extract boundary
+        String boundary = getBoundary(request);
+        if (boundary == null || boundary.isBlank()) {
+            throw new UnsupportedOperationException("No boundary found");
+        }
+        boundary = "--" + boundary;
+
+        // parse body
+        byte[] body = request.getBody().getMessage();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(body);
+
+        Map<String, byte[]> resultMap = new HashMap<>();
+        try {
+            String line;
+            while ((line = readLine(inputStream)) != null) {
+                if (line.equals(boundary)) {
+                    // Process each part
+                    String headers = readUntilCrlf(inputStream);
+                    String contentDisposition = getContentDisposition(headers);
+                    byte[] content = readContent(inputStream, boundary);
+                    resultMap.put(contentDisposition, content);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        return resultMap;
+    }
+
+    private String getContentDisposition(String headers) {
+        String[] lines = headers.split("\n");
+        for (String line : lines) {
+            if (line.trim().startsWith("Content-Disposition")) {
+                String[] parts = line.split(";");
+                for (String part : parts) {
+                    if (part.trim().startsWith("name")) {
+                        return part.split("=")[1].trim().replace("\"", "");
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
+    private byte[] readContent(InputStream inputStream, String boundary) throws IOException {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        int prev = 0, current;
+        while ((current = inputStream.read()) != -1) {
+            if (prev == '\r' && current == '\n') {
+                if (checkBoundary(inputStream, boundary)) {
+                    break;
+                }
+            }
+            buffer.write(prev);
+            prev = current;
+        }
+        buffer.write(prev); // Write the last character
+        return buffer.toByteArray();
+    }
+
+    private boolean checkBoundary(InputStream inputStream, String boundary) throws IOException {
+        inputStream.mark(boundary.length() + 2);
+        byte[] boundaryBytes = new byte[boundary.length() + 2];
+        int readBytes = inputStream.read(boundaryBytes);
+        String readBoundary = new String(boundaryBytes, 0, readBytes, StandardCharsets.UTF_8);
+        inputStream.reset();
+        return readBoundary.startsWith(boundary);
+    }
+
+    private String readUntilCrlf(InputStream inputStream) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = readLine(inputStream)) != null && !line.isEmpty()) {
+            sb.append(line).append("\n");
+        }
+        return sb.toString();
+    }
+
+    private String readLine(InputStream inputStream) throws IOException {
+        StringBuilder sb = new StringBuilder();
+        int c;
+        while ((c = inputStream.read()) != -1) {
+            if (c == '\n') {
+                break;
+            }
+            if (c != '\r') {
+                sb.append((char) c);
+            }
+        }
+        if (sb.isEmpty() && c == -1) {
+            return null;
+        }
+        return sb.toString();
+    }
+
+    private String getBoundary(HttpRequest request) {
+        String[] contentType = request.getHeader().get(Header.CONTENT_TYPE.getFieldName()).split(";");
+        for (String attribute : contentType) {
+            String[] split = attribute.split("=");
+            if (split.length == 2 && split[0].trim().equalsIgnoreCase("boundary")) {
+                return split[1].trim();
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean support(Parameter parameter, HttpRequest request) {
+        return parameter.isAnnotationPresent(Multipart.class) && parameter.getType().isAssignableFrom(Map.class);
+    }
+}

--- a/src/main/java/codesquad/application/checker/FileSignatureChecker.java
+++ b/src/main/java/codesquad/application/checker/FileSignatureChecker.java
@@ -1,0 +1,35 @@
+package codesquad.application.checker;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FileSignatureChecker {
+
+    private static final Map<String, String> FILE_SIGNATURES = new HashMap<>();
+
+    static {
+        FILE_SIGNATURES.put("FFD8FF", "jpg");
+        FILE_SIGNATURES.put("89504E47", "png");
+        FILE_SIGNATURES.put("47494638", "gif");
+        FILE_SIGNATURES.put("25504446", "pdf");
+        // 필요에 따라 더 많은 파일 서명을 추가할 수 있습니다.
+    }
+
+    public static String getFileExtension(byte[] data) {
+        String fileSignature = bytesToHex(data, 5); // 처음 4바이트를 사용
+        for (Map.Entry<String, String> entry : FILE_SIGNATURES.entrySet()) {
+            if (fileSignature.contains(entry.getKey())) {
+                return entry.getValue();
+            }
+        }
+        return null; // 확장자를 찾을 수 없는 경우 null을 반환
+    }
+
+    private static String bytesToHex(byte[] bytes, int length) {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < length && i < bytes.length; i++) {
+            sb.append(String.format("%02X", bytes[i]));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/codesquad/application/model/Article.java
+++ b/src/main/java/codesquad/application/model/Article.java
@@ -5,12 +5,14 @@ public class Article {
     private String title;
     private String authorId;
     private String content;
+    private byte[] image;
 
-    public Article(String id, String title, String authorId, String content) {
+    public Article(String id, String title, String authorId, String content, byte[] image) {
         this.id = id;
         this.title = title;
         this.authorId = authorId;
         this.content = content;
+        this.image = image;
     }
 
     public String getId() {
@@ -27,5 +29,9 @@ public class Article {
 
     public String getContent() {
         return content;
+    }
+
+    public byte[] getImage() {
+        return image;
     }
 }

--- a/src/main/java/codesquad/application/returnvaluehandler/ModelViewHandler.java
+++ b/src/main/java/codesquad/application/returnvaluehandler/ModelViewHandler.java
@@ -113,6 +113,7 @@ public class ModelViewHandler implements ReturnValueHandler {
             temp = block.replace("{{title}}", article.getTitle());
             temp = block.replace("{{account}}", article.getAuthorId());
             temp = temp.replace("{{content}}", article.getContent());
+            temp = temp.replace("{{article_id}}", article.getId());
             replacement.append(temp);
         }
         String result = target.replace(marker, replacement);

--- a/src/main/java/codesquad/infra/JdbcArticleStorage.java
+++ b/src/main/java/codesquad/infra/JdbcArticleStorage.java
@@ -14,13 +14,14 @@ import java.util.Optional;
 public class JdbcArticleStorage implements ArticleDao {
     @Override
     public void save(Article article) {
-        String sql = "insert into articles(id, title, author_id, content) values(?,?,?,?)";
+        String sql = "insert into articles(id, title, author_id, content, image) values(?,?,?,?,?)";
         try (Connection connection = H2ConnectionManager.getConnection()) {
             PreparedStatement statement = connection.prepareStatement(sql);
             statement.setString(1, article.getId());
             statement.setString(2, article.getTitle());
             statement.setString(3, article.getAuthorId());
             statement.setString(4, article.getContent());
+            statement.setBytes(5, article.getImage());
             statement.executeUpdate();
             statement.close();
         } catch (SQLException e) {
@@ -36,7 +37,7 @@ public class JdbcArticleStorage implements ArticleDao {
             statement.setString(1, id);
             ResultSet resultSet = statement.executeQuery();
             if (resultSet.next()) {
-                Article article = new Article(resultSet.getString("id"), resultSet.getString("title"), resultSet.getString("author_id"), resultSet.getString("content"));
+                Article article = new Article(resultSet.getString("id"), resultSet.getString("title"), resultSet.getString("author_id"), resultSet.getString("content"), resultSet.getBytes("image"));
                 return Optional.of(article);
             }
             resultSet.close();
@@ -55,7 +56,7 @@ public class JdbcArticleStorage implements ArticleDao {
             PreparedStatement statement = connection.prepareStatement(sql);
             ResultSet resultSet = statement.executeQuery();
             while (resultSet.next()) {
-                Article article = new Article(resultSet.getString("id"), resultSet.getString("title"), resultSet.getString("author_id"), resultSet.getString("content"));
+                Article article = new Article(resultSet.getString("id"), resultSet.getString("title"), resultSet.getString("author_id"), resultSet.getString("content"), resultSet.getBytes("image"));
                 articles.add(article);
             }
             resultSet.close();

--- a/src/main/resources/h2.properties
+++ b/src/main/resources/h2.properties
@@ -1,6 +1,6 @@
 # JDBC connection URL for H2 database running in Docker
-jdbc.url=jdbc:h2:tcp://localhost:9092//h2-data/xtagram
-#jdbc.url=jdbc:h2:tcp://my-h2:9092//h2-data/xtagram
+#jdbc.url=jdbc:h2:file:./h2-data/xtagram
+jdbc.url=jdbc:h2:tcp://my-h2:9092//h2-data/xtagram
 # JDBC driver class for H2 database
 jdbc.driverClassName=org.h2.Driver
 # Database credentials

--- a/src/main/resources/h2.properties
+++ b/src/main/resources/h2.properties
@@ -1,6 +1,6 @@
 # JDBC connection URL for H2 database running in Docker
-#jdbc.url=jdbc:h2:file:./h2-data/xtagram
-jdbc.url=jdbc:h2:tcp://my-h2:9092//h2-data/xtagram
+jdbc.url=jdbc:h2:file:.//xtagram
+#jdbc.url=jdbc:h2:tcp://my-h2:9092//h2-data/xtagram
 # JDBC driver class for H2 database
 jdbc.driverClassName=org.h2.Driver
 # Database credentials

--- a/src/main/resources/templates/article/index.html
+++ b/src/main/resources/templates/article/index.html
@@ -23,7 +23,7 @@
     </header>
     <div class="page">
         <h2 class="page-title">게시글 작성</h2>
-        <form class="form" method="post" action="/article">
+        <form class="form" method="post" action="/article" enctype="multipart/form-data">
             <div class="textfield textfield_size_s">
                 <p class="title_textfield">제목</p>
                 <input
@@ -40,7 +40,7 @@
                         placeholder="글의 내용을 입력하세요"
                 ></textarea>
             </div>
-            <input type="file" id="image" name="image" accept="image/*" disabled>
+            <input type="file" id="image" name="image" accept="image/*">
             <button
                     id="registration-btn"
                     class="btn btn_contained btn_size_m"

--- a/src/main/resources/templates/block/article/article.html
+++ b/src/main/resources/templates/block/article/article.html
@@ -1,24 +1,24 @@
 <div class="post">
     <div class="post__account">
-        <img class="post__account__img" />
+        <img class="post__account__img"/>
         <p class="post__account__nickname">{{account}}</p>
     </div>
-    <img class="post__img" />
+    <img class="post__img" src="/static/img/article/{{article_id}}"/>
     <div class="post__menu">
         <ul class="post__menu__personal">
             <li>
                 <button class="post__menu__btn">
-                    <img src="/static/img/like.svg" />
+                    <img src="/static/img/like.svg"/>
                 </button>
             </li>
             <li>
                 <button class="post__menu__btn">
-                    <img src="/static/img/sendLink.svg" />
+                    <img src="/static/img/sendLink.svg"/>
                 </button>
             </li>
         </ul>
         <button class="post__menu__btn">
-            <img src="/static/img/bookMark.svg" />
+            <img src="/static/img/bookMark.svg"/>
         </button>
     </div>
     <p class="post__article">

--- a/src/main/resources/templates/block/article/article.html
+++ b/src/main/resources/templates/block/article/article.html
@@ -3,7 +3,7 @@
         <img class="post__account__img"/>
         <p class="post__account__nickname">{{account}}</p>
     </div>
-    <img class="post__img" src="/static/img/article/{{article_id}}"/>
+    <img class="post__img" src="/images/articles/{{article_id}}"/>
     <div class="post__menu">
         <ul class="post__menu__personal">
             <li>

--- a/src/main/resources/xtagram.sql
+++ b/src/main/resources/xtagram.sql
@@ -13,5 +13,8 @@ CREATE TABLE  IF NOT EXISTS users
     nickname VARCHAR(255) NOT NULL
 );
 INSERT INTO users (user_id, password, nickname)
-VALUES ('user1', 'password1', 'User One'),
-       ('user2', 'password2', 'User Two');
+SELECT 'user1', 'password1', 'User One'
+    WHERE NOT EXISTS (SELECT 1 FROM users WHERE user_id = 'user1');
+INSERT INTO users (user_id, password, nickname)
+SELECT 'user2', 'password2', 'User Two'
+    WHERE NOT EXISTS (SELECT 1 FROM users WHERE user_id = 'user2');

--- a/src/test/java/codesquad/application/handler/MockArticleDao.java
+++ b/src/test/java/codesquad/application/handler/MockArticleDao.java
@@ -35,6 +35,6 @@ public class MockArticleDao implements ArticleDao {
 
     @Override
     public List<Article> findAllArticle() {
-        return List.of(article);
+        return List.of();
     }
 }

--- a/src/test/java/codesquad/application/handler/RequestHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/RequestHandlerTest.java
@@ -28,7 +28,7 @@ class RequestHandlerTest implements HttpRequestFixture {
         mockArticleDao = new MockArticleDao();
         memorySessionStorage = new MemorySessionStorage();
         requestHandler = new RequestHandler(mockUserDao, mockArticleDao, memorySessionStorage);
-        requestHandlerAdapter = new RequestHandlerAdapter(List.of(new NoOpArgumentResolver(), new SessionArgumentResolver(memorySessionStorage), new FormUrlEncodedResolver(), new QueryStringArgumentResolver()), List.of(new ModelViewHandler(), new NoOpViewHandler()));
+        requestHandlerAdapter = new RequestHandlerAdapter(List.of(new NoOpArgumentResolver(), new SessionArgumentResolver(memorySessionStorage), new FormUrlEncodedResolver(), new QueryStringArgumentResolver(), new MultipartArgumentResolver()), List.of(new ModelViewHandler(), new NoOpViewHandler()));
     }
 
     @DisplayName("html을 요청하면")

--- a/src/test/java/codesquad/application/handler/RequestHandlerTest.java
+++ b/src/test/java/codesquad/application/handler/RequestHandlerTest.java
@@ -1,11 +1,11 @@
 package codesquad.application.handler;
 
 import codesquad.application.adapter.RequestHandlerAdapter;
-import codesquad.application.argumentresolver.FormUrlEncodedResolver;
-import codesquad.application.argumentresolver.NoOpArgumentResolver;
+import codesquad.application.argumentresolver.*;
 import codesquad.application.fixture.HttpRequestFixture;
 import codesquad.application.model.User;
 import codesquad.application.returnvaluehandler.ModelViewHandler;
+import codesquad.application.returnvaluehandler.NoOpViewHandler;
 import codesquad.infra.MemorySessionStorage;
 import org.junit.jupiter.api.*;
 import server.http.model.HttpRequest;
@@ -25,9 +25,10 @@ class RequestHandlerTest implements HttpRequestFixture {
     @BeforeEach
     void setUp() {
         mockUserDao = new MockUserDao();
+        mockArticleDao = new MockArticleDao();
         memorySessionStorage = new MemorySessionStorage();
         requestHandler = new RequestHandler(mockUserDao, mockArticleDao, memorySessionStorage);
-        requestHandlerAdapter = new RequestHandlerAdapter(List.of(new NoOpArgumentResolver(), new FormUrlEncodedResolver()), List.of(new ModelViewHandler()));
+        requestHandlerAdapter = new RequestHandlerAdapter(List.of(new NoOpArgumentResolver(), new SessionArgumentResolver(memorySessionStorage), new FormUrlEncodedResolver(), new QueryStringArgumentResolver()), List.of(new ModelViewHandler(), new NoOpViewHandler()));
     }
 
     @DisplayName("html을 요청하면")
@@ -41,7 +42,7 @@ class RequestHandlerTest implements HttpRequestFixture {
             void login_header() throws NoSuchMethodException {
                 // when
                 HttpRequest httpRequest = simpleRequest(Method.GET, "/");
-                HttpResponse httpResponse = requestHandlerAdapter.handle(requestHandler, requestHandler.getClass().getMethod("index", HttpRequest.class), httpRequest);
+                HttpResponse httpResponse = requestHandlerAdapter.handle(requestHandler, requestHandler.getClass().getMethod("index", User.class), httpRequest);
 
                 // then
                 Assertions.assertEquals(httpResponse.getStatusLine().toString(), "HTTP/1.1 200 OK\n");
@@ -52,7 +53,7 @@ class RequestHandlerTest implements HttpRequestFixture {
             void not_login_header() throws NoSuchMethodException {
                 // when
                 HttpRequest httpRequest = simpleRequest(Method.GET, "/");
-                HttpResponse httpResponse = requestHandlerAdapter.handle(requestHandler, requestHandler.getClass().getMethod("index", HttpRequest.class), httpRequest);
+                HttpResponse httpResponse = requestHandlerAdapter.handle(requestHandler, requestHandler.getClass().getMethod("index", User.class), httpRequest);
 
                 // then
                 Assertions.assertEquals(httpResponse.getStatusLine().toString(), "HTTP/1.1 200 OK\n");


### PR DESCRIPTION
## 구현 내용
- article 업로드시 이미지도 업로드할 수 있게 구현
   - Http 요청에 따른 로직수행을 담당하는 `RequestHandler`에 이미지 조회를 하는 로직 추가.
   - `RequestHandler`에서 Multipart를 받아볼 수 있도록 `MultipartArgumentResolver`구현
- 이미지 저장
   - 두가지 방식으로 저장/조회 가능
   - 1. H2에 blob으로 저장 / 2. 파일로 이미지 저장

## 고민 사항
- 클라이언트로부터 바이너리데이터를 받을 수도 있으므로 byte 배열로 받아야 한다. String으로 받게 되면 모든 요청이 동일한 방식으로 decoding되기 때문에 곤란
- InputStream.readNByte()를 사용하면 된다.
- read를 N번 호출하게 만들면 1.너무 많은 I/O가 발생하고, 2.sender가 데이터를 보내는 속도보다 receiver가 읽는 속도가 더 빠르면, read의 결과로 -1이 호출될 수 있다.
